### PR TITLE
fix: account for pitch in right vector

### DIFF
--- a/src/utils/vector3.ts
+++ b/src/utils/vector3.ts
@@ -18,13 +18,35 @@ export function getForwardVector(pitch: number, yaw: number): Vector3 {
 }
 
 /**
- * Calculate right vector from yaw and roll (for banking/rolling movements)
+ * Calculate right vector from pitch, yaw, and roll.
+ *
+ * Previous implementation ignored the pitch component which caused the
+ * resulting vector to be incorrect when an object was looking straight up or
+ * down (pitch ±90°). This version builds an orthonormal basis from the forward
+ * vector and applies roll around it to obtain the right vector.
  */
-export function getRightVector(yaw: number, roll: number): Vector3 {
+export function getRightVector(pitch: number, yaw: number, roll: number): Vector3 {
+  const forward = getForwardVector(pitch, yaw);
+  // World up vector for initial basis
+  const worldUp: Vector3 = { x: 0, y: 0, z: 1 };
+  // Compute an initial right vector perpendicular to forward and world up
+  let right = cross(worldUp, forward);
+  const mag = magnitude(right);
+  if (mag < 1e-6) {
+    // Forward is parallel (or very close) to worldUp; choose arbitrary right vector
+    right = { x: 1, y: 0, z: 0 };
+  } else {
+    right = scale(right, 1 / mag);
+  }
+  // Up vector prior to roll
+  const up = cross(forward, right);
+  const cosR = Math.cos(roll);
+  const sinR = Math.sin(roll);
+  // Rotate right/up around forward axis by roll
   return {
-    x: -Math.sin(yaw) * Math.cos(roll),
-    y: Math.cos(yaw) * Math.cos(roll),
-    z: Math.sin(roll)
+    x: right.x * cosR + up.x * sinR,
+    y: right.y * cosR + up.y * sinR,
+    z: right.z * cosR + up.z * sinR
   };
 }
 
@@ -33,7 +55,7 @@ export function getRightVector(yaw: number, roll: number): Vector3 {
  */
 export function getUpVector(pitch: number, yaw: number, roll: number): Vector3 {
   const forward = getForwardVector(pitch, yaw);
-  const right = getRightVector(yaw, roll);
+  const right = getRightVector(pitch, yaw, roll);
   
   // Up = forward × right (cross product)
   return {

--- a/test/vitest/vector3.spec.ts
+++ b/test/vitest/vector3.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+import { getForwardVector, getRightVector, getUpVector, dot } from '../../src/utils/vector3.js';
+
+// helper dot from utils? Wait dot function defined in same file; we imported above. yes.
+
+describe('vector3 orientation', () => {
+  test('right vector accounts for pitch', () => {
+    const pitch = Math.PI / 2; // looking straight up
+    const yaw = 0;
+    const roll = 0;
+    const right = getRightVector(pitch, yaw, roll);
+    expect(right.x).toBeCloseTo(1, 6);
+    expect(right.y).toBeCloseTo(0, 6);
+    expect(right.z).toBeCloseTo(0, 6);
+  });
+
+  test('basis vectors remain orthogonal after roll', () => {
+    const pitch = 0;
+    const yaw = 0;
+    const roll = Math.PI / 2; // 90 degree roll
+    const forward = getForwardVector(pitch, yaw);
+    const right = getRightVector(pitch, yaw, roll);
+    const up = getUpVector(pitch, yaw, roll);
+    expect(dot(forward, right)).toBeCloseTo(0, 6);
+    expect(dot(forward, up)).toBeCloseTo(0, 6);
+    expect(dot(right, up)).toBeCloseTo(0, 6);
+    // After a 90deg roll, right vector should align with world up
+    expect(right.x).toBeCloseTo(0, 6);
+    expect(right.y).toBeCloseTo(0, 6);
+    expect(right.z).toBeCloseTo(1, 6);
+  });
+});


### PR DESCRIPTION
## Summary
- compute right vector using pitch, yaw, and roll
- ensure orientation basis remains orthonormal
- add tests for right/up vector correctness

## Testing
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b88d9672a8832a9eca622d2338f157