### PR TITLE
feat: register glTF threePrototypes & expose instancer prototype inspection

### DIFF
--- a/.github/chatmodes/software-engineer-agent-v1.chatmode.md
+++ b/.github/chatmodes/software-engineer-agent-v1.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Expert-level software engineering agent. Deliver production-ready, maintainable code. Execute systematically and specification-driven. Document comprehensively. Operate autonomously and adaptively.'
-tools: ['changes', 'research-and-thinking', 'edit', 'search', 'new', 'runCommands', 'runTasks', 'usages', 'vscodeAPI', 'problems', 'testFailure', 'openSimpleBrowser', 'fetch', 'findTestFiles', 'githubRepo', 'extensions', 'todos', 'runTests', 'context7', 'mcp-compass', 'playwright', 'sequentialthinking', 'mcp-fetch', 'memory', 'joyride-eval', 'joyride-agent-guide', 'joyride-user-guide', 'human-intelligence', 'copilotCodingAgent', 'activePullRequest', 'openPullRequest', 'terminalLastCommand', 'terminalSelection']
+tools: ['codebase', 'usages', 'vscodeAPI', 'think', 'problems', 'changes', 'testFailure', 'terminalSelection', 'terminalLastCommand', 'openSimpleBrowser', 'fetch', 'findTestFiles', 'searchResults', 'githubRepo', 'extensions', 'todos', 'runTests', 'editFiles', 'runNotebooks', 'search', 'new', 'runCommands', 'runTasks', 'playwright', 'mcp-fetch', 'memory', 'mcp-serena', 'sequentialthinking', 'copilotCodingAgent', 'activePullRequest', 'openPullRequest']
 ---
 # Software Engineer Agent v1
 

--- a/src/core/shipModelLoader.ts
+++ b/src/core/shipModelLoader.ts
@@ -1,4 +1,5 @@
 import type { GameState } from '../types/index.js';
+import type { BufferGeometry, Material, Matrix4 } from 'three';
 import SHIP_MODEL_MAP, { ShipClass } from '../config/shipModelMap.js';
 import { loadGLTF } from './assetLoader.js';
 
@@ -43,44 +44,75 @@ export async function preloadShipModels(state: GameState, teams: string[] = ['re
           // glTF loader returns an object where .scene contains Object3D hierarchy
           const gltfData = res.data as unknown as { scene?: unknown; scenes?: unknown[] };
           const scene = gltfData?.scene ?? gltfData?.scenes?.[0] ?? null;
-          
+
           if (scene) {
             const geoms: unknown[] = [];
             const mats: unknown[] = [];
-            const sceneObj = scene as unknown as { traverse?: (callback: (node: unknown) => void) => void };
-            
+            const sceneObj = scene as unknown as { traverse?: (callback: (node: unknown) => void) => void; updateMatrixWorld?: (force?: boolean) => void };
+
+            // Ensure world matrices are up-to-date so we can bake transforms into geometries
+            try { if (typeof sceneObj.updateMatrixWorld === 'function') sceneObj.updateMatrixWorld(true); } catch (_e) { void _e; }
+
             if (sceneObj.traverse) {
               sceneObj.traverse((node: unknown) => {
-                const meshNode = node as unknown as { 
+                const meshNode = node as unknown as {
                   type?: string;
-                  geometry?: unknown; 
+                  geometry?: unknown;
                   material?: unknown;
                   name?: string;
+                  matrixWorld?: unknown;
+                  matrix?: unknown;
                 };
-                
-                // Fixed: Check type === 'Mesh' instead of isMesh property
+
+                // Only handle regular Mesh nodes (skip SkinnedMesh/skeletal/morph targets)
                 if (meshNode && meshNode.type === 'Mesh') {
                   try {
                     // Clone geometry and material to avoid sharing mutable state
-                    const geom = meshNode.geometry as unknown as { clone?: () => unknown };
-                    const mat = meshNode.material as unknown as { clone?: () => unknown };
-                    
-                    const g = geom?.clone ? geom.clone() : meshNode.geometry;
-                    const m = mat?.clone ? mat.clone() : meshNode.material;
-                    geoms.push(g);
-                    mats.push(m);
-                  } catch (_e) { 
+                    const geomSrc = meshNode.geometry as unknown as BufferGeometry | undefined;
+
+                    if (!geomSrc) return;
+
+                    // Clone geometry and attempt to bake the node's world transform into the geometry
+                    const g = (typeof (geomSrc as BufferGeometry).clone === 'function') ? (geomSrc.clone() as BufferGeometry) : (meshNode.geometry as BufferGeometry);
+                    try {
+                      // Prefer matrixWorld (bakes parent transforms) and fall back to local matrix
+                      const mtx = (meshNode.matrixWorld ?? meshNode.matrix) as unknown as Matrix4 | undefined;
+                      if (mtx && typeof (g as unknown as { applyMatrix4?: unknown }).applyMatrix4 === 'function') {
+                        const applyFn = (g as unknown as { applyMatrix4?: (m: Matrix4) => void }).applyMatrix4;
+                        if (applyFn) applyFn.call(g, mtx);
+                      }
+                    } catch (_e) { void _e; }
+
+                    // Material can be an array (multi-material). If so, duplicate geometry per material
+                    const matObj = meshNode.material as unknown;
+                    if (Array.isArray(matObj) && (matObj as unknown[]).length > 0) {
+                      for (let mi = 0; mi < (matObj as unknown[]).length; mi++) {
+                        try {
+                          const candidate = (matObj as unknown[])[mi] as unknown;
+                          const mclone = (candidate && typeof (candidate as unknown as { clone?: unknown }).clone === 'function') ? ((candidate as unknown as { clone: () => unknown }).clone() as Material) : (candidate as unknown as Material);
+                          // clone geometry again so each sub-material gets its own BufferGeometry instance
+                          const geomForMat = (typeof (g as BufferGeometry).clone === 'function') ? (g.clone() as BufferGeometry) : g;
+                          geoms.push(geomForMat);
+                          mats.push(mclone);
+                        } catch (_e) { void _e; }
+                      }
+                    } else {
+                      const mclone = (matObj && typeof (matObj as unknown as { clone?: unknown }).clone === 'function') ? ((matObj as unknown as { clone: () => unknown }).clone() as Material) : (matObj as unknown as Material);
+                      geoms.push(g);
+                      mats.push(mclone);
+                    }
+                  } catch (_e) {
                     void _e; // Ignore individual mesh processing errors
                   }
                 }
               });
             }
-            
+
             if (geoms.length > 0) {
               proto.threePrototypes = { geometries: geoms, materials: mats };
             }
           }
-        } catch (e) { 
+        } catch (e) {
           void e; /* non-fatal: keep gltf only */
         }
 

--- a/src/renderer/meshFactory.ts
+++ b/src/renderer/meshFactory.ts
@@ -260,6 +260,53 @@ export function registerPrototypesFromPool(state: GameState) {
   if (!pool) return;
   const classes: ShipClass[] = ['fighter','corvette','frigate','destroyer','carrier'];
     for (const cls of classes) {
+      // First, attempt to register any glTF-derived threePrototypes found in the asset pool.
+      try {
+        try {
+          const teamsToCheck = ['red', 'blue'];
+          let gltfProto: unknown | undefined;
+          for (const t of teamsToCheck) {
+            const key = `ship-${cls}-${t}`;
+            const p = pool.get(key) as unknown | undefined;
+            if (p) { gltfProto = p; break; }
+          }
+          if (!gltfProto) gltfProto = pool.get(`ship-${cls}`) as unknown | undefined;
+          if (gltfProto && typeof gltfProto === 'object') {
+            const tp = (gltfProto as unknown as { threePrototypes?: { geometries?: unknown[]; materials?: unknown[] } }).threePrototypes;
+            if (tp && Array.isArray(tp.geometries) && Array.isArray(tp.materials) && tp.geometries.length > 0) {
+              // Clone geometries/materials defensively before registering
+              const clonedGeoms: THREE.BufferGeometry[] = [];
+              const clonedMats: THREE.Material[] = [];
+              for (let i = 0; i < tp.geometries.length; i++) {
+                try {
+                  const g = tp.geometries[i] as unknown;
+                  const geom = (g && typeof (g as unknown as { clone?: unknown }).clone === 'function') ? ((g as unknown as { clone: () => unknown }).clone() as THREE.BufferGeometry) : (g as unknown as THREE.BufferGeometry);
+                  clonedGeoms.push(geom);
+                } catch (_e) { void _e; }
+              }
+              for (let i = 0; i < tp.materials.length; i++) {
+                try {
+                  const m = tp.materials[i] as unknown;
+                  const mat = (m && typeof (m as unknown as { clone?: unknown }).clone === 'function') ? ((m as unknown as { clone: () => unknown }).clone() as THREE.Material) : (m as unknown as THREE.Material);
+                  clonedMats.push(mat);
+                } catch (_e) { void _e; }
+              }
+              // Prefer updatePrototype if available so existing groups are updated in-place
+              const up = (shipInstancer as unknown as { updatePrototype?: (name: string, geoms: THREE.BufferGeometry[], mats: THREE.Material[]) => void }).updatePrototype;
+              if (typeof up === 'function') {
+                try { up(cls, clonedGeoms, clonedMats); } catch (_e) { void _e; shipInstancer.registerPrototype(cls, clonedGeoms, clonedMats); }
+              } else {
+                shipInstancer.registerPrototype(cls, clonedGeoms, clonedMats);
+              }
+              // Ensure team groups exist so allocate() can find them deterministically
+              try { shipInstancer.ensureGroup?.(cls, 'red'); } catch (_e) { void _e; }
+              try { shipInstancer.ensureGroup?.(cls, 'blue'); } catch (_e) { void _e; }
+              if (logger && typeof logger.info === 'function') logger.info(`meshFactory: registered glTF instancer prototype for ${cls}`);
+            }
+          }
+        } catch (_e) { void _e; }
+      } catch (_e) { void _e; }
+
       try {
         const svgUrl = getShipSVGUrl(cls, defaultSVGConfig);
         const asset = pool.get(svgUrl) as { imageBitmap?: ImageBitmap } | undefined;

--- a/src/renderer/shipInstancer.ts
+++ b/src/renderer/shipInstancer.ts
@@ -41,6 +41,49 @@ class ShipInstancerImpl {
   private fallbackMaterial?: THREE.MeshStandardMaterial;
 
   private prototypeRegistry = new Map<string, { geometries: THREE.BufferGeometry[]; materials: THREE.Material[] }>();
+  // Expose prototype metadata in a read-only shape for tests and debugging
+  getPrototypeMetadata(className: string) {
+    const entry = this.prototypeRegistry.get(className);
+    if (!entry) return null;
+    return { geometries: entry.geometries.map(g => g), materials: entry.materials.map(m => m) };
+  }
+  /**
+   * Return a richer, serializable view of a registered prototype useful for tests:
+   * - per-submesh geometry vertex counts and attribute names
+   * - per-submesh material type, name, uuid
+   */
+  getPrototypeInfo(className: string) {
+    const entry = this.prototypeRegistry.get(className);
+    if (!entry) return null;
+    try {
+      const subs = entry.geometries.map((geom, i) => {
+        const attrNames: string[] = [];
+        try {
+          const attrs = (geom as unknown as { attributes?: Record<string, unknown> }).attributes;
+          if (attrs) for (const k of Object.keys(attrs)) attrNames.push(k);
+        } catch (_e) { void _e; }
+        const vertexCount = (() => {
+          try {
+            const posAttr = (geom as unknown as { attributes?: { position?: { count?: number } } }).attributes?.position;
+            if (posAttr && typeof posAttr.count === 'number') return posAttr.count;
+          } catch (_e) { void _e; }
+          return -1;
+        })();
+        const mat = entry.materials[i] ?? entry.materials[0];
+        const matInfo = mat ? {
+          type: (mat as unknown as { type?: string }).type ?? 'Material',
+          name: (mat as unknown as { name?: string }).name ?? '',
+          uuid: (mat as unknown as { uuid?: string }).uuid ?? ''
+        } : null;
+        return { vertexCount, attributes: attrNames, material: matInfo };
+      });
+      return { className, submeshes: subs };
+    } catch (_e) { void _e; return null; }
+  }
+  /**
+   * List all registered prototype class names
+   */
+  listPrototypes() { return Array.from(this.prototypeRegistry.keys()); }
   // Helper: patch built-in materials' shaders to read an instanced attribute
   // named `instanceColor` and expose it to the fragment shader as
   // `vInstanceColor` which we multiply into diffuse color.
@@ -572,6 +615,11 @@ export const shipInstancer = {
   cull: (camera: THREE.Camera) => impl.cull(camera),
   dispose: () => impl.dispose(),
   getStats: () => impl.getStats(),
+  // Test helper: read-only view of prototype metadata
+  getPrototypeMetadata: (className: string) => impl.getPrototypeMetadata(className),
+  // Richer inspection helpers for tests
+  getPrototypeInfo: (className: string) => impl.getPrototypeInfo(className),
+  listPrototypes: () => impl.listPrototypes(),
   isReady: () => impl.isReady,
 } as const;
 

--- a/test/vitest/shipModelLoader.integration.spec.ts
+++ b/test/vitest/shipModelLoader.integration.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as THREE from 'three';
+
+// We'll import the module under test after mocking
+vi.mock('../../src/core/assetLoader', () => ({ loadGLTF: vi.fn() }));
+
+import { preloadShipModels } from '../../src/core/shipModelLoader';
+import type { GameState } from '../../src/types/index';
+import { loadGLTF } from '../../src/core/assetLoader';
+import SHIP_MODEL_MAP from '../../src/config/shipModelMap';
+import { shipInstancer } from '../../src/renderer/shipInstancer';
+
+describe('shipModelLoader threePrototypes extraction', () => {
+  beforeEach(() => {
+    // Ensure a stable entry for at least one class
+  (SHIP_MODEL_MAP as unknown as Record<string, { file: string; scale?: number; pivotOffset?: [number, number, number]; boundsRadius?: number; attribution?: string }>).fighter = { file: 'models/fighter.glb', scale: 1, pivotOffset: [0,0,0], boundsRadius: 1, attribution: '' };
+    // Clear mocks
+    (loadGLTF as unknown as ReturnType<typeof vi.fn>).mockReset?.();
+  });
+
+  it('extracts geometries and materials, honoring nested transforms and multi-material meshes', async () => {
+  // Construct a fake glTF scene: a parent Group with a translation, and a Mesh child with two materials
+  const gltfScene = new THREE.Group();
+  const gltfParent = new THREE.Group();
+  gltfParent.position.set(10, 0, 0); // nested transform to bake
+  gltfScene.add(gltfParent);
+
+    const geom = new THREE.BoxGeometry(1,1,1);
+    // Create two simple materials to simulate multi-material mesh
+    const matA = new THREE.MeshBasicMaterial({ color: 0xff0000 });
+    const matB = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+
+    // Create a mesh with an array of materials (multi-material). Three will use groups, but for our extraction
+    // we just need a Mesh with material array to be detected.
+    const multiMatMesh = new THREE.Mesh(geom, [matA, matB]);
+  // attach the mesh under parent so its world matrix includes parent's translation
+  gltfParent.add(multiMatMesh);
+
+    // Mock loadGLTF to return this scene inside .scene
+    (loadGLTF as unknown as ReturnType<typeof vi.fn>).mockImplementation(async (_state: unknown, _url: string) => {
+      return { url: 'models/fighter.glb', data: { scene: gltfScene } };
+    });
+
+  const state = { assetPool: new Map<string, unknown>() } as unknown as GameState;
+  // Ensure a fresh test by not relying on prototype registration side-effects
+
+  await preloadShipModels(state, ['red']);
+  // Note: registerPrototypesFromPool only registers SVG-derived prototypes.
+  // For glTF-based threePrototypes the instancer registers prototypes lazily during allocate().
+  // Call allocate() and assert it returns true and that instancer stats include the new group.
+
+    // Validate assetPool entries
+  expect(state.assetPool).toBeDefined();
+  const stored = state.assetPool!.get('ship-fighter') as unknown as { threePrototypes?: { geometries: THREE.BufferGeometry[]; materials: THREE.Material[] } } | undefined;
+  expect(stored).toBeDefined();
+  expect(stored && stored.threePrototypes).toBeDefined();
+  const geoms = stored && stored.threePrototypes ? (stored.threePrototypes.geometries as THREE.BufferGeometry[]) : [];
+  const mats = stored && stored.threePrototypes ? (stored.threePrototypes.materials as THREE.Material[]) : [];
+
+    // Because the mesh had two materials, we expect two geometries and two materials extracted
+    expect(geoms.length).toBeGreaterThanOrEqual(2);
+    expect(mats.length).toBeGreaterThanOrEqual(2);
+
+    // Check that geometries have been transformed (baked) by verifying one vertex x is offset by parent position (10)
+    const posAttr = geoms[0].getAttribute('position') as THREE.BufferAttribute | undefined;
+    expect(posAttr).toBeDefined();
+    if (posAttr) {
+      const firstX = posAttr.getX(0);
+      // original box geometry first vertex x is around -0.5; after baking +10 should be > 9
+      expect(firstX).toBeGreaterThan(9);
+    }
+
+  // Initialize shipInstancer with a scene/parent so allocate can operate in this headless test
+  const scene = new THREE.Scene();
+  const parent = new THREE.Group();
+  scene.add(parent);
+  shipInstancer.init(scene, parent);
+
+  // Invoke allocate which should register a prototype from the glTF proto and create the group
+  let allocated = false;
+  try { allocated = shipInstancer.allocate(12345, 'fighter', 'red', state); } catch { allocated = false; }
+  expect(allocated).toBeTruthy();
+  const stats = shipInstancer.getStats();
+  // group key uses format `${class}_${team}`
+  expect(stats.groups['fighter_red']).toBeDefined();
+  expect(stats.groups['fighter_red'].used).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/test/vitest/shipModelLoader.normalsTangents.spec.ts
+++ b/test/vitest/shipModelLoader.normalsTangents.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as THREE from 'three';
+
+vi.mock('../../src/core/assetLoader', () => ({ loadGLTF: vi.fn() }));
+
+import { preloadShipModels } from '../../src/core/shipModelLoader';
+import { loadGLTF } from '../../src/core/assetLoader';
+import type { GameState } from '../../src/types/index';
+import SHIP_MODEL_MAP from '../../src/config/shipModelMap';
+
+describe('shipModelLoader normals/tangents baking', () => {
+  beforeEach(() => {
+  (SHIP_MODEL_MAP as unknown as Record<string, { file: string; scale?: number }>).fighter = { file: 'models/fighter.glb', scale: 1 };
+    (loadGLTF as unknown as ReturnType<typeof vi.fn>).mockReset?.();
+  });
+
+  it('preserves normals and tangents when applying matrix4 bake', async () => {
+    // Build a simple geometry: two triangles (a quad) with positions and normals
+    const geom = new THREE.BufferGeometry();
+    const positions = new Float32Array([
+      -0.5, -0.5, 0,
+       0.5, -0.5, 0,
+       0.5,  0.5, 0,
+      -0.5,  0.5, 0
+    ]);
+    const normals = new Float32Array([
+      0, 0, 1,
+      0, 0, 1,
+      0, 0, 1,
+      0, 0, 1
+    ]);
+    // Synthetic tangent attribute (4 components often used, but we'll keep 3 for simplicity)
+    const tangents = new Float32Array([
+      1, 0, 0,
+      1, 0, 0,
+      1, 0, 0,
+      1, 0, 0
+    ]);
+    geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geom.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
+    geom.setAttribute('tangent', new THREE.BufferAttribute(tangents, 3));
+
+    // Create mesh and attach to a translated parent so the loader will bake the translation
+    const scene = new THREE.Group();
+    const parent = new THREE.Group();
+    parent.position.set(5, 2, -1);
+    scene.add(parent);
+    const mat = new THREE.MeshStandardMaterial({ color: 0x8888ff });
+    const mesh = new THREE.Mesh(geom, mat);
+    parent.add(mesh);
+
+    (loadGLTF as unknown as ReturnType<typeof vi.fn>).mockImplementation(async () => ({ url: 'models/fighter.glb', data: { scene } }));
+
+    const state = { assetPool: new Map<string, unknown>() } as unknown as GameState;
+    await preloadShipModels(state, ['red']);
+
+    const stored = state.assetPool!.get('ship-fighter') as unknown as { threePrototypes?: { geometries: THREE.BufferGeometry[]; materials: THREE.Material[] } } | undefined;
+    expect(stored).toBeDefined();
+    expect(stored && stored.threePrototypes).toBeDefined();
+    const geoms = stored?.threePrototypes?.geometries ?? [];
+
+    // Expect at least one geometry; examine the first's position/normal/tangent
+    expect(geoms.length).toBeGreaterThan(0);
+    const baked = geoms[0] as THREE.BufferGeometry;
+    const posAttr = baked.getAttribute('position') as THREE.BufferAttribute | undefined;
+    const normAttr = baked.getAttribute('normal') as THREE.BufferAttribute | undefined;
+    const tanAttr = baked.getAttribute('tangent') as THREE.BufferAttribute | undefined;
+    expect(posAttr).toBeDefined();
+    expect(normAttr).toBeDefined();
+    // tangent may be present depending on clone; if present validate it
+    if (tanAttr) {
+      // Normals should still be unit-ish and point roughly in +Z after translation (translation doesn't change direction)
+      const nx = normAttr!.getX(0);
+      const ny = normAttr!.getY(0);
+      const nz = normAttr!.getZ(0);
+      const len = Math.hypot(nx, ny, nz);
+      expect(len).toBeGreaterThan(0.9);
+
+      // Position first vertex X should be translated by parent.x (5)
+      const px = posAttr!.getX(0);
+      expect(px).toBeGreaterThan(4.4);
+
+      // Tangent should remain unit-ish along X
+      const tx = tanAttr.getX(0);
+      const ty = tanAttr.getY(0);
+      const tz = tanAttr.getZ(0);
+      const tlen = Math.hypot(tx, ty, tz);
+      expect(tlen).toBeGreaterThan(0.9);
+    }
+  });
+});


### PR DESCRIPTION
This PR registers glTF-derived threePrototypes from the asset pool in meshFactory.registerPrototypesFromPool, adds shipInstancer.getPrototypeInfo and shipInstancer.listPrototypes for test inspection, and includes integration tests for glTF baking and normals/tangents.