### PR TITLE
feat: optimize ship instancer updates

### DIFF
--- a/SHIP_INSTANCING.md
+++ b/SHIP_INSTANCING.md
@@ -16,6 +16,8 @@ The ship instancing system replaces individual ship meshes with InstancedMesh re
 - **Async Asset Loading**: Ships start as placeholders and upgrade to textured when SVG assets load
 - **Dynamic Capacity**: Automatic capacity growth when instance limits are reached
 - **Proper Cleanup**: Handles ship removal and resource disposal correctly
+- **Group Frustum Culling**: Bounding-sphere culling disables entire groups outside the active camera frustum
+- **Transform Coalescing**: Per-instance transform state skips GPU uploads when the change is below epsilon thresholds
 
 ### 🏗️ Architecture
 
@@ -102,7 +104,7 @@ console.log('Group Stats:', stats.groups);
 
 1. **Simplified Submeshes**: Current implementation uses basic ship parts
 2. **Static Materials**: Materials are not yet dynamically updated per ship
-3. **Culling**: InstancedMeshes are culled as a group (may need subdivision)
+3. **Culling Granularity**: Groups use a single bounding sphere (no spatial subdivision yet)
 4. **Asset Dependencies**: Requires proper SVG asset loading infrastructure
 
 ## Future Enhancements
@@ -110,7 +112,7 @@ console.log('Group Stats:', stats.groups);
 - [ ] More detailed ship submesh decomposition
 - [ ] Per-instance material variations (damage, upgrades)
 - [ ] Spatial subdivision for better culling
-- [ ] Performance metrics and benchmarking
+- [x] Performance metrics and benchmarking (`npm run perf:instancer`)
 - [ ] Level-of-detail (LOD) integration
 - [ ] Support for animated ship parts
 
@@ -143,6 +145,23 @@ state.ships.forEach((s) => console.log(`${s.class}_${s.team}`));
 - `src/renderer/threeRenderer.ts` - Integration point
 - `src/config/rendererConfig.ts` - Configuration
 - `test/vitest/ship-instancer.spec.ts` - Unit tests
+- `scripts/perf/ship-instancer-harness.mjs` - Automated performance harness
+
+### Performance Harness
+
+Run `npm run perf:instancer` to launch a headless Playwright session that:
+
+1. Builds the production bundle (unless `PERF_SKIP_BUILD=1`)
+2. Spawns a static server for `dist/`
+3. Loads the game with `debugPerf` enabled and spawns the configured number of ships (default 400)
+4. Captures renderer subsystem timings plus ship-instancer stats
+5. Writes a JSON report to `perf/runs/ship-instancer-<timestamp>.json`
+
+Tune the harness via environment variables:
+
+```bash
+INSTANCER_SHIP_COUNT=600 INSTANCER_MIN_FRAMES=360 npm run perf:instancer
+```
 
 ### Integration Points
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "add-memory-node": "node ./scripts/add_memory_node.mjs",
     "generate-memories": "node ./scripts/generate_memories.mjs",
     "test:browser": "vitest --config=vitest.browser.config.ts",
-    "perf:baseline": "node ./scripts/perf/collect-baseline.mjs"
+    "perf:baseline": "node ./scripts/perf/collect-baseline.mjs",
+    "perf:instancer": "node ./scripts/perf/ship-instancer-harness.mjs"
   },
   "devDependencies": {
     "@babel/preset-env": "latest",

--- a/scripts/perf/ship-instancer-harness.mjs
+++ b/scripts/perf/ship-instancer-harness.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { existsSync, createReadStream, statSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { createServer } from 'node:http';
+import { chromium } from 'playwright';
+
+const OUTPUT_DIR = process.env.PERF_OUTPUT_DIR ?? path.resolve('perf', 'runs');
+const DEFAULT_SHIP_COUNT = 400;
+const DEFAULT_MIN_FRAMES = 240;
+const DEFAULT_SETTLE_MS = 1000;
+
+function parseIntEnv(key, fallback) {
+  const raw = process.env[key];
+  if (!raw) return fallback;
+  const num = Number.parseInt(raw, 10);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+const SHIP_COUNT = parseIntEnv('INSTANCER_SHIP_COUNT', DEFAULT_SHIP_COUNT);
+const MIN_FRAMES = Math.max(90, parseIntEnv('INSTANCER_MIN_FRAMES', DEFAULT_MIN_FRAMES));
+const SETTLE_MS = Math.max(100, parseIntEnv('INSTANCER_SETTLE_MS', DEFAULT_SETTLE_MS));
+
+async function runCommand(command, args) {
+  return new Promise((resolve, reject) => {
+    const cmd = process.platform === 'win32' && command === 'npm' ? 'npm.cmd' : command;
+    const child = spawn(cmd, args, { stdio: 'inherit', shell: true, env: process.env });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} ${args.join(' ')} failed with exit code ${code}`));
+      }
+    });
+  });
+}
+
+async function ensureBuild() {
+  if ((process.env.PERF_SKIP_BUILD || '').toLowerCase() === '1') {
+    console.log('[instancer-perf] Skipping build step (PERF_SKIP_BUILD=1)');
+    return;
+  }
+  console.log('[instancer-perf] Running npm run build …');
+  await runCommand('npm', ['run', 'build']);
+}
+
+function createStaticServer(rootDir) {
+  return createServer((req, res) => {
+    try {
+      const urlPath = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+      let filePath = path.join(rootDir, urlPath);
+      if (urlPath === '/' || urlPath.endsWith('/')) {
+        filePath = path.join(rootDir, 'spaceautobattler.html');
+      }
+      if (!filePath.startsWith(rootDir)) {
+        res.statusCode = 403;
+        res.end('Forbidden');
+        return;
+      }
+      const stats = statSync(filePath);
+      if (stats.isDirectory()) {
+        filePath = path.join(filePath, 'spaceautobattler.html');
+      }
+      const stream = createReadStream(filePath);
+      const ext = path.extname(filePath).toLowerCase();
+      const types = {
+        '.html': 'text/html; charset=utf-8',
+        '.js': 'application/javascript; charset=utf-8',
+        '.css': 'text/css; charset=utf-8',
+        '.json': 'application/json; charset=utf-8',
+        '.glb': 'model/gltf-binary',
+        '.png': 'image/png',
+        '.jpg': 'image/jpeg',
+        '.svg': 'image/svg+xml',
+      };
+      res.statusCode = 200;
+      res.setHeader('Content-Type', types[ext] || 'application/octet-stream');
+      stream.pipe(res);
+    } catch (err) {
+      res.statusCode = 404;
+      res.end('Not found');
+    }
+  });
+}
+
+async function waitForApp(page) {
+  await page.waitForFunction(() => {
+    return Boolean(window.__appDebug && typeof window.__appDebug.configurePerfScenario === 'function' && window.perf);
+  });
+}
+
+async function collectMetrics(page) {
+  return page.evaluate(
+    ({ shipCount, minFrames, settleMs }) => {
+      const perf = window.perf;
+      const inst = window.__shipInstancer;
+      const summary = perf?.getSummary();
+      const relevant = summary
+        ? summary.subsystems.filter((sub) => sub.name.startsWith('renderer.'))
+        : [];
+      return {
+        frameCount: summary?.frameCount ?? 0,
+        avgFrameMs: summary?.avgFrameMs ?? 0,
+        p95FrameMs: summary?.p95FrameMs ?? 0,
+        settleMs,
+        minFrames,
+        shipCount,
+        rendererSubsystems: relevant,
+        instancerStats: inst?.getStats ? inst.getStats() : null,
+      };
+    },
+    { shipCount: SHIP_COUNT, minFrames: MIN_FRAMES, settleMs: SETTLE_MS },
+  );
+}
+
+async function runHarness() {
+  await ensureBuild();
+  const distDir = path.resolve('dist');
+  const distHtml = path.join(distDir, 'spaceautobattler.html');
+  if (!existsSync(distHtml)) {
+    throw new Error('dist/spaceautobattler.html not found. Run npm run build first.');
+  }
+
+  const server = createStaticServer(distDir);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : address;
+  const url = `http://127.0.0.1:${port}/spaceautobattler.html?debugPerf=1&showPerf=1`;
+
+  const launchOptions = {
+    headless: true,
+    args: ['--use-gl=swiftshader', '--disable-dev-shm-usage', '--ignore-gpu-blocklist'],
+  };
+
+  const browser = await chromium.launch(launchOptions);
+  try {
+    const page = await browser.newPage();
+    await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+    await waitForApp(page);
+
+    await page.evaluate(() => {
+      window.perf?.clear();
+    });
+
+    const scenario = await page.evaluate((count) => {
+      const helper = window.__appDebug?.configurePerfScenario;
+      if (typeof helper !== 'function') {
+        return { ok: false, error: 'configurePerfScenario missing' };
+      }
+      const result = helper({ totalShips: count, running: true });
+      if (!result) {
+        return { ok: false, error: 'configurePerfScenario returned null' };
+      }
+      return { ok: true, data: result };
+    }, SHIP_COUNT);
+
+    if (!scenario.ok) {
+      throw new Error(`[instancer-perf] Failed to configure scenario: ${scenario.error}`);
+    }
+
+    await page.waitForTimeout(SETTLE_MS);
+    await page.waitForFunction(
+      (target) => {
+        const perf = window.perf;
+        if (!perf) return false;
+        const summary = perf.getSummary();
+        return summary.frameCount >= target;
+      },
+      MIN_FRAMES,
+      { timeout: 45000 },
+    );
+
+    const metrics = await collectMetrics(page);
+
+    await mkdir(OUTPUT_DIR, { recursive: true });
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const outputPath = path.join(OUTPUT_DIR, `ship-instancer-${timestamp}.json`);
+    await writeFile(outputPath, JSON.stringify({ metrics, scenario: scenario.data }, null, 2), 'utf8');
+    console.log(`[instancer-perf] Metrics written to ${outputPath}`);
+  } finally {
+    await browser.close();
+    server.close();
+  }
+}
+
+runHarness().catch((err) => {
+  console.error('[instancer-perf] Harness failed', err);
+  process.exitCode = 1;
+});

--- a/src/renderer/shipInstancer.ts
+++ b/src/renderer/shipInstancer.ts
@@ -6,6 +6,12 @@ import type { GameState } from '../types/index.js';
 
 type Float3 = { x: number; y: number; z: number };
 
+type InstanceTransformState = {
+  position: THREE.Vector3;
+  quaternion: THREE.Quaternion;
+  scale: number;
+};
+
 type GroupData = {
   className: string;
   team?: string;
@@ -23,6 +29,8 @@ type GroupData = {
   boundsCenter: THREE.Vector3;
   boundsRadius: number;
   boundsDirty: boolean;
+  lastTransforms: Map<number, InstanceTransformState>;
+  dirtyRange: { min: number; max: number } | null;
 };
 
 class ShipInstancerImpl {
@@ -126,6 +134,24 @@ class ShipInstancerImpl {
   // Reusable temporaries to avoid per-frame allocations
   private tmpMatrix = new THREE.Matrix4();
   private tmpQuat = new THREE.Quaternion();
+  private readonly positionEpsilonSq = 1e-6;
+  private readonly quaternionEpsilon = 1e-5;
+  private readonly scaleEpsilon = 1e-4;
+
+  private markDirtyRange(group: GroupData, index: number) {
+    if (!group.dirtyRange) {
+      group.dirtyRange = { min: index, max: index };
+    } else {
+      if (index < group.dirtyRange.min) group.dirtyRange.min = index;
+      if (index > group.dirtyRange.max) group.dirtyRange.max = index;
+    }
+    group.matricesNeedUpdate = true;
+  }
+
+  private markFullRangeDirty(group: GroupData) {
+    group.dirtyRange = { min: 0, max: Math.max(0, group.capacity - 1) };
+    group.matricesNeedUpdate = true;
+  }
 
   init(scene: THREE.Scene, parent: THREE.Group) {
     console.log(`ShipInstancer.init called with scene: ${!!scene}, parent: ${!!parent}`);
@@ -460,10 +486,15 @@ class ShipInstancerImpl {
     // Reuse a shared identity matrix to avoid allocations
     this.tmpMatrix.identity();
     for (const m of group.meshes) m.setMatrixAt(idx, this.tmpMatrix);
+    this.markDirtyRange(group, idx);
     // initialize tracked position
     group.positions.set(shipId, new THREE.Vector3());
+    group.lastTransforms.set(shipId, {
+      position: new THREE.Vector3(),
+      quaternion: new THREE.Quaternion(),
+      scale: 1,
+    });
     group.boundsDirty = true;
-    group.matricesNeedUpdate = true;
     // Write per-instance team color into instanceColor attribute if available
     try {
       const hex =
@@ -498,11 +529,12 @@ class ShipInstancerImpl {
         group.freeIndices.push(idx);
         // remove tracked position and mark bounds dirty
         group.positions.delete(shipId);
+        group.lastTransforms.delete(shipId);
         group.boundsDirty = true;
         // Reuse tmpMatrix for clearing the instance (scale to zero)
         this.tmpMatrix.makeScale(0, 0, 0);
         for (const m of group.meshes) m.setMatrixAt(idx, this.tmpMatrix);
-        group.matricesNeedUpdate = true;
+        this.markDirtyRange(group, idx);
         return true;
       }
     }
@@ -546,14 +578,39 @@ class ShipInstancerImpl {
 
       this.tmpVec.set(pos.x, pos.y, pos.z);
       this.tmpScale.set(scale, scale, scale);
+      let state = g.lastTransforms.get(shipId);
+      if (!state) {
+        state = {
+          position: new THREE.Vector3(),
+          quaternion: new THREE.Quaternion(),
+          scale: Number.NaN,
+        };
+        g.lastTransforms.set(shipId, state);
+      }
+      const posChanged = state.position.distanceToSquared(this.tmpVec) > this.positionEpsilonSq;
+      const dot = Math.min(1, Math.max(-1, state.quaternion.dot(quat)));
+      const quatChanged = 1 - Math.abs(dot) > this.quaternionEpsilon;
+      const scaleChanged = !Number.isFinite(state.scale)
+        ? true
+        : Math.abs(state.scale - scale) > this.scaleEpsilon;
+
+      if (!posChanged && !quatChanged && !scaleChanged) return true;
+
       this.tmpMatrix.compose(this.tmpVec, quat, this.tmpScale);
       for (const mesh of g.meshes) mesh.setMatrixAt(idx, this.tmpMatrix);
-      g.matricesNeedUpdate = true;
-      // update coarse position and mark bounds dirty
-      const tr = g.positions.get(shipId);
-      if (tr) {
-        tr.copy(this.tmpVec);
-        g.boundsDirty = true;
+      this.markDirtyRange(g, idx);
+
+      state.position.copy(this.tmpVec);
+      state.quaternion.copy(quat);
+      state.scale = scale;
+
+      // update coarse position and mark bounds dirty when position changed
+      if (posChanged) {
+        const tr = g.positions.get(shipId);
+        if (tr) {
+          tr.copy(this.tmpVec);
+          g.boundsDirty = true;
+        }
       }
       return true;
     }
@@ -586,6 +643,17 @@ class ShipInstancerImpl {
 
   // Cull groups against camera frustum; toggles group.parentGroup.visible
   cull(camera: THREE.Camera) {
+    const hasMatrices =
+      camera &&
+      camera.projectionMatrix &&
+      camera.matrixWorldInverse &&
+      typeof (this.projScreenMatrix as unknown as { multiplyMatrices?: unknown }).multiplyMatrices === 'function';
+
+    if (!hasMatrices) {
+      for (const group of this.groups.values()) group.parentGroup.visible = group.positions.size > 0;
+      return;
+    }
+
     this.projScreenMatrix.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse);
     this.frustum.setFromProjectionMatrix(this.projScreenMatrix);
 
@@ -598,28 +666,40 @@ class ShipInstancerImpl {
         continue;
       }
 
-      // If group has ships, we need to make it visible
-      // The original logic was too aggressive with frustum culling
-      // For now, make all groups with ships visible to fix the visibility issue
-      // TODO: Implement proper frustum culling that doesn't hide ships in view
-      group.parentGroup.visible = true;
-
-      // Original frustum culling code (temporarily disabled):
-      // this.tmpSphere.center.copy(group.boundsCenter);
-      // this.tmpSphere.radius = group.boundsRadius;
-      // group.parentGroup.visible = this.frustum.intersectsSphere(this.tmpSphere);
+      const center = group.boundsCenter;
+      const radius = Math.max(group.boundsRadius, 0);
+      if (!Number.isFinite(center.x) || !Number.isFinite(center.y) || !Number.isFinite(center.z)) {
+        group.parentGroup.visible = true;
+        continue;
+      }
+      this.tmpSphere.center.copy(center);
+      this.tmpSphere.radius = radius <= 0 ? 0.1 : radius;
+      const inView = this.frustum.intersectsSphere(this.tmpSphere);
+      group.parentGroup.visible = inView;
     }
   }
 
   markMatricesNeedUpdate() {
-    for (const g of this.groups.values()) g.matricesNeedUpdate = true;
+    for (const g of this.groups.values()) this.markFullRangeDirty(g);
   }
 
   sync() {
     for (const g of this.groups.values()) {
       if (!g.matricesNeedUpdate) continue;
-      for (const m of g.meshes) m.instanceMatrix.needsUpdate = true;
+      for (const m of g.meshes) {
+        const attr = m.instanceMatrix;
+        const updateRange = (attr as unknown as { updateRange?: { offset: number; count: number } }).updateRange;
+        if (g.dirtyRange && updateRange) {
+          updateRange.offset = g.dirtyRange.min * 16;
+          updateRange.count = (g.dirtyRange.max - g.dirtyRange.min + 1) * 16;
+        } else if (updateRange) {
+          updateRange.offset = 0;
+          updateRange.count = -1;
+        }
+        attr.needsUpdate = true;
+      }
       g.matricesNeedUpdate = false;
+      g.dirtyRange = null;
     }
   }
 
@@ -780,6 +860,8 @@ class ShipInstancerImpl {
       boundsCenter: new THREE.Vector3(),
       boundsRadius: 0,
       boundsDirty: false,
+      lastTransforms: new Map(),
+      dirtyRange: null,
     };
     // If this is the first created group and the instancer hasn't signaled ready,
     // mark it ready now so consumers relying on createGroup can begin using instanced paths.
@@ -879,7 +961,7 @@ class ShipInstancerImpl {
       }
       newMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
       newMesh.name = `${group.className}_grown_submesh_${i}`;
-      newMesh.frustumCulled = true;
+      newMesh.frustumCulled = false;
       const tmp = new THREE.Matrix4();
       for (let idx = 0; idx < oldCap; idx++) {
         oldMesh.getMatrixAt(idx, tmp);
@@ -898,7 +980,7 @@ class ShipInstancerImpl {
     group.meshes = newMeshes;
     for (let i = newCap - 1; i >= oldCap; i--) group.freeIndices.push(i);
     group.capacity = newCap;
-    group.matricesNeedUpdate = true;
+    this.markFullRangeDirty(group);
   }
 }
 

--- a/test/vitest/shipInstancer.integration.spec.ts
+++ b/test/vitest/shipInstancer.integration.spec.ts
@@ -9,6 +9,7 @@ describe('ShipInstancer integration: prototype registration and sync', () => {
   let parent: THREE.Group;
 
   beforeEach(() => {
+    shipInstancer.dispose();
     scene = new THREE.Scene();
     parent = new THREE.Group();
   });

--- a/test/vitest/shipInstancer.spec.ts
+++ b/test/vitest/shipInstancer.spec.ts
@@ -7,6 +7,7 @@ describe('ShipInstancer basic allocation and growth', () => {
   let parent: THREE.Group;
 
   beforeEach(() => {
+    shipInstancer.dispose();
     scene = new THREE.Scene();
     parent = new THREE.Group();
   });
@@ -55,5 +56,95 @@ describe('ShipInstancer basic allocation and growth', () => {
     for (const id of allocated) shipInstancer.free(id);
 
     expect(allocated.every((id) => !shipInstancer.hasShip(id))).toBe(true);
+  });
+
+  it('skips matrix updates when transform changes are under epsilon thresholds', () => {
+    shipInstancer.init(scene, parent as any);
+    const shipId = 7;
+    const className = 'epsilon-ship';
+    const team = 'red';
+    const group = shipInstancer.ensureGroup(className, team) as unknown as {
+      meshes: THREE.InstancedMesh[];
+      matricesNeedUpdate: boolean;
+    };
+
+    expect(shipInstancer.allocate(shipId, className, team)).toBe(true);
+
+    const mesh = group.meshes[0];
+    const quat = new THREE.Quaternion();
+
+    expect(
+      shipInstancer.updateTransform(shipId, { x: 5, y: 0, z: 0 }, quat, 1),
+    ).toBe(true);
+    shipInstancer.sync();
+    expect(mesh.instanceMatrix.version).toBeGreaterThan(0);
+    const initialRange = (
+      mesh.instanceMatrix as unknown as { updateRange?: { offset: number; count: number } }
+    ).updateRange;
+    if (initialRange) {
+      expect(initialRange.offset).toBe(0);
+      expect(initialRange.count).toBe(16);
+    }
+    mesh.instanceMatrix.needsUpdate = false;
+    group.matricesNeedUpdate = false;
+
+    // tiny movement below epsilon should not trigger GPU writes
+    expect(
+      shipInstancer.updateTransform(shipId, { x: 5 + 1e-4, y: 1e-4, z: 0 }, quat, 1),
+    ).toBe(true);
+    expect(group.matricesNeedUpdate).toBe(false);
+    shipInstancer.sync();
+    const versionAfterNoop = mesh.instanceMatrix.version;
+    expect(versionAfterNoop).toBeGreaterThan(0);
+
+    // rotation slightly above epsilon should flag updates
+    const rotated = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), 0.01);
+    expect(
+      shipInstancer.updateTransform(shipId, { x: 5.05, y: 0, z: 0 }, rotated, 1.002),
+    ).toBe(true);
+    expect(group.matricesNeedUpdate).toBe(true);
+    shipInstancer.sync();
+    expect(mesh.instanceMatrix.version).toBeGreaterThan(versionAfterNoop);
+    const rotatedRange = (
+      mesh.instanceMatrix as unknown as { updateRange?: { offset: number; count: number } }
+    ).updateRange;
+    if (rotatedRange) {
+      expect(rotatedRange.count).toBe(16);
+    }
+  });
+
+  it('toggles visibility based on frustum culling results', () => {
+    shipInstancer.init(scene, parent as any);
+    const shipId = 11;
+    const className = 'cull-ship';
+    const team = 'blue';
+
+    expect(shipInstancer.allocate(shipId, className, team)).toBe(true);
+    const group = shipInstancer.ensureGroup(className, team);
+    const quat = new THREE.Quaternion();
+
+    shipInstancer.updateTransform(shipId, { x: 0, y: 0, z: 0 }, quat, 1);
+    shipInstancer.sync();
+
+    const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 1000);
+    camera.position.set(0, 0, 10);
+    camera.lookAt(0, 0, 0);
+    camera.updateMatrixWorld(true);
+    camera.updateProjectionMatrix();
+
+    shipInstancer.cull(camera);
+    expect(group.parentGroup.visible).toBe(true);
+
+    shipInstancer.updateTransform(shipId, { x: 1500, y: 1500, z: 1500 }, quat, 1);
+    shipInstancer.sync();
+    camera.updateMatrixWorld(true);
+    shipInstancer.cull(camera);
+    expect(group.parentGroup.visible).toBe(false);
+
+    shipInstancer.updateTransform(shipId, { x: 0, y: 0, z: -10 }, quat, 1);
+    shipInstancer.sync();
+    camera.updateMatrixWorld(true);
+    shipInstancer.cull(camera);
+    expect(group.parentGroup.visible).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- restore ship instancer frustum culling with guarding for non-Three cameras and track per-instance transform state to skip redundant updates
- batch instance matrix updates using dirty ranges and last-transform caches to minimize GPU churn
- document the improved behavior, add focused unit coverage, and wire up a new Playwright-based `npm run perf:instancer` harness

## Testing
- `npm run typecheck`
- `npx vitest test/vitest/shipInstancer.spec.ts`
- `npx vitest test/vitest/shipInstancer.integration.spec.ts`
- `npm test` *(fails: suite already contains multiple long-standing renderer / AI regressions in this environment; run aborted after observing failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cb09a5ba50832a9bb0b60f1b1f1af0