### PR TITLE
feat: add adaptive effects governor

### DIFF
--- a/src/config/rendererConfig.ts
+++ b/src/config/rendererConfig.ts
@@ -1,4 +1,25 @@
 // Renderer configuration for visual effects and display settings
+export type EffectsQualityLevel = 'low' | 'medium' | 'high';
+
+export interface EffectsQualityGovernorConfig {
+  enabled: boolean;
+  frameTimeBudgetMs: number;
+  sampleWindow: number;
+  triggerThreshold: number;
+  recoverThreshold: number;
+  resumeBelowMs?: number;
+  disableParticles: boolean;
+  disablePostprocessing: boolean;
+  degradeQuality: EffectsQualityLevel;
+  recoverQuality?: EffectsQualityLevel;
+  logTransitions?: boolean;
+}
+
+export interface EffectsQualityConfig {
+  defaultQuality: EffectsQualityLevel;
+  governor: EffectsQualityGovernorConfig;
+}
+
 export interface RendererConfig {
   // Camera settings
   camera: {
@@ -219,6 +240,9 @@ export interface RendererConfig {
 
   // Enable/disable visual interpolation between sim steps
   enableInterpolation?: boolean;
+
+  // Quality settings for visual effects with adaptive governor
+  effectsQuality: EffectsQualityConfig;
 }
 
 export const DefaultRendererConfig: RendererConfig = {
@@ -401,6 +425,23 @@ export const DefaultRendererConfig: RendererConfig = {
   },
 
   enableInterpolation: true, // Default to enabled for smooth rendering
+
+  effectsQuality: {
+    defaultQuality: 'high',
+    governor: {
+      enabled: true,
+      frameTimeBudgetMs: 20,
+      sampleWindow: 30,
+      triggerThreshold: 20,
+      recoverThreshold: 120,
+      resumeBelowMs: 16,
+      disableParticles: true,
+      disablePostprocessing: true,
+      degradeQuality: 'low',
+      recoverQuality: 'high',
+      logTransitions: false,
+    },
+  },
 };
 
 // Export the default config as RendererConfig for backward compatibility

--- a/src/renderer/effectsGovernor.ts
+++ b/src/renderer/effectsGovernor.ts
@@ -1,0 +1,202 @@
+import type {
+  EffectsQualityConfig,
+  EffectsQualityGovernorConfig,
+  EffectsQualityLevel,
+} from '../config/rendererConfig.js';
+
+export interface EffectsGovernorHooks {
+  applyQuality: (quality: EffectsQualityLevel) => void;
+  setParticlesEnabled: (enabled: boolean) => void;
+  setPostprocessingEnabled: (enabled: boolean) => void;
+  log?: (message: string, details?: Record<string, unknown>) => void;
+}
+
+export interface EffectsGovernorOptions {
+  config: EffectsQualityConfig;
+  initialParticlesEnabled: boolean;
+  initialPostprocessingEnabled: boolean;
+  hooks: EffectsGovernorHooks;
+}
+
+export interface EffectsGovernor {
+  update: (frameMs: number) => void;
+  reset: () => void;
+  areParticlesEnabled: () => boolean;
+  isPostprocessingEnabled: () => boolean;
+  currentQuality: () => EffectsQualityLevel;
+  getAverageFrameMs: () => number;
+  getSampleCount: () => number;
+}
+
+function clampConfig(cfg: EffectsQualityGovernorConfig): EffectsQualityGovernorConfig {
+  return {
+    ...cfg,
+    frameTimeBudgetMs: Math.max(1, cfg.frameTimeBudgetMs || 1),
+    sampleWindow: Math.max(1, Math.floor(cfg.sampleWindow || 1)),
+    triggerThreshold: Math.max(1, Math.floor(cfg.triggerThreshold || 1)),
+    recoverThreshold: Math.max(1, Math.floor(cfg.recoverThreshold || 1)),
+    resumeBelowMs:
+      typeof cfg.resumeBelowMs === 'number'
+        ? Math.max(0, cfg.resumeBelowMs)
+        : Math.max(0, Math.floor(cfg.frameTimeBudgetMs * 0.85)),
+    degradeQuality: cfg.degradeQuality ?? 'low',
+    recoverQuality: cfg.recoverQuality ?? 'high',
+  };
+}
+
+export function createEffectsGovernor(options: EffectsGovernorOptions): EffectsGovernor {
+  const { config } = options;
+  const governor = clampConfig(config.governor);
+
+  let particlesEnabled = !!options.initialParticlesEnabled;
+  let postprocessingEnabled = !!options.initialPostprocessingEnabled;
+  let currentQuality: EffectsQualityLevel = config.defaultQuality;
+  let degraded = false;
+  let sampleSum = 0;
+  const samples: number[] = [];
+  let overBudgetStreak = 0;
+  let underBudgetStreak = 0;
+
+  const applyQuality = (quality: EffectsQualityLevel) => {
+    if (currentQuality === quality) return;
+    currentQuality = quality;
+    try {
+      options.hooks.applyQuality(quality);
+    } catch (_err) {
+      void _err;
+    }
+  };
+
+  const setParticles = (enabled: boolean) => {
+    if (particlesEnabled === enabled) return;
+    particlesEnabled = enabled;
+    try {
+      options.hooks.setParticlesEnabled(enabled);
+    } catch (_err) {
+      void _err;
+    }
+  };
+
+  const setPostprocessing = (enabled: boolean) => {
+    if (postprocessingEnabled === enabled) return;
+    postprocessingEnabled = enabled;
+    try {
+      options.hooks.setPostprocessingEnabled(enabled);
+    } catch (_err) {
+      void _err;
+    }
+  };
+
+  const logTransition = (message: string, details: Record<string, unknown>) => {
+    if (!governor.logTransitions || !options.hooks.log) return;
+    try {
+      options.hooks.log(message, details);
+    } catch (_err) {
+      void _err;
+    }
+  };
+
+  const resetState = () => {
+    degraded = false;
+    overBudgetStreak = 0;
+    underBudgetStreak = 0;
+    samples.length = 0;
+    sampleSum = 0;
+    currentQuality = config.defaultQuality;
+    setParticles(!!options.initialParticlesEnabled);
+    setPostprocessing(!!options.initialPostprocessingEnabled);
+    try {
+      options.hooks.applyQuality(currentQuality);
+    } catch (_err) {
+      void _err;
+    }
+  };
+
+  // Apply initial quality immediately so downstream systems can align.
+  try {
+    options.hooks.applyQuality(currentQuality);
+  } catch (_err) {
+    void _err;
+  }
+
+  const update = (frameMs: number) => {
+    if (!governor.enabled) {
+      return;
+    }
+    if (!Number.isFinite(frameMs) || frameMs <= 0) {
+      return;
+    }
+
+    samples.push(frameMs);
+    sampleSum += frameMs;
+    if (samples.length > governor.sampleWindow) {
+      const removed = samples.shift();
+      if (removed !== undefined) {
+        sampleSum -= removed;
+      }
+    }
+
+    if (samples.length < governor.sampleWindow) {
+      return;
+    }
+
+    const average = sampleSum / samples.length;
+
+    if (!degraded) {
+      if (average >= governor.frameTimeBudgetMs) {
+        overBudgetStreak += 1;
+      } else {
+        overBudgetStreak = 0;
+      }
+
+      if (overBudgetStreak >= governor.triggerThreshold) {
+        degraded = true;
+        overBudgetStreak = 0;
+        underBudgetStreak = 0;
+        applyQuality(governor.degradeQuality);
+        if (governor.disableParticles) {
+          setParticles(false);
+        }
+        if (governor.disablePostprocessing) {
+          setPostprocessing(false);
+        }
+        logTransition('degraded', { average, frameMs, samples: samples.length });
+      }
+    } else {
+      if (average <= (governor.resumeBelowMs ?? governor.frameTimeBudgetMs)) {
+        underBudgetStreak += 1;
+      } else {
+        underBudgetStreak = 0;
+      }
+
+      if (underBudgetStreak >= governor.recoverThreshold) {
+        degraded = false;
+        underBudgetStreak = 0;
+        overBudgetStreak = 0;
+        applyQuality(governor.recoverQuality ?? config.defaultQuality);
+        if (governor.disableParticles) {
+          setParticles(!!options.initialParticlesEnabled);
+        }
+        if (governor.disablePostprocessing) {
+          setPostprocessing(!!options.initialPostprocessingEnabled);
+        }
+        logTransition('recovered', { average, frameMs, samples: samples.length });
+      }
+    }
+  };
+
+  const getAverageFrameMs = () => {
+    if (samples.length === 0) return 0;
+    return sampleSum / samples.length;
+  };
+
+  return {
+    update,
+    reset: resetState,
+    areParticlesEnabled: () => particlesEnabled,
+    isPostprocessingEnabled: () => postprocessingEnabled,
+    currentQuality: () => currentQuality,
+    getAverageFrameMs,
+    getSampleCount: () => samples.length,
+  };
+}

--- a/src/renderer/threeRenderer.ts
+++ b/src/renderer/threeRenderer.ts
@@ -8,6 +8,7 @@ import {
   disposeParticleRenderer,
 } from './particleRenderer.js';
 import { RendererConfig } from '../config/rendererConfig.js';
+import { createEffectsGovernor } from './effectsGovernor.js';
 import { ShipVisualConfig } from '../config/shipVisualConfig.js';
 import { RendererEffectsConfig } from '../config/rendererEffectsConfig.js';
 import { defaultSVGConfig, getShipSVGUrl } from '../config/svgConfig.js';
@@ -75,6 +76,47 @@ export function createThreeRenderer(state: GameState, canvas: HTMLCanvasElement)
   type LooseDict = Record<string, unknown>;
   const _G = globalThis as unknown as LooseDict;
   const rng = state.rng ?? createRNG(String(Date.now()));
+  const baselineParticlesVisual = !!RendererConfig.visual.enableParticles;
+  const baselineParticlesExplosion = !!RendererConfig.particles.explosion.enabled;
+  let allowPostprocessing = true;
+  const getTimestampMs = () =>
+    typeof performance !== 'undefined' && typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now();
+
+  const effectsGovernor = createEffectsGovernor({
+    config: RendererConfig.effectsQuality,
+    initialParticlesEnabled: baselineParticlesVisual && baselineParticlesExplosion,
+    initialPostprocessingEnabled: true,
+    hooks: {
+      applyQuality: (quality) => {
+        try {
+          state.unifiedFX?.setQuality?.(quality);
+        } catch (_err) {
+          void _err;
+        }
+      },
+      setParticlesEnabled: (enabled) => {
+        if (enabled) {
+          RendererConfig.visual.enableParticles = baselineParticlesVisual;
+          RendererConfig.particles.explosion.enabled = baselineParticlesExplosion;
+        } else {
+          RendererConfig.visual.enableParticles = false;
+          RendererConfig.particles.explosion.enabled = false;
+        }
+      },
+      setPostprocessingEnabled: (enabled) => {
+        allowPostprocessing = enabled;
+      },
+      log: (message, details) => {
+        try {
+          console.info('[RendererEffectsGovernor]', message, details);
+        } catch (_err) {
+          void _err;
+        }
+      },
+    },
+  });
   // Apply global readPixels/prototype patches early, if available.
   try {
     if (typeof gAny.__applyEffectsManagerGlobalPatches === 'function') {
@@ -2160,6 +2202,7 @@ export function createThreeRenderer(state: GameState, canvas: HTMLCanvasElement)
   }
 
   function render(_dt: number) {
+    const frameStartMs = getTimestampMs();
     // Calculate interpolation factor
     const interpolationFactor = Math.min(1, (state.time - lastSimulatedTime) / fixedSimulationDt);
 
@@ -2242,41 +2285,46 @@ export function createThreeRenderer(state: GameState, canvas: HTMLCanvasElement)
     perfEnd('renderer.particles');
 
     perfBegin('renderer.effects');
-    // Prefer postprocessing composer when available
-    if (effectsManager && effectsManager.initDone) {
+    let usedPostprocessing = false;
+    if (allowPostprocessing && effectsManager && effectsManager.initDone) {
       try {
         effectsManager.render(_dt);
-        perfEnd('renderer.effects');
-        return;
+        usedPostprocessing = true;
       } catch (e) {
         logger.warn('Effects manager render failed, falling back to default renderer', e);
+        usedPostprocessing = false;
       }
     }
     perfEnd('renderer.effects');
 
-    perfBegin('renderer.culling');
-    // Render the scene
-    // Ensure instanced meshes have their instanceMatrix flags updated before rendering
-    console.log('About to call shipInstancer.cull()');
-    try {
-      shipInstancer.cull(camera);
-    } catch (e) {
-      logger.error('Failed to cull ship instancer', e);
-    }
-    console.log('About to call shipInstancer.sync()');
-    try {
-      shipInstancer.sync();
-    } catch (e) {
-      logger.error('Failed to sync ship instancer', e);
-    }
-    perfEnd('renderer.culling');
-    perfEnd('renderer.culling');
+    if (!usedPostprocessing) {
+      perfBegin('renderer.culling');
+      try {
+        shipInstancer.cull(camera);
+      } catch (e) {
+        logger.error('Failed to cull ship instancer', e);
+      }
+      try {
+        shipInstancer.sync();
+      } catch (e) {
+        logger.error('Failed to sync ship instancer', e);
+      }
+      perfEnd('renderer.culling');
 
-    perfBegin('renderer.webgl');
-    renderer.render(scene, camera);
-    perfEnd('renderer.webgl');
+      perfBegin('renderer.webgl');
+      renderer.render(scene, camera);
+      perfEnd('renderer.webgl');
+    }
 
     lastSimulatedTime = state.time; // Update last simulated time for next frame's interpolation
+
+    const frameEndMs = getTimestampMs();
+    const frameDurationMs = Math.max(0, frameEndMs - frameStartMs);
+    try {
+      effectsGovernor.update(frameDurationMs);
+    } catch (_err) {
+      void _err;
+    }
   }
 
   window.addEventListener('resize', resize);

--- a/src/renderer/unifiedEffectsManager.ts
+++ b/src/renderer/unifiedEffectsManager.ts
@@ -4,6 +4,7 @@ import { createBVHManager } from './bvhManager.js';
 import type { EffectsManager } from './effects.js';
 import type { AnimationManager } from './animationManager.js';
 import type { BVHManager } from './bvhManager.js';
+import { RendererConfig } from '../config/rendererConfig.js';
 
 export interface UnifiedEffectsManager {
   initDone: boolean;
@@ -283,6 +284,13 @@ export function createUnifiedEffectsManager(
     addExplosionEffect: () => {},
     addHitSpark: () => {},
   };
+
+  try {
+    const defaultQuality = RendererConfig.effectsQuality?.defaultQuality ?? 'high';
+    setQuality(defaultQuality);
+  } catch (_err) {
+    void _err;
+  }
 
   return {
     initDone: finalEffects.initDone && animation.initDone && bvh.initDone,

--- a/test/vitest/effectsGovernor.spec.ts
+++ b/test/vitest/effectsGovernor.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { createEffectsGovernor } from '../../src/renderer/effectsGovernor.js';
+import type { EffectsQualityConfig } from '../../src/config/rendererConfig.js';
+
+describe('effectsGovernor', () => {
+  const baseConfig: EffectsQualityConfig = {
+    defaultQuality: 'high',
+    governor: {
+      enabled: true,
+      frameTimeBudgetMs: 10,
+      sampleWindow: 2,
+      triggerThreshold: 2,
+      recoverThreshold: 2,
+      resumeBelowMs: 6,
+      disableParticles: true,
+      disablePostprocessing: true,
+      degradeQuality: 'low',
+      recoverQuality: 'high',
+      logTransitions: false,
+    },
+  };
+
+  it('degrades quality when frames exceed budget for sustained window', () => {
+    const actions: string[] = [];
+    const governor = createEffectsGovernor({
+      config: baseConfig,
+      initialParticlesEnabled: true,
+      initialPostprocessingEnabled: true,
+      hooks: {
+        applyQuality: (quality) => actions.push(`quality:${quality}`),
+        setParticlesEnabled: (enabled) => actions.push(`particles:${enabled}`),
+        setPostprocessingEnabled: (enabled) => actions.push(`post:${enabled}`),
+      },
+    });
+
+    actions.length = 0;
+
+    governor.update(12);
+    governor.update(12);
+    governor.update(12);
+
+    expect(actions).toContain('quality:low');
+    expect(actions).toContain('particles:false');
+    expect(actions).toContain('post:false');
+    expect(governor.areParticlesEnabled()).toBe(false);
+    expect(governor.isPostprocessingEnabled()).toBe(false);
+    expect(governor.currentQuality()).toBe('low');
+  });
+
+  it('recovers quality after sustained improvement', () => {
+    const actions: string[] = [];
+    const governor = createEffectsGovernor({
+      config: baseConfig,
+      initialParticlesEnabled: true,
+      initialPostprocessingEnabled: true,
+      hooks: {
+        applyQuality: (quality) => actions.push(`quality:${quality}`),
+        setParticlesEnabled: (enabled) => actions.push(`particles:${enabled}`),
+        setPostprocessingEnabled: (enabled) => actions.push(`post:${enabled}`),
+      },
+    });
+
+    actions.length = 0;
+
+    governor.update(12);
+    governor.update(12);
+    governor.update(12);
+
+    actions.length = 0;
+
+    governor.update(5);
+    governor.update(5);
+    governor.update(5);
+
+    expect(actions).toContain('quality:high');
+    expect(actions).toContain('particles:true');
+    expect(actions).toContain('post:true');
+    expect(governor.areParticlesEnabled()).toBe(true);
+    expect(governor.isPostprocessingEnabled()).toBe(true);
+    expect(governor.currentQuality()).toBe('high');
+  });
+
+  it('no-ops when governor disabled', () => {
+    const disabledConfig: EffectsQualityConfig = {
+      ...baseConfig,
+      governor: { ...baseConfig.governor, enabled: false },
+    };
+    const actions: string[] = [];
+    const governor = createEffectsGovernor({
+      config: disabledConfig,
+      initialParticlesEnabled: true,
+      initialPostprocessingEnabled: true,
+      hooks: {
+        applyQuality: (quality) => actions.push(`quality:${quality}`),
+        setParticlesEnabled: (enabled) => actions.push(`particles:${enabled}`),
+        setPostprocessingEnabled: (enabled) => actions.push(`post:${enabled}`),
+      },
+    });
+
+    actions.length = 0;
+
+    governor.update(40);
+    governor.update(40);
+    governor.update(40);
+
+    expect(actions).toEqual([]);
+    expect(governor.areParticlesEnabled()).toBe(true);
+    expect(governor.isPostprocessingEnabled()).toBe(true);
+    expect(governor.getSampleCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add effect quality governor settings to the renderer config so runtime quality knobs are available
- introduce an effects governor utility and integrate it with the Three.js renderer to throttle particles and postprocessing when frame times spike
- default the unified effects manager to the configured quality and add a unit smoke test for the governor logic

## Testing
- npx vitest run *(fails: numerous existing Vitest suites require browser features such as Canvas and worker support; see console output for missing context errors and timeouts)*
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cb122b5ff0832aaf0f0d2f699328e6