### PR TITLE
fix: include ship speed in worker ai data

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -837,7 +837,7 @@ export function initGame(seed?: string) {
             try {
               lastAIDt = dt;
               // Pack ship data for AI (more fields than physics)
-              const floatsPerShip = 11; // id, px, py, pz, vx, vy, vz, health, targetId, team, class
+              const floatsPerShip = 12; // id, px, py, pz, vx, vy, vz, health, targetId, team, class, speed
               const shipsBuffer = new Float32Array(state.ships.length * floatsPerShip);
               for (let i = 0; i < state.ships.length; i++) {
                 const ship = state.ships[i];
@@ -853,6 +853,7 @@ export function initGame(seed?: string) {
                 shipsBuffer[base + 8] = ship.targetId || -1;
                 shipsBuffer[base + 9] = ship.team === 'red' ? 0 : 1;
                 shipsBuffer[base + 10] = 0; // ship class placeholder
+                shipsBuffer[base + 11] = ship.speed ?? 0;
               }
               // Pack bullet data if needed
               const floatsPerBullet = 11; // id, px, py, pz, vx, vy, vz, ttl, damage, ownerShipId, ownerTeam

--- a/src/simWorker.ts
+++ b/src/simWorker.ts
@@ -958,8 +958,8 @@ self.addEventListener('message', async (e: MessageEvent) => {
   const ships: ShipLike[] = [];
       if (aiPayload.shipsBuffer) {
         const shipsData = new Float32Array(aiPayload.shipsBuffer);
-        // Expected format: [id, px, py, pz, vx, vy, vz, health, targetId, team, class] per ship
-        const floatsPerShip = 11;
+        // Expected format: [id, px, py, pz, vx, vy, vz, health, targetId, team, class, speed] per ship
+        const floatsPerShip = 12;
         for (let i = 0; i < shipsData.length; i += floatsPerShip) {
           ships.push({
             id: shipsData[i],
@@ -969,6 +969,7 @@ self.addEventListener('message', async (e: MessageEvent) => {
             targetId: shipsData[i + 8] === -1 ? null : shipsData[i + 8],
             team: shipsData[i + 9] === 0 ? 'red' : 'blue',
             class: Math.floor(shipsData[i + 10]), // ship class as integer
+            speed: shipsData[i + 11] || 0,
             // Ensure turrets exists on reconstructed ships so AIController can iterate safely.
             turrets: [],
             aiState: {} // Initialize basic AI state


### PR DESCRIPTION
## Summary
- include each ship's speed when serializing the AI step payload sent to the simulation worker
- hydrate the worker-side ship objects with the transmitted speed so steering logic can produce non-zero velocities

## Testing
- npm test *(fails: `Performance Optimizations Integration > should demonstrate quickselect performance benefits` exceeded expected threshold; passes when re-run alone)*
- npx vitest run test/vitest/performance-optimizations-integration.spec.ts
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cd03ec7094832abe99653e721f3928