### PR TITLE
feat: add ai v2 decision system skeleton

### DIFF
--- a/docs/ai-v2-overview.md
+++ b/docs/ai-v2-overview.md
@@ -1,0 +1,28 @@
+# AI V2 Overview
+
+_Updated: 2025-09-22_
+
+## Goals
+
+- Provide deterministic, profile-driven ship behaviors with varied intents (attack, kite, escort, flee) behind a feature flag.
+- Share expensive queries via an AI blackboard so 300 ships can be processed within a fixed budget.
+- Preserve existing gameplay by keeping legacy AI active when the flag is disabled.
+
+## Architecture
+
+- **AI Manager (`GameState.ai`)** — stores feature flag, tick interval (default 10 Hz), max ships per tick, accumulator, tick index, slice cursor, and escort assignments.
+- **Blackboard (`GameState.blackboard`)** — caches ally centroids, team posture, nearest enemy per ship, and VIP threat mapping. Rebuilt each AI tick.
+- **Profiles (`src/game/aiProfiles.ts`)** — describe desired engagement bands, aggression/patience knobs, class biases, and gates. Ships pick defaults on spawn via hull → profile mapping.
+- **Decision System (`updateDecisionSystem`)** — round-robin scheduler evaluating intent utility scores; writes `AICommand` (heading, thrust, fire gating, targetId) into each ship’s `ai` component. Tie-breaking uses hashed `traitSeed` + tick index for determinism.
+- **Execution (`prepareShips`)** — interprets `AICommand` each frame (orient, move, fire) or runs legacy nearest-target steering when AI V2 is disabled. Embedded turrets reuse the same target data.
+
+## Feature Flag
+
+- `config.ai.v2Enabled` defaults to `false`. Toggle at runtime (or via config) to switch between legacy AI and the new decision system.
+- When disabled, AI blackboard still resets but no commands are written; legacy behavior remains untouched.
+
+## Follow-ups
+
+- Add deterministic Vitest suites covering scoring, escort assignment, and legacy fallback.
+- Wire a UI toggle for QA and update docs once V2 becomes the default.
+- Extend performance harness to assert AI tick budget at 300 ships.

--- a/memory/_index.md
+++ b/memory/_index.md
@@ -17,6 +17,7 @@ This index lists the short searchable memory summaries generated for the `src/` 
 - [core-physics.md](./core-physics.md) — `src/game/state.ts` & `src/game/systems.ts` (Rapier initialization, main-thread stepping, collision/resolve helpers).
 - [core-assets.md](./core-assets.md) — `src/utils/patchGltfLoader.ts` and `src/assets/ships.ts` (GLTF loader guard and model asset mappings used by renderer).
 - [core-rng.md](./core-rng.md) — `src/utils/rng.ts` (seeded deterministic RNG used by simulation and spawn randomization).
+- [core-aiProfiles.md](./core-aiProfiles.md) — `src/game/aiProfiles.ts` (behavior profile definitions + hull-to-profile mapping for AI v2).
 
 - [projectbrief.md](./projectbrief.md) — Project brief describing goals, constraints, and success criteria.
 - [productContext.md](./productContext.md) — Users, stakeholders, and high-level assumptions.

--- a/memory/activeContext.md
+++ b/memory/activeContext.md
@@ -2,20 +2,20 @@
 
 Current focuses (short-term):
 
-- Validate gameplay after 2025 rewrite (branch `feat-shipstats`): main-thread Rapier + R3F step, Miniplex ECS.
-- Improve unit test coverage for AI targeting/movement and projectile resolution.
-- Maintain canonical `GameState` and avoid module-level side effects.
+- Land AI v2 skeleton: deterministic decision system, blackboard scheduling, and profile-driven ship commands behind feature flag.
+- Validate gameplay after 2025 rewrite (main-thread Rapier + R3F + Miniplex) while preserving legacy behavior when AI v2 is disabled.
+- Improve unit test coverage for AI intent scoring/movement and projectile resolution.
 
 Recent changes:
 
-- Rewrote `/src` from scratch; Rapier stepped inside R3F `useFrame`, no worker.
-- Added material registry with built-in shield and bullet materials.
-- Introduced per-hull shield visuals in `src/config/renderer.ts`.
+- Added `GameState.ai` manager + blackboard scaffolding seeded from `config.ai` (v2 disabled by default).
+- Implemented `updateDecisionSystem` in `systems.ts`, per-ship AI components, and new behavior profiles (`src/game/aiProfiles.ts`).
+- Refactored `prepareShips` to execute AI commands while retaining legacy nearest-enemy fallback; embedded turret logic shared across both paths.
 
 Next steps:
 
-- Run full test suite and ensure `npm run typecheck` passes on CI.
-- Add targeted unit tests for `systems.ts` (nearest-target, damage application, shield ripple emission).
-- Add a small deterministic tick helper for tests (mirrors E2E window hooks).
+- Author deterministic Vitest suites for AI scoring (posture/escort influence) and confirm command streams remain stable per seed.
+- Wire a UI/config toggle for QA to enable/disable AI v2 at runtime (if not already exposed).
+- Extend perf harness to measure AI tick budget under 300-ship load with new scheduler.
 
-Generated: 2025-09-21
+Updated: 2025-09-22

--- a/memory/core-aiProfiles.md
+++ b/memory/core-aiProfiles.md
@@ -1,0 +1,22 @@
+# Memory — core-aiProfiles
+
+File: `src/game/aiProfiles.ts`
+
+Summary
+
+- Declares `AI_PROFILES`, a small set of behavior profiles (`brawler`, `kiter`, `escort`, `artillery`) implementing `BehaviorProfile`.
+- Each profile defines desired engagement band, orbit radius, aggression/patience knobs, dodge frequency, per-hull class bias, stylistic tag, and optional retreat gates (hp thresholds).
+- `getDefaultProfileId(hull)` maps `ShipHull` to a default profile (fighters -> escort, corvette/frigate -> brawler, capitals -> artillery).
+- `resolveBehaviorProfile(profileId)` returns the profile or falls back to `brawler` if missing; used heavily by the decision system.
+
+Usage
+
+- `spawnShip` calls `getDefaultProfileId` to seed each ship's AI component; other systems can override `profileId` to experiment with roles.
+- `updateDecisionSystem` retrieves behavior knobs via `resolveBehaviorProfile` when evaluating intents.
+
+Follow-ups
+
+- Extend the profile table when adding new roles; keep values deterministic-friendly (plain numbers, no functions).
+- Consider splitting tuning constants into JSON/yaml once designers need to iterate without touching code.
+
+Created: 2025-09-22

--- a/memory/core-gameState.md
+++ b/memory/core-gameState.md
@@ -4,25 +4,30 @@ File: `src/game/state.ts`
 
 Responsibilities (summary)
 
-- `createGameState()` initializes Rapier, creates the physics `World` and `EventQueue`, constructs the Miniplex ECS world, and returns the canonical `GameState` used across the app and tests.
-- `destroyEntity(state, entity)` and `disposeGameState(state)` provide robust lifecycle handling for entities and Rapier resources.
-- Spawn helpers: `spawnInitialFleets()`, `spawnRandomShip()`, and `resetGame()` are responsible for consistent, deterministic entity creation.
+- `createGameState()` initializes Rapier, the physics `World`/`EventQueue`, the Miniplex ECS world, seeded RNG, and now wires the AI manager (`state.ai`) plus AI blackboard scaffolding.
+- Lifecycle helpers `destroyEntity(state, entity)` / `disposeGameState(state)` manage Rapier resources, ECS cleanup, turret cascade removal, and now leave AI bookkeeping to be rebuilt next tick.
+- Spawn helpers (`spawnInitialFleets`, `spawnRandomShip`, `resetGame`) create deterministic fleets and reseed per-ship cooldowns/AI traits.
 
 Key data and structures
 
-- `GameState` contains: Rapier runtime objects (`rapier`, `physicsWorld`, `eventQueue`), `world` (Miniplex), `colliderLookup: Map<number, Entity>`, `turretsByShip: Map<number, Set<Entity>>`, `queries` (ships/projectiles/turrets), `rng` (SeededRng), `time`, `paused`, and `timeScale`.
-
-- `turretsByShip` is an explicit registry used for efficient turret cascade removal when ships are destroyed.
+- `GameState` now carries:
+  - Rapier runtime objects (`rapier`, `physicsWorld`, `eventQueue`).
+  - ECS world, entity queries, `colliderLookup`, optional `turretsByShip` registry.
+  - Simulation clock (`time`), `paused`, `timeScale`, and canonical `rng`.
+  - `ai: AIManagerState` (flag, tick interval, max-per-tick budget, accumulator, tick index/cursor, slice count, escort assignments map).
+  - `blackboard: AIBlackboard` (per-team centroids, posture, nearest-enemy/threat maps, scratch vectors, tick index).
 
 Behavior notes
 
-- `destroyEntity` performs defensive Rapier removals with `isValid()` checks and try/catch, removes collider lookup entries, uses `turretsByShip` to find and destroy child turrets, and ensures ECS entities are cleaned from queries to avoid stale references in tests.
-
-- `spawnRandomShip` and other spawn helpers use `state.rng` (the canonical seeded RNG) to ensure deterministic placement and cooldown seeding.
+- `createGameState` seeds AI defaults from `config.ai` (v2 disabled by default, 10 Hz tick). Blackboard vectors are preallocated to avoid per-tick allocations.
+- `resetGame` now resets AI counters, clears escort assignments/nearest caches, and zeroes centroids/posture in addition to respawning fleets.
+- `spawnShip` attaches an `ai` component per ship (profile id derived from hull, initial `AICommand` heading forward, deterministic `traitSeed`). Turret entity registration unchanged.
+- `destroyEntity` still clears Rapier handles/turret registries; AI state is transient and rebuilt via `updateDecisionSystem` so no extra teardown is needed.
 
 Testing & recommendations
 
-- Tests should create `GameState` with a known seed and use `state.rng` for any randomness.
-- Ensure turret registration helpers (`registerTurret`/`unregisterTurret`) are used in tests to keep `turretsByShip` accurate so `destroyEntity` fast-paths work as intended.
+- Tests toggling AI V2 should assert `state.ai.enabled` and blackboard contents; when flag-off, the legacy systems should behave as before.
+- When spawning ships in tests, inspect `entity.ai` to validate profile assignment or override behavior; any deterministic scenarios should set `state.ai.tickInterval`/`maxPerTick` explicitly.
+- Continue using `registerTurret`/`unregisterTurret` helpers so destroy cascades remain O(1).
 
-Generated: 2025-09-21 (automated promotion)
+Updated: 2025-09-22

--- a/memory/core-ships.md
+++ b/memory/core-ships.md
@@ -4,15 +4,20 @@ File: `src/game/ships.ts`
 
 Responsibilities
 
-- Declares `SHIP_STATS` per hull and provides `spawnShip()` to create ECS entity with Rapier body/collider.
-- Initializes health/shield, combat stats, scale, model key, and shield ripple buffer.
+- Defines `SHIP_STATS` per hull and `spawnShip()` which instantiates Rapier rigid bodies/colliders plus ECS entities.
+- Seeds ship combat state (hp/shield regen/cooldowns), model key, muzzle flash buffer, and turret state arrays.
+- Attaches a deterministic AI component per ship (profile id from hull -> behavior profile, initial `AICommand`, `traitSeed`).
 
 Integration
 
-- Used by `state.ts` spawn helpers and by tests for deterministic setups.
-- Colliders are registered in `GameState.colliderLookup` for potential future collision handling.
+- Called by `state.ts` helpers (`spawnInitialFleets`, `spawnRandomShip`, `resetGame`) and tests; relies on `GameState.rapier`, `rng`, and `ai.tickInterval` to configure runtime state.
+- Registers colliders in `GameState.colliderLookup` and turrets through `registerTurret` to keep cascade removal fast.
+- AI profiles are resolved via `getDefaultProfileId` (see `src/game/aiProfiles.ts`); ships spawn ready for the decision system without additional wiring.
 
 Tunables
 
-- Per-hull stats (hp, shield, damage, fireRate, projectile speed/range, movement speed, scale).
-- Collider shapes/sizes if GLBs change scale.
+- Per-hull stats: hp/shield pools, regen, damage, fire rate, projectile speed/range, move speed, scale, default bullet type, optional turret specs.
+- Collider primitive (capsule) sized for current GLB scale; adjust if art assets change.
+- Profile defaults can be overridden by editing `PROFILE_BY_HULL` in `aiProfiles.ts` for new roles/behaviors.
+
+Updated: 2025-09-22

--- a/memory/core-systems.md
+++ b/memory/core-systems.md
@@ -4,32 +4,33 @@ File: `src/game/systems.ts`
 
 Responsibilities
 
-- `updateGame(state, delta)`: top-level per-tick orchestration. The current order is:
-  1. `prepareShips(state, delta)` — AI and ship-driven actions (movement, firing, embedded turret fallback).
-  2. `updateTurrets(state, delta)` — turret entity updates (aiming, firing).
-  3. `advanceProjectiles(state, delta)` — move projectiles kinematically and clamp to world.
-  4. `state.physicsWorld.step(state.eventQueue)` — step Rapier physics.
-  5. `syncTransforms(state)` — copy rigid body transforms back into ECS transform objects.
-  6. `resolveProjectiles(state, delta)` — TTL handling, collision checks (distance-based), shield absorption & ripple emission, hull damage, and queued destruction.
+- `updateGame(state, delta)`: orchestrates the simulation tick in this order:
+  1. `updateDecisionSystem(state, delta)` — fixed-rate AI V2 scheduler that rebuilds the blackboard, assigns escorts/posture, and runs a round-robin decision slice when the feature flag is enabled.
+  2. `prepareShips(state, delta)` — executes deterministic `AICommand`s (movement, thrust, fire gating) or falls back to the legacy nearest-enemy steering when AI V2 is disabled; also manages shields, muzzle flashes, and embedded turrets.
+  3. `updateTurrets(state, delta)` — updates turret entities (aiming arcs, cooldowns, firing) against nearest targets.
+  4. `advanceProjectiles(state, delta)` — moves projectiles kinematically while clamping to world bounds.
+  5. `state.physicsWorld.step(state.eventQueue)` — steps Rapier physics.
+  6. `syncTransforms(state)` — copies rigid body transforms back onto ECS transforms for rendering.
+  7. `resolveProjectiles(state, delta)` — TTL decrement, collision distance checks, shield absorption/ripple emission, hull damage, and queued destruction.
 
 Key details
 
-- `prepareShips`: simple AI (nearest enemy), orientation, movement with world clamp, firing cooldown management and projectile spawn.
-- `updateTurrets`: updates turret entity kinematics, aiming arcs, and firing when within arc.
-- `advanceProjectiles`: kinematic movement for bullets with world clamp.
-- `syncTransforms`: copy Rapier rigid body transforms back onto ECS entities for renderer.
-- `resolveProjectiles`: TTL handling, shield absorption + ripple emission, hull damage, and entity cleanup.
+- `updateDecisionSystem` derives ally centroids, team posture (`aggressive`/`hold`/`retreat`), nearest-enemy & VIP threat caches, and escort assignments, then evaluates intent scores (`Attack`, `Kite`, `Escort`, `Flee`) per ship within the configured budget (`config.ai.maxPerTick`). Deterministic tie-breaking hashes each ship's `traitSeed` with the tick index.
+- `prepareShips` branches per flag: AI V2 consumes the stored command (normalizing headings, clamping thrust, resolving target IDs for turret fallback) while the legacy path keeps the prior nearest-enemy chase/fire routine. Both flows prune muzzle flashes and use `runEmbeddedTurrets` when no turret entities exist.
+- `runEmbeddedTurrets` centralizes the legacy turret firing path so both AI modes share it; dedicated turret entities remain unaffected.
+- Movement uses pooled vectors (`TEMP_DIR`, `TEMP_POS`), and world clamping to maintain determinism.
+- Projectile spawning still respects `PROJECTILE_CONFIG`/`DEFAULT_PROJECTILE_CONFIG`; only the gating signal changed (AI command vs. distance check).
 
 Implementation notes
 
-- Uses temporary Vector3 instances (`TEMP_DIR`, `TEMP_POS`) to avoid per-frame allocations in hot loops.
-- Projectile visuals and physics sizes are determined via `PROJECTILE_CONFIG` mapping with a `DEFAULT_PROJECTILE_CONFIG` fallback.
-- The collision / damage model is intentionally simple and distance-based (no Rapier collision events used for damage resolution in this path).
+- LOD spacing (0/1/2) determines how many AI ticks a ship can skip before its next evaluation; spacing is configurable and keyed off desired range vs. `config.ai.lod` thresholds.
+- Blackboard + assignments reset when no ships remain, and `resetGame` zeroes centroids/posture alongside AI scheduler counters.
+- Utility scores remain integer-friendly math; posture, profile aggression/patience knobs, and VIP threats bias which intent wins.
 
 Follow-ups
 
-- Tests should verify both the turret-entity flow (when turret entities exist) and the legacy embedded turret fallback (when `state.queries.turrets.entities.length === 0`).
-- Consider adding explicit unit tests for turret priority selection and the scoring heuristic.
-- If you plan to switch to Rapier collision events for projectile hit detection, note the need to update `resolveProjectiles` and remove the distance-based checks.
+- Add deterministic Vitest coverage for the decision system (blackboard contents, escort assignment, tie-breaking) and regression tests verifying the legacy path when `config.ai.v2Enabled` is `false`.
+- Consider caching ship lookups for `getShipById` or adding a spatial grid if 300+ ships make the O(N²) nearest-enemy cache too expensive.
+- A debug overlay (intent, score deltas, desired band error) would help tune profiles during rollout.
 
-Generated: 2025-09-21 (automated draft)
+Updated: 2025-09-22

--- a/memory/progress.md
+++ b/memory/progress.md
@@ -4,6 +4,7 @@ This file summarizes recent work and maintenance actions performed on the memory
 
 Recent updates (automated agent)
 
+- 2025-09-22: Documented AI v2 scaffolding (state.ai, blackboard, decision system, aiProfiles) and refreshed active context/progress notes.
 - 2025-09-21: Created/verified core memory files (projectbrief.md, productContext.md, activeContext.md, techContext.md, core-*.md)
 - 2025-09-21: Added `systemPatterns.md` to capture architecture guidance and reusable patterns.
 - 2025-09-21: Verified `memory/tasks/_index.md` and added a completed note about memory bank core files.

--- a/memory/tasks/COMPLETED/TASK102-ai-v2-skeleton.md
+++ b/memory/tasks/COMPLETED/TASK102-ai-v2-skeleton.md
@@ -1,0 +1,15 @@
+# TASK102 — AI V2 Skeleton & Blackboard
+
+Status: Completed — 2025-09-22
+
+Summary
+
+- Added `GameState.ai` manager, blackboard scaffolding, and deterministic AI components on ships.
+- Implemented `updateDecisionSystem` in `src/game/systems.ts` with round-robin scheduler, team posture/escort assignment, and utility scoring for `Attack`, `Kite`, `Escort`, `Flee` intents.
+- Introduced `src/game/aiProfiles.ts` and default hull→profile mapping; `spawnShip` seeds commands/traits accordingly.
+- Refactored `prepareShips` to execute AI commands when the v2 flag is enabled while retaining the legacy nearest-enemy path under the flag-off case.
+
+Follow-ups
+
+- Add Vitest coverage for scoring determinism, posture influence, and legacy fallback when the flag is disabled.
+- Extend perf harness to assert AI tick budget under 300-ship load.

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -12,6 +12,8 @@ This index tracks active tasks and their memory files. Use the `tasks/` folder f
 
 - [TASK101](COMPLETED/TASK101-implement-miniplex-zustand.md) Implement Miniplex + Zustand Integration - Completed comprehensive implementation with lifecycle hooks, consumer replacement, and UI store
 
+- [TASK102](COMPLETED/TASK102-ai-v2-skeleton.md) AI V2 Skeleton & Blackboard - Added GameState.ai manager, decision scheduler, behavior profiles, and refactored ship prep to honor the feature flag.
+
 - Align docs and memory with 2025 rewrite - Updated `llms.txt`, `AGENTS.md`, `.github/copilot-instructions.md`, and memory files to match new src layout (R3F + Miniplex + Rapier on main thread).
 
 ## Pending
@@ -19,5 +21,8 @@ This index tracks active tasks and their memory files. Use the `tasks/` folder f
 - Add CI link-check job
 
 - Expand `docs/_index.md` from `llms.txt`
+
+- Author Vitest coverage for AI v2 scoring/escort posture and flag-off regression
+- Extend perf harness to validate AI tick budget at 300 ships
 
 ## Abandoned

--- a/src/game/aiProfiles.ts
+++ b/src/game/aiProfiles.ts
@@ -1,0 +1,85 @@
+import type { BehaviorProfile, ShipHull } from '../types/index.js';
+
+export const AI_PROFILES: Record<string, BehaviorProfile> = {
+  brawler: {
+    desiredRange: [120, 220] as const,
+    orbit: 0,
+    aggression: 0.8,
+    patience: 0.4,
+    dodgeFreq: 0.2,
+    classBias: {
+      fighter: 20,
+      corvette: 10,
+      frigate: 5,
+    },
+    style: 'brawler',
+    gates: {
+      hpRetreatPct: 0.25,
+    },
+  },
+  kiter: {
+    desiredRange: [240, 360] as const,
+    orbit: 160,
+    aggression: 0.5,
+    patience: 0.7,
+    dodgeFreq: 0.6,
+    classBias: {
+      destroyer: 8,
+      carrier: 12,
+    },
+    style: 'kiter',
+    gates: {
+      hpRetreatPct: 0.35,
+    },
+  },
+  escort: {
+    desiredRange: [90, 180] as const,
+    orbit: 60,
+    aggression: 0.6,
+    patience: 0.8,
+    dodgeFreq: 0.3,
+    classBias: {
+      fighter: 15,
+      corvette: 10,
+    },
+    style: 'escort',
+    gates: {
+      hpRetreatPct: 0.3,
+    },
+  },
+  artillery: {
+    desiredRange: [360, 520] as const,
+    orbit: 0,
+    aggression: 0.4,
+    patience: 0.9,
+    dodgeFreq: 0.1,
+    classBias: {
+      carrier: 25,
+      destroyer: 15,
+    },
+    style: 'artillery',
+    gates: {
+      hpRetreatPct: 0.4,
+    },
+  },
+};
+
+const PROFILE_BY_HULL: Record<ShipHull, string> = {
+  fighter: 'escort',
+  corvette: 'brawler',
+  frigate: 'brawler',
+  destroyer: 'artillery',
+  carrier: 'artillery',
+};
+
+export function getDefaultProfileId(hull: ShipHull): string {
+  return PROFILE_BY_HULL[hull] ?? 'brawler';
+}
+
+export function resolveBehaviorProfile(profileId: string): BehaviorProfile {
+  const profile = AI_PROFILES[profileId];
+  if (!profile) {
+    return AI_PROFILES.brawler;
+  }
+  return profile;
+}

--- a/src/game/config.ts
+++ b/src/game/config.ts
@@ -20,6 +20,18 @@ export const FOG_DEFAULTS: readonly [string, number, number] = [
   WORLD_SIZE * 1.2,
 ];
 
+// AI configuration
+export const AI_CONFIG = {
+  v2Enabled: false,
+  tickRateHz: 10,
+  maxPerTick: 60,
+  slices: 5,
+  lod: {
+    activeDistance: 320,
+    idleDistance: 900,
+  },
+};
+
 // AI and movement configuration
 export const WORLD_BOUNDS_MARGIN = 2; // small margin to stay slightly within the cube
 

--- a/src/game/ships.ts
+++ b/src/game/ships.ts
@@ -1,5 +1,6 @@
 import { Quaternion, Vector3 } from 'three';
 import type {
+  AIState,
   GameState,
   ShipBlueprint,
   ShipEntity,
@@ -9,6 +10,7 @@ import type {
   TurretEntity,
 } from '../types/index.js';
 import { registerTurret } from './turretRegistry.js';
+import { getDefaultProfileId } from './aiProfiles.js';
 
 export const SHIP_STATS: Record<ShipHull, ShipStats> = {
   fighter: {
@@ -314,6 +316,7 @@ export function spawnShip(state: GameState, blueprint: ShipBlueprint): ShipEntit
       bulletType: t.bulletType,
       cooldown: t.fireRate * state.rng.next(),
     })),
+    ai: createInitialAIState(state, blueprint.hull),
   };
 
   const registered = state.world.createEntity(entity) as ShipEntity;
@@ -371,4 +374,27 @@ export function spawnShip(state: GameState, blueprint: ShipBlueprint): ShipEntit
     }
   });
   return registered;
+}
+
+function createInitialAIState(state: GameState, hull: ShipHull): AIState {
+  const profileId = getDefaultProfileId(hull);
+  const heading = new Vector3(0, 0, 1);
+  const tickInterval = state.ai.tickInterval || 0.1;
+  return {
+    profileId,
+    intent: 'Attack',
+    nextThinkAt: 0,
+    cooldowns: {
+      dodgeAt: 0,
+      burstAt: 0,
+    },
+    lod: 1,
+    traitSeed: Math.floor(state.rng.next() * 0x7fffffff),
+    command: {
+      heading,
+      thrust: 0,
+      firePrimary: false,
+      ttl: tickInterval,
+    },
+  };
 }

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -12,7 +12,7 @@ import type {
 import { SeededRng } from '../utils/rng.js';
 import { spawnShip } from './ships.js';
 import { unregisterTurret } from './turretRegistry.js';
-import { WORLD_HALF } from './config.js';
+import { AI_CONFIG, WORLD_HALF } from './config.js';
 
 export async function createGameState(): Promise<GameState> {
   await Rapier.init();
@@ -40,6 +40,32 @@ export async function createGameState(): Promise<GameState> {
     rng: new SeededRng(1337),
     paused: false,
     timeScale: 1,
+    ai: {
+      enabled: AI_CONFIG.v2Enabled,
+      tickInterval: 1 / AI_CONFIG.tickRateHz,
+      maxPerTick: AI_CONFIG.maxPerTick,
+      accumulator: 0,
+      tickIndex: 0,
+      cursor: 0,
+      slices: AI_CONFIG.slices,
+      assignments: {
+        escorts: new Map(),
+      },
+    },
+    blackboard: {
+      tickIndex: 0,
+      teamPosture: {
+        blue: 'hold',
+        red: 'hold',
+      },
+      allyCentroid: {
+        blue: new Vector3(),
+        red: new Vector3(),
+      },
+      nearestEnemy: new Map(),
+      threatToVip: new Map(),
+      tmpVectors: [new Vector3(), new Vector3(), new Vector3(), new Vector3()],
+    },
   };
 
   return state;
@@ -198,4 +224,14 @@ export function resetGame(state: GameState): void {
   }
   // Respawn baseline fleets
   spawnInitialFleets(state);
+  state.ai.cursor = 0;
+  state.ai.accumulator = 0;
+  state.ai.tickIndex = 0;
+  state.ai.assignments.escorts.clear();
+  state.blackboard.nearestEnemy.clear();
+  state.blackboard.threatToVip.clear();
+  state.blackboard.teamPosture.blue = 'hold';
+  state.blackboard.teamPosture.red = 'hold';
+  state.blackboard.allyCentroid.blue.set(0, 0, 0);
+  state.blackboard.allyCentroid.red.set(0, 0, 0);
 }

--- a/src/game/systems.ts
+++ b/src/game/systems.ts
@@ -1,23 +1,428 @@
 import { Quaternion, Vector3 } from 'three';
 import type {
+  AIIntent,
+  AIState,
+  BehaviorProfile,
   GameEntity,
   GameState,
   ProjectileEntity,
   ShipEntity,
   ShieldRipple,
+  Team,
+  TeamPosture,
   TurretState,
   TurretEntity,
 } from '../types/index.js';
 import { destroyEntity } from './state.js';
-import { clampToWorld } from './config.js';
+import { AI_CONFIG, clampToWorld } from './config.js';
 import { PROJECTILE_CONFIG, DEFAULT_PROJECTILE_CONFIG } from '../config/projectiles.js';
+import { resolveBehaviorProfile } from './aiProfiles.js';
 
 const FORWARD = new Vector3(0, 0, 1);
 const TEMP_DIR = new Vector3();
 const TEMP_POS = new Vector3();
+interface IntentCandidate {
+  intent: AIIntent;
+  score: number;
+  target?: ShipEntity | null;
+}
+
+function updateDecisionSystem(state: GameState, delta: number): void {
+  const manager = state.ai;
+  if (!manager.enabled) return;
+  if (manager.tickInterval <= 0) return;
+
+  manager.accumulator += delta;
+
+  while (manager.accumulator >= manager.tickInterval) {
+    manager.accumulator -= manager.tickInterval;
+    manager.tickIndex += 1;
+    state.blackboard.tickIndex = manager.tickIndex;
+
+    const ships = state.queries.ships.entities as ShipEntity[];
+    if (ships.length === 0) {
+      manager.cursor = 0;
+      manager.assignments.escorts.clear();
+      state.blackboard.nearestEnemy.clear();
+      state.blackboard.threatToVip.clear();
+      continue;
+    }
+
+    const entityById = new Map<number, ShipEntity>();
+    for (const ship of ships) entityById.set(ship.id, ship);
+
+    refreshBlackboard(state, ships);
+    assignTeamRoles(state, ships);
+    runShipDecisions(state, ships, entityById);
+  }
+}
+
+function refreshBlackboard(state: GameState, ships: ShipEntity[]): void {
+  const { blackboard } = state;
+  const centroid = blackboard.allyCentroid;
+  centroid.blue.set(0, 0, 0);
+  centroid.red.set(0, 0, 0);
+  let blueCount = 0;
+  let redCount = 0;
+  let blueHp = 0;
+  let redHp = 0;
+
+  blackboard.nearestEnemy.clear();
+  blackboard.threatToVip.clear();
+
+  const shipsLength = ships.length;
+  for (let i = 0; i < shipsLength; i += 1) {
+    const ship = ships[i];
+    if (ship.ship.team === 'blue') {
+      centroid.blue.add(ship.transform.position);
+      blueCount += 1;
+      blueHp += ship.ship.hp;
+    } else {
+      centroid.red.add(ship.transform.position);
+      redCount += 1;
+      redHp += ship.ship.hp;
+    }
+  }
+
+  if (blueCount > 0) centroid.blue.multiplyScalar(1 / blueCount);
+  if (redCount > 0) centroid.red.multiplyScalar(1 / redCount);
+
+  for (let i = 0; i < shipsLength; i += 1) {
+    const ship = ships[i];
+    let bestDist = Number.POSITIVE_INFINITY;
+    let bestId: number | undefined;
+    for (let j = 0; j < shipsLength; j += 1) {
+      if (i === j) continue;
+      const other = ships[j];
+      if (other.ship.team === ship.ship.team) continue;
+      const distSq = ship.transform.position.distanceToSquared(other.transform.position);
+      if (distSq < bestDist) {
+        bestDist = distSq;
+        bestId = other.id;
+      }
+    }
+    if (bestId != null) {
+      blackboard.nearestEnemy.set(ship.id, bestId);
+      if (ship.ship.hull === 'carrier' || ship.ship.hull === 'destroyer') {
+        blackboard.threatToVip.set(ship.id, bestId);
+      }
+    }
+  }
+
+  const blueStrength = redHp > 0 ? blueHp / redHp : 1;
+  const redStrength = blueHp > 0 ? redHp / blueHp : 1;
+  blackboard.teamPosture.blue = resolvePosture(blueStrength);
+  blackboard.teamPosture.red = resolvePosture(redStrength);
+}
+
+function resolvePosture(strengthRatio: number): TeamPosture {
+  if (strengthRatio > 1.25) return 'aggressive';
+  if (strengthRatio < 0.8) return 'retreat';
+  return 'hold';
+}
+
+function assignTeamRoles(state: GameState, ships: ShipEntity[]): void {
+  const escorts = state.ai.assignments.escorts;
+  escorts.clear();
+  const teamEscorts: Record<Team, ShipEntity[]> = {
+    blue: [],
+    red: [],
+  };
+  const teamVips: Record<Team, ShipEntity[]> = {
+    blue: [],
+    red: [],
+  };
+
+  for (const ship of ships) {
+    if (ship.ai) {
+      const profile = resolveBehaviorProfile(ship.ai.profileId);
+      if (profile.style === 'escort') {
+        teamEscorts[ship.ship.team].push(ship);
+      }
+    }
+    if (ship.ship.hull === 'carrier' || ship.ship.hull === 'destroyer') {
+      teamVips[ship.ship.team].push(ship);
+    }
+  }
+
+  const compareById = (a: ShipEntity, b: ShipEntity) => a.id - b.id;
+  for (const team of ['blue', 'red'] as const) {
+    const vips = teamVips[team].sort(compareById);
+    const pool = teamEscorts[team].sort(compareById);
+    const vipCount = vips.length;
+    if (vipCount === 0) continue;
+    for (let i = 0; i < pool.length; i += 1) {
+      const vip = vips[i % vipCount];
+      escorts.set(pool[i].id, vip.id);
+    }
+  }
+}
+
+function runShipDecisions(
+  state: GameState,
+  ships: ShipEntity[],
+  entityById: Map<number, ShipEntity>,
+): void {
+  const manager = state.ai;
+  const total = ships.length;
+  if (total === 0) return;
+
+  const slices = Math.max(1, Math.ceil(total / Math.max(1, manager.maxPerTick)));
+  manager.slices = slices;
+  const sliceSize = Math.min(manager.maxPerTick, Math.ceil(total / slices));
+  const startIndex = manager.cursor % total;
+
+  for (let processed = 0; processed < sliceSize && processed < total; processed += 1) {
+    const index = (startIndex + processed) % total;
+    const ship = ships[index];
+    const ai = ship.ai;
+    if (!ai) continue;
+    if (ai.nextThinkAt > manager.tickIndex) continue;
+
+    evaluateShip(state, ship, ai, entityById);
+  }
+
+  manager.cursor = (startIndex + sliceSize) % total;
+}
+
+function evaluateShip(
+  state: GameState,
+  ship: ShipEntity,
+  ai: AIState,
+  entityById: Map<number, ShipEntity>,
+): void {
+  const profile = resolveBehaviorProfile(ai.profileId);
+  const blackboard = state.blackboard;
+  const nearestEnemyId = blackboard.nearestEnemy.get(ship.id);
+  const target = nearestEnemyId != null ? entityById.get(nearestEnemyId) ?? null : null;
+  const escortTargetId = state.ai.assignments.escorts.get(ship.id);
+  const escortTarget = escortTargetId != null ? entityById.get(escortTargetId) ?? null : null;
+
+  const intent = selectIntent(state, ship, ai, profile, target, escortTarget);
+  ai.intent = intent.intent;
+  ai.lastScore = intent.score;
+  ai.targetId = intent.target?.id ?? target?.id;
+
+  const lod = computeLod(ship, target, profile);
+  ai.lod = lod;
+  const spacing = lod === 0 ? 1 : lod === 1 ? 2 : 4;
+  ai.nextThinkAt = state.ai.tickIndex + spacing;
+
+  writeCommand(state, ship, ai, profile, intent.target ?? target, escortTarget);
+}
+
+function selectIntent(
+  state: GameState,
+  ship: ShipEntity,
+  ai: AIState,
+  profile: BehaviorProfile,
+  primaryTarget: ShipEntity | null,
+  escortTarget: ShipEntity | null,
+): IntentCandidate {
+  const candidates: IntentCandidate[] = [];
+  const posture = state.blackboard.teamPosture[ship.ship.team];
+
+  const attackScore = scoreAttackIntent(ship, profile, primaryTarget, posture);
+  candidates.push({ intent: 'Attack', score: attackScore, target: primaryTarget });
+
+  const kiteScore = scoreKiteIntent(ship, profile, primaryTarget, posture);
+  candidates.push({ intent: 'Kite', score: kiteScore, target: primaryTarget });
+
+  if (escortTarget) {
+    const escortScore = scoreEscortIntent(ship, profile, escortTarget, state);
+    candidates.push({ intent: 'Escort', score: escortScore, target: escortTarget });
+  }
+
+  const fleeScore = scoreFleeIntent(ship, profile, primaryTarget, posture);
+  candidates.push({ intent: 'Flee', score: fleeScore, target: primaryTarget });
+
+  candidates.sort((a, b) => b.score - a.score);
+  return tieBreak(ai, state.ai.tickIndex, candidates);
+}
+
+function scoreAttackIntent(
+  ship: ShipEntity,
+  profile: BehaviorProfile,
+  target: ShipEntity | null,
+  posture: TeamPosture,
+): number {
+  if (!target) return 0;
+  const desiredMin = profile.desiredRange[0];
+  const desiredMax = profile.desiredRange[1];
+  const dist = ship.transform.position.distanceTo(target.transform.position);
+  const mid = (desiredMin + desiredMax) * 0.5;
+  const bandError = Math.abs(dist - mid);
+  const hpRatio = ship.ship.hp / Math.max(1, ship.ship.maxHp);
+  let score = 1000 - bandError * 4 + profile.aggression * 120;
+  score += hpRatio * 80;
+  if (posture === 'aggressive') score += 90;
+  if (posture === 'retreat') score -= 120;
+  const bias = profile.classBias[target.ship.hull] ?? 0;
+  score += bias;
+  return Math.floor(score);
+}
+
+function scoreKiteIntent(
+  ship: ShipEntity,
+  profile: BehaviorProfile,
+  target: ShipEntity | null,
+  posture: TeamPosture,
+): number {
+  if (!target) return 100;
+  const dist = ship.transform.position.distanceTo(target.transform.position);
+  const desiredMax = profile.desiredRange[1];
+  const hpRatio = ship.ship.hp / Math.max(1, ship.ship.maxHp);
+  let score = 500 + (dist - desiredMax) * 3;
+  score += (1 - hpRatio) * 200;
+  score += profile.patience * 80;
+  if (posture === 'retreat') score += 120;
+  if (posture === 'aggressive') score -= 60;
+  return Math.floor(score);
+}
+
+function scoreEscortIntent(
+  ship: ShipEntity,
+  profile: BehaviorProfile,
+  escortTarget: ShipEntity,
+  state: GameState,
+): number {
+  const dist = ship.transform.position.distanceTo(escortTarget.transform.position);
+  const threatId = state.blackboard.threatToVip.get(escortTarget.id);
+  const threatWeight = threatId != null ? 180 : 0;
+  const bandError = Math.abs(dist - profile.desiredRange[0]);
+  return Math.floor(700 - bandError * 2 + profile.patience * 90 + threatWeight);
+}
+
+function scoreFleeIntent(
+  ship: ShipEntity,
+  profile: BehaviorProfile,
+  target: ShipEntity | null,
+  posture: TeamPosture,
+): number {
+  const hpRatio = ship.ship.hp / Math.max(1, ship.ship.maxHp);
+  const gate = profile.gates?.hpRetreatPct ?? 0.2;
+  if (hpRatio > gate && posture !== 'retreat') return 150;
+  const threat = target
+    ? ship.transform.position.distanceTo(target.transform.position)
+    : profile.desiredRange[1];
+  return Math.floor(400 + (gate - hpRatio) * 400 + Math.max(0, 300 - threat));
+}
+
+function tieBreak(ai: AIState, tickIndex: number, candidates: IntentCandidate[]): IntentCandidate {
+  if (candidates.length === 0) {
+    return { intent: 'Attack', score: 0 };
+  }
+  const topScore = candidates[0].score;
+  const tied = candidates.filter((c) => c.score === topScore);
+  if (tied.length === 1) return tied[0];
+  const seed = ai.traitSeed ^ (tickIndex * 4099);
+  const idx = Math.abs(hashToInt(seed)) % tied.length;
+  return tied[idx];
+}
+
+function hashToInt(value: number): number {
+  let x = value >>> 0;
+  x ^= x << 13;
+  x ^= x >>> 17;
+  x ^= x << 5;
+  return x | 0;
+}
+
+function computeLod(ship: ShipEntity, target: ShipEntity | null, profile: BehaviorProfile): 0 | 1 | 2 {
+  if (!target) return 2;
+  const dist = ship.transform.position.distanceTo(target.transform.position);
+  const active = Math.max(profile.desiredRange[1], AI_CONFIG.lod.activeDistance);
+  if (dist <= active) return 0;
+  if (dist <= AI_CONFIG.lod.idleDistance) return 1;
+  return 2;
+}
+
+function writeCommand(
+  state: GameState,
+  ship: ShipEntity,
+  ai: AIState,
+  profile: BehaviorProfile,
+  target: ShipEntity | null,
+  escortTarget: ShipEntity | null,
+): void {
+  const command = ai.command;
+  const heading = command.heading;
+  command.ttl = state.ai.tickInterval;
+
+  switch (ai.intent) {
+    case 'Escort':
+      if (escortTarget) {
+        heading.copy(escortTarget.transform.position).sub(ship.transform.position);
+        if (heading.lengthSq() < 1e-5) {
+          heading.set(0, 0, 1).applyQuaternion(ship.transform.rotation);
+        } else {
+          heading.normalize();
+        }
+      } else {
+        heading.set(0, 0, 1).applyQuaternion(ship.transform.rotation);
+      }
+      command.thrust = 0.8;
+      command.firePrimary = false;
+      command.targetId = escortTarget?.id;
+      break;
+    case 'Kite':
+      if (target) {
+        heading
+          .copy(ship.transform.position)
+          .sub(target.transform.position)
+          .normalize();
+      } else {
+        heading.set(0, 0, 1).applyQuaternion(ship.transform.rotation);
+      }
+      command.thrust = 1;
+      command.firePrimary = target != null;
+      command.targetId = target?.id;
+      break;
+    case 'Flee':
+      {
+        const allyCentroid = state.blackboard.allyCentroid[ship.ship.team];
+        heading.copy(allyCentroid).sub(ship.transform.position);
+        if (heading.lengthSq() < 1e-5) {
+          heading.set(0, 0, 1).applyQuaternion(ship.transform.rotation);
+        } else {
+          heading.normalize();
+        }
+        command.thrust = 1;
+        command.firePrimary = false;
+        command.targetId = undefined;
+      }
+      break;
+    case 'Attack':
+    default:
+      if (target) {
+        heading.copy(target.transform.position).sub(ship.transform.position).normalize();
+        const dist = ship.transform.position.distanceTo(target.transform.position);
+        const desiredMin = profile.desiredRange[0];
+        const desiredMax = profile.desiredRange[1];
+        if (dist > desiredMax) {
+          command.thrust = 1;
+        } else if (dist < desiredMin) {
+          heading.negate();
+          command.thrust = 0.6;
+        } else {
+          command.thrust = 0.35;
+        }
+        command.firePrimary = dist <= ship.ship.range;
+        command.targetId = target.id;
+      } else {
+        heading.set(0, 0, 1).applyQuaternion(ship.transform.rotation);
+        command.thrust = 0;
+        command.firePrimary = false;
+        command.targetId = undefined;
+      }
+      break;
+  }
+}
 
 export function updateGame(state: GameState, delta: number): void {
   state.time += delta;
+
+  updateDecisionSystem(state, delta);
 
   prepareShips(state, delta);
   updateTurrets(state, delta);
@@ -31,106 +436,167 @@ export function updateGame(state: GameState, delta: number): void {
 
 function prepareShips(state: GameState, delta: number): void {
   const ships = state.queries.ships.entities as ShipEntity[];
+  const useAIV2 = state.ai.enabled;
 
   for (const ship of ships) {
     ship.ship.cooldown = Math.max(0, ship.ship.cooldown - delta);
-    // Tick turret cooldowns if present
     if (ship.turrets) {
       for (const turret of ship.turrets) turret.cooldown = Math.max(0, turret.cooldown - delta);
     }
-    // Shield regeneration (per-second rate stored on the ship component). Clamped to maxShield.
+
     const regen = ship.ship.shieldRegen ?? 0;
     if (regen > 0 && ship.ship.shield < ship.ship.maxShield) {
       ship.ship.shield = Math.min(ship.ship.maxShield, ship.ship.shield + regen * delta);
     }
-    const target = findNearestEnemy(state, ship);
 
-    if (!target) {
-      ship.rigidBody.setNextKinematicTranslation({
-        x: ship.transform.position.x,
-        y: ship.transform.position.y,
-        z: ship.transform.position.z,
-      });
-      continue;
-    }
+    let preferredTarget: ShipEntity | null = null;
 
-    const direction = TEMP_DIR.subVectors(target.transform.position, ship.transform.position);
-    const distance = direction.length();
-    if (distance > 0.0001) {
-      direction.normalize();
+    if (useAIV2 && ship.ai) {
+      preferredTarget = executeAICommand(state, ship, delta);
     } else {
-      direction.set(0, 0, 1);
+      preferredTarget = runLegacyShipBehavior(state, ship, delta);
     }
 
-    orientTowards(ship, direction);
-
-    if (distance > ship.ship.range * 0.6) {
-      const moveDistance = Math.min(
-        ship.ship.speed * delta,
-        Math.max(distance - ship.ship.range * 0.55, 0),
-      );
-      const nextPosition = TEMP_POS.copy(ship.transform.position).addScaledVector(
-        direction,
-        moveDistance,
-      );
-      clampToWorld(nextPosition);
-
-      ship.rigidBody.setNextKinematicTranslation({
-        x: nextPosition.x,
-        y: nextPosition.y,
-        z: nextPosition.z,
-      });
-    } else {
-      ship.rigidBody.setNextKinematicTranslation({
-        x: ship.transform.position.x,
-        y: ship.transform.position.y,
-        z: ship.transform.position.z,
-      });
+    if (state.queries.turrets.entities.length === 0 && ship.turrets && preferredTarget) {
+      runEmbeddedTurrets(state, ship, preferredTarget);
     }
 
-    if (distance <= ship.ship.range && ship.ship.cooldown <= 0) {
-      // Emit a muzzle flash at the ship nose (local forward offset)
-      (ship.muzzleFlashes ??= []).push({
-        local: new Vector3(0, 0, ship.transform.scale * 1.6),
-        t0: state.time,
-        amp: 1,
-        bulletType: ship.ship.bulletType,
-      });
-      fireProjectile(state, ship, direction);
-      ship.ship.cooldown = ship.ship.fireRate;
-    }
-
-    // Legacy embedded turret logic: only run if there are no turret entities present
-    if (state.queries.turrets.entities.length === 0 && ship.turrets && target) {
-      for (const turret of ship.turrets) {
-        if (turret.cooldown > 0) continue;
-        // Compute turret world-space origin and direction towards target
-        const turretOrigin = getTurretWorldPosition(ship, turret);
-        const toTarget = TEMP_DIR.copy(target.transform.position).sub(turretOrigin);
-        const dist = toTarget.length();
-        if (dist <= turret.range) {
-          if (dist > 1e-5) toTarget.divideScalar(dist);
-          else toTarget.set(0, 0, 1);
-          // Legacy path: we keep ship-level flashes only when no turret entities are used
-          fireProjectile(state, ship, toTarget, {
-            originPosition: turretOrigin,
-            override: {
-              damage: turret.damage,
-              projectileSpeed: turret.projectileSpeed,
-              range: turret.range,
-              bulletType: turret.bulletType,
-            },
-          });
-          turret.cooldown = turret.fireRate;
-        }
-      }
-    }
-
-    // Prune old muzzle flashes (lifetime ~0.25s)
     if (ship.muzzleFlashes && ship.muzzleFlashes.length) {
       const life = 0.25;
       ship.muzzleFlashes = ship.muzzleFlashes.filter((m) => state.time - m.t0 < life);
     }
+  }
+}
+
+function executeAICommand(state: GameState, ship: ShipEntity, delta: number): ShipEntity | null {
+  const ai = ship.ai;
+  if (!ai) return runLegacyShipBehavior(state, ship, delta);
+  const command = ai.command;
+  command.ttl = Math.max(0, command.ttl - delta);
+
+  const heading = command.heading;
+  if (heading.lengthSq() < 1e-5) {
+    heading.set(0, 0, 1).applyQuaternion(ship.transform.rotation);
+  } else {
+    heading.normalize();
+  }
+
+  orientTowards(ship, heading);
+
+  const thrust = Math.min(1, Math.max(0, command.thrust));
+  if (thrust > 0) {
+    const moveDistance = ship.ship.speed * thrust * delta;
+    const nextPosition = TEMP_POS.copy(ship.transform.position).addScaledVector(heading, moveDistance);
+    clampToWorld(nextPosition);
+    ship.rigidBody.setNextKinematicTranslation({ x: nextPosition.x, y: nextPosition.y, z: nextPosition.z });
+  } else {
+    ship.rigidBody.setNextKinematicTranslation({
+      x: ship.transform.position.x,
+      y: ship.transform.position.y,
+      z: ship.transform.position.z,
+    });
+  }
+
+  let target: ShipEntity | null = null;
+  if (command.targetId != null) {
+    target = getShipById(state, command.targetId);
+  } else if (ai.targetId != null) {
+    target = getShipById(state, ai.targetId);
+  }
+
+  if (command.firePrimary && ship.ship.cooldown <= 0) {
+    (ship.muzzleFlashes ??= []).push({
+      local: new Vector3(0, 0, ship.transform.scale * 1.6),
+      t0: state.time,
+      amp: 1,
+      bulletType: ship.ship.bulletType,
+    });
+    const fireDir = TEMP_DIR.copy(heading);
+    if (fireDir.lengthSq() < 1e-5) fireDir.set(0, 0, 1);
+    else fireDir.normalize();
+    fireProjectile(state, ship, fireDir);
+    ship.ship.cooldown = ship.ship.fireRate;
+  }
+
+  return target;
+}
+
+function runLegacyShipBehavior(state: GameState, ship: ShipEntity, delta: number): ShipEntity | null {
+  const target = findNearestEnemy(state, ship);
+
+  if (!target) {
+    ship.rigidBody.setNextKinematicTranslation({
+      x: ship.transform.position.x,
+      y: ship.transform.position.y,
+      z: ship.transform.position.z,
+    });
+    return null;
+  }
+
+  const direction = TEMP_DIR.subVectors(target.transform.position, ship.transform.position);
+  const distance = direction.length();
+  if (distance > 0.0001) {
+    direction.normalize();
+  } else {
+    direction.set(0, 0, 1);
+  }
+
+  orientTowards(ship, direction);
+
+  if (distance > ship.ship.range * 0.6) {
+    const moveDistance = Math.min(
+      ship.ship.speed * delta,
+      Math.max(distance - ship.ship.range * 0.55, 0),
+    );
+    const nextPosition = TEMP_POS.copy(ship.transform.position).addScaledVector(direction, moveDistance);
+    clampToWorld(nextPosition);
+
+    ship.rigidBody.setNextKinematicTranslation({
+      x: nextPosition.x,
+      y: nextPosition.y,
+      z: nextPosition.z,
+    });
+  } else {
+    ship.rigidBody.setNextKinematicTranslation({
+      x: ship.transform.position.x,
+      y: ship.transform.position.y,
+      z: ship.transform.position.z,
+    });
+  }
+
+  if (distance <= ship.ship.range && ship.ship.cooldown <= 0) {
+    (ship.muzzleFlashes ??= []).push({
+      local: new Vector3(0, 0, ship.transform.scale * 1.6),
+      t0: state.time,
+      amp: 1,
+      bulletType: ship.ship.bulletType,
+    });
+    fireProjectile(state, ship, direction);
+    ship.ship.cooldown = ship.ship.fireRate;
+  }
+
+  return target;
+}
+
+function runEmbeddedTurrets(state: GameState, ship: ShipEntity, target: ShipEntity): void {
+  for (const turret of ship.turrets ?? []) {
+    if (turret.cooldown > 0) continue;
+    const turretOrigin = getTurretWorldPosition(ship, turret);
+    const toTarget = TEMP_DIR.copy(target.transform.position).sub(turretOrigin);
+    const dist = toTarget.length();
+    if (dist > turret.range) continue;
+    if (dist > 1e-5) toTarget.divideScalar(dist);
+    else toTarget.set(0, 0, 1);
+    fireProjectile(state, ship, toTarget, {
+      originPosition: turretOrigin,
+      override: {
+        damage: turret.damage,
+        projectileSpeed: turret.projectileSpeed,
+        range: turret.range,
+        bulletType: turret.bulletType,
+      },
+    });
+    turret.cooldown = turret.fireRate;
   }
 }
 
@@ -404,6 +870,15 @@ export function findNearestEnemy(state: GameState, origin: ShipEntity): ShipEnti
   }
 
   return closest;
+}
+
+function getShipById(state: GameState, id: number | undefined): ShipEntity | null {
+  if (id == null) return null;
+  const ships = state.queries.ships.entities as ShipEntity[];
+  for (const ship of ships) {
+    if (ship.id === id) return ship;
+  }
+  return null;
 }
 
 // Compute turret origin in world space from ship transform and local turret offset

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -112,6 +112,81 @@ export interface MuzzleFlash {
   bulletType?: string;
 }
 
+export type EntityId = number;
+
+export type AIIntent =
+  | 'Attack'
+  | 'Kite'
+  | 'Escort'
+  | 'Intercept'
+  | 'Flee'
+  | 'Regroup'
+  | 'Reposition';
+
+export interface AICommand {
+  heading: Vector3;
+  thrust: number;
+  firePrimary: boolean;
+  orbit?: number;
+  targetId?: EntityId;
+  ttl: number;
+}
+
+export interface AIState {
+  profileId: string;
+  intent: AIIntent;
+  nextThinkAt: number;
+  cooldowns: {
+    dodgeAt: number;
+    burstAt: number;
+  };
+  lod: 0 | 1 | 2;
+  traitSeed: number;
+  targetId?: EntityId;
+  lastScore?: number;
+  command: AICommand;
+}
+
+export interface BehaviorProfile {
+  desiredRange: readonly [number, number];
+  orbit: number;
+  aggression: number;
+  patience: number;
+  dodgeFreq: number;
+  classBias: Partial<Record<ShipHull, number>>;
+  style: 'brawler' | 'kiter' | 'artillery' | 'escort';
+  gates?: {
+    ammoMin?: number;
+    hpRetreatPct?: number;
+  };
+}
+
+export type TeamPosture = 'aggressive' | 'hold' | 'retreat';
+
+export interface AIBlackboard {
+  tickIndex: number;
+  teamPosture: Record<Team, TeamPosture>;
+  allyCentroid: Record<Team, Vector3>;
+  nearestEnemy: Map<EntityId, EntityId>;
+  threatToVip: Map<EntityId, EntityId>;
+  tmpVectors: Vector3[];
+}
+
+export interface AITeamAssignments {
+  escorts: Map<EntityId, EntityId>;
+}
+
+export interface AIManagerState {
+  enabled: boolean;
+  tickInterval: number;
+  maxPerTick: number;
+  accumulator: number;
+  tickIndex: number;
+  cursor: number;
+  slices: number;
+  assignments: AITeamAssignments;
+}
+
 export interface GameEntity extends TransformComponent {
   id: number;
   rigidBody: RigidBody;
@@ -119,6 +194,7 @@ export interface GameEntity extends TransformComponent {
   ship?: ShipComponent;
   projectile?: ProjectileComponent;
   turret?: TurretComponent;
+  ai?: AIState;
   /** Unit direction vector used for projectile integration. */
   direction?: Vector3;
   /** Identifier of the model to render for this entity. */
@@ -157,6 +233,8 @@ export interface GameState {
   paused: boolean;
   /** Global time scale multiplier (1 = real-time). */
   timeScale: number;
+  ai: AIManagerState;
+  blackboard: AIBlackboard;
 }
 
 export interface ShipBlueprint {


### PR DESCRIPTION
## Summary
- add AI manager/blackboard types and config plus default behavior profiles
- seed ships with deterministic AI state and run new decision system/command execution behind feature flag
- document AI V2 architecture and update memory bank/task records for the new system

## Testing
- `npm install` *(fails: dependency resolution conflict with @testing-library/react peer requirement)*
- `npx tsc --noEmit` *(fails: missing type definitions because install failed)*
- `npm test` *(fails: vitest missing due to install failure)*

------
https://chatgpt.com/codex/tasks/task_e_68d152c9bd0c832aa1dd847c8253ce60