### PR TITLE
Add movement smoke test and expose ship snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Open the local server at http://localhost:8080 (or the URL printed by the serve 
 
 Developer reference: a short, up-to-date layout of the `src/` directory is available at `spec/src-structure.md` in this repository. It lists the key entry points (`src/main.tsx`, `src/App.tsx`), the `src/game/` pure logic folder, and where to find types and utilities.
 
+### Motion system specification
+
+- Deterministic ship movement, renderer interpolation, and banking behaviour are defined in [`spec/spec-physical-movement.md`](spec/spec-physical-movement.md). The spec details canonical motion stats, the simulation loop expectations, and renderer smoothing guidance for implementers.
+
 ## Project layout
 
 Edit TypeScript sources in `src/` only. Key folders:

--- a/docs/CONFIG_PARAMETERS.md
+++ b/docs/CONFIG_PARAMETERS.md
@@ -37,3 +37,9 @@ These can be tuned directly in `Battlefield.tsx` if the world size is changed.
 ---
 
 Legacy docs that referenced broader configs (AI behavior, separation, etc.) are archived. When reintroducing runtime-tunable parameters, prefer a single config module and add minimal unit tests demonstrating the effect of the parameter on behavior.
+
+## Motion troubleshooting
+
+- **dt spikes / low frame rate** — the motion system integrates at a fixed `simulation.step` (default `1/20`). When render frames stall, interpolation can no longer hide the gap. Enable the `__SAB.tick` helper (or lower the render lerp factors in `src/config/renderer.ts`) to keep the simulation advancing deterministically during diagnostics.
+- **Teleporting ships** — large positional deltas usually mean the teleport threshold is too low or `clampToWorld` is clipping ships every frame. Confirm ship stats use sensible `maxSpeed` and `teleportDistance`, then check for stale AI commands that flip targets every tick.
+- **Target flip-flop** — aggressive AI retargeting can cause oscillating headings that look like jitter. Use the motion spec defaults for angular acceleration/damping and inspect AI scorer thresholds; high aggression with low patience tends to thrash.

--- a/memory/tasks/TASK102-implement-physical-movement.md
+++ b/memory/tasks/TASK102-implement-physical-movement.md
@@ -1,8 +1,8 @@
 # [TASK102] - Implement Physical Movement System
 
-**Status:** In Progress  
+**Status:** In Review  
 **Added:** 2025-09-22  
-**Updated:** 2025-09-22
+**Updated:** 2025-09-24
 
 ## Original Request
 
@@ -33,36 +33,38 @@ This aligns with the project constraints: all state on GameState, deterministic 
 
 ## Progress Tracking
 
-**Overall Status:** In Progress - 50% complete
+**Overall Status:** In Review - 100% complete
 
 ### Subtasks
 
-| ID  | Description                                    | Status      | Updated    | Notes                                        |
+| ID  | Description                                    | Status      | Updated    | Notes |
 |-----|-----------------------------------------------|-------------|------------|----------------------------------------------|
-| 1.1 | Add MotionStats interface to types           | Complete    | 2025-09-22 | Phase 1: Foundation types                    |
-| 1.2 | Update ship stats with motion defaults       | Complete    | 2025-09-22 | Per-class tuning values                     |
-| 1.3 | Add renderer smoothing config                 | Not Started |            | Fallback defaults                            |
-| 1.4 | Add validation helpers                        | Not Started |            | Range validation for stats                   |
-| 2.1 | Create motion system module                   | Complete    | 2025-09-22 | Phase 2: Core physics implementation        |
-| 2.2 | Implement angular PD control                  | Complete    | 2025-09-22 | Shortest arc, rate limits                    |
-| 2.3 | Add continuous angular damping                | Complete    | 2025-09-22 | 1 - exp(-damping * dt)                      |
-| 2.4 | Implement linear acceleration                 | Complete    | 2025-09-22 | Forward thrust with speed caps              |
-| 2.5 | Add lateral acceleration support              | Not Started |            | Optional strafe movement                     |
-| 2.6 | Optimize allocation-free hot paths            | Complete    | 2025-09-22 | Reuse temp vectors/quaternions              |
-| 2.7 | Wire into main simulation loop                | Complete    | 2025-09-22 | Call order after AI, before collision       |
-| 3.1 | Track transform history in Ship.tsx          | Not Started |            | Phase 3: Visual smoothing                   |
-| 2.2 | Implement angular PD control                  | Not Started |            | Shortest arc, rate limits                    |
-| 2.3 | Add continuous angular damping                | Not Started |            | 1 - exp(-damping * dt)                      |
-| 2.4 | Implement linear acceleration                 | Not Started |            | Forward thrust with speed caps              |
-| 2.5 | Add lateral acceleration support              | Not Started |            | Optional strafe movement                     |
-| 2.6 | Optimize allocation-free hot paths            | Not Started |            | Reuse temp vectors/quaternions              |
-| 2.7 | Wire into main simulation loop                | Not Started |            | Call order after AI, before collision       |
-| 3.1 | Track transform history in Ship.tsx          | Not Started |            | Phase 3: Visual smoothing                   |
-| 3.2 | Apply lerp/slerp interpolation                | Not Started |            | No GameState mutations                       |
-| 3.3 | Guard teleport/spawn edge cases               | Not Started |            | Reset prev state to avoid trails            |
-| 4.1 | Compute banking from yaw rate                 | Not Started |            | Phase 4: Visual polish                      |
-| 4.2 | Add smooth banking filter                     | Not Started |            | Low-pass to avoid jitter                    |
-| 4.3 | Hook thruster VFX to throttle                 | Not Started |            | Visual feedback for thrust                   |
+| 1.1 | Add MotionStats interface to types             | Complete    | 2025-09-22 | Phase 1: Foundation types                    |
+| 1.2 | Update ship stats with motion defaults         | Complete    | 2025-09-22 | Per-class tuning values                      |
+| 1.3 | Add renderer smoothing config                  | Complete    | 2025-09-23 | Global defaults for interpolation/banking    |
+| 1.4 | Add validation helpers                         | Complete    | 2025-09-23 | Motion stats range guard                     |
+| 2.1 | Create motion system module                    | Complete    | 2025-09-22 | Phase 2: Core physics implementation         |
+| 2.2 | Implement angular PD control                   | Complete    | 2025-09-22 | Shortest arc, rate limits                    |
+| 2.3 | Add continuous angular damping                 | Complete    | 2025-09-22 | 1 - exp(-damping * dt)                       |
+| 2.4 | Implement linear acceleration                  | Complete    | 2025-09-22 | Forward thrust with speed caps               |
+| 2.5 | Add lateral acceleration support               | Complete    | 2025-09-23 | Command-driven strafe & telemetry            |
+| 2.6 | Optimize allocation-free hot paths             | Complete    | 2025-09-22 | Reuse temp vectors/quaternions               |
+| 2.7 | Wire into main simulation loop                 | Complete    | 2025-09-22 | Call order after AI, before collision        |
+| 3.1 | Track transform history in Ship.tsx            | Complete    | 2025-09-23 | Cached prev/curr transforms for lerp         |
+| 3.2 | Apply lerp/slerp interpolation                 | Complete    | 2025-09-23 | Visual smoothing via fixed-step alpha        |
+| 3.3 | Guard teleport/spawn edge cases                | Complete    | 2025-09-23 | Teleport threshold resets interpolation      |
+| 4.1 | Compute banking from yaw rate                  | Complete    | 2025-09-23 | Uses angular velocity & lateral ratio        |
+| 4.2 | Add smooth banking filter                      | Complete    | 2025-09-23 | Low-pass filtered roll clamp                 |
+| 4.3 | Hook thruster VFX to throttle                  | Complete    | 2025-09-23 | Emissive intensity scales with thrust |
+| 5.1 | Add motion math unit tests                   | Complete    | 2025-09-22 | Covered wrap/damping/accel clamp cases |
+| 5.2 | Add motion system integration scenarios        | Complete    | 2025-09-22 | Forward accel & turn validations        |
+| 5.3 | Add determinism regression coverage            | Complete    | 2025-09-22 | Replayed seeds across multiple ticks    |
+| 6.1 | Author Playwright movement smoke                | Complete    | 2025-09-24 | Samples ship transforms via __SAB API   |
+| 6.2 | Enforce heuristics + role-based locators        | Complete    | 2025-09-24 | Monitors displacement & rotation bounds |
+| 7.1 | Link movement spec from README                  | Complete    | 2025-09-24 | Added dedicated doc section             |
+| 7.2 | Document MotionStats tuning notes               | Complete    | 2025-09-22 | Inline comments on per-hull defaults    |
+| 7.3 | Add troubleshooting notes to docs               | Complete    | 2025-09-24 | Diagnosed dt spikes & teleports         |
+     |
 
 ## Progress Log
 
@@ -75,7 +77,7 @@ This aligns with the project constraints: all state on GameState, deterministic 
 - **PHASE 1 COMPLETE**: Added MotionStats interface with mass, acceleration, damping, and turn rates to types
 - Extended ShipComponent with velocity, angularVelocity, and motion fields
 - Added motion stats defaults for all ship classes (fighter through carrier) with realistic values
-- Updated spawnShip function to initialize new motion fields  
+- Updated spawnShip function to initialize new motion fields
 - Fixed all test files to include required motion fields using createDefaultMotionStats helper
 - All 54 tests pass and TypeScript compiles cleanly
 - Ready to start Phase 2: Deterministic Motion System
@@ -89,3 +91,22 @@ This aligns with the project constraints: all state on GameState, deterministic 
 - All 69 tests pass including 15 new motion system tests
 - System maintains zero per-frame allocations using temp objects
 - Ready to start Phase 3: Renderer Interpolation for visual smoothing
+
+### 2025-09-23
+
+- Added renderer motion defaults (lerp/slerp/bank clamps) and motion validation helpers.
+- Extended ship stats with smoothing/banking overrides and validated all hull presets.
+- Enabled strafe acceleration in the motion system while tracking last lateral accel for visuals.
+- Converted battlefield loop to fixed-step simulation with interpolation alpha tracking.
+- Implemented Ship renderer smoothing (prev/curr sampling, lerp/slerp, teleport guard).
+- Added procedural banking and thruster intensity feedback tied to throttle.
+- Updated tests and helpers to carry the new motion fields.
+
+### 2025-09-24
+
+- Extended `__SAB` diagnostics to expose deterministic ship motion snapshots for automation.
+- Authored Playwright movement heuristic that samples ship transforms over 32 ticks and asserts bounded deltas.
+- Verified role-based locator usage and avoided hard waits by relying on web-first polling.
+- Documented troubleshooting guidance for dt spikes, teleports, and retarget jitter.
+- Linked the motion specification from the README to guide future implementers.
+- Updated task metadata and plan status to reflect completion of phases 6 and 7.

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -4,7 +4,7 @@ This index tracks active tasks and their memory files. Use the `tasks/` folder f
 
 ## In Progress
 
-- [TASK102](TASK102-implement-physical-movement.md) Implement Physical Movement System - Adding deterministic physics-based movement with renderer smoothing and banking
+- [TASK102](TASK102-implement-physical-movement.md) Implement Physical Movement System - Motion, renderer smoothing, tests, and docs complete; awaiting review
 
 ## Completed
 

--- a/plan/plan-physical-movement.md
+++ b/plan/plan-physical-movement.md
@@ -2,9 +2,9 @@
 goal: Implement deterministic physics-based ship movement with renderer smoothing and banking
 version: 1.0
 date_created: 2025-09-22
-last_updated: 2025-09-22
+last_updated: 2025-09-24
 owner: SpaceAutoBattler Maintainers
-status: 'Planned'
+status: 'In Review'
 tags:
 	- feature
 	- architecture
@@ -15,7 +15,7 @@ tags:
 
 # Introduction
 
-![Status: Planned](https://img.shields.io/badge/status-Planned-blue)
+![Status: In Review](https://img.shields.io/badge/status-In%20Review-yellow)
 
 This plan implements deterministic, acceleration-limited ship motion in the simulation (canonical GameState) and adds renderer-side smoothing (lerp/slerp) and procedural banking/visual cues. It is derived from `spec/spec-physical-movement.md` and adheres to project constraints: all state lives in GameState and simulation remains deterministic.
 
@@ -39,13 +39,12 @@ This plan implements deterministic, acceleration-limited ship motion in the simu
 
 - GOAL-001: Add motion stats types and per-class defaults.
 
-| Task     | Description                                                                                                       | Completed | Date |
-| -------- | ----------------------------------------------------------------------------------------------------------------- | --------- | ---- |
-| TASK-001 | Update `src/types/index.ts`: add `MotionStats` interface per spec and extend ship config types to include it.     |           |      |
-| TASK-002 | Update `src/game/ships.ts`: define default `MotionStats` per ship class; units consistent (deg/s, deg/s²).       |           |      |
-| TASK-003 | Add global renderer smoothing defaults in config (fallbacks) in `src/config/renderer.ts` if not present.         |           |      |
-| TASK-004 | Add validation helpers for stats ranges in `src/game/config.ts` or a new `src/game/validation.ts`.               |           |      |
-
+| Task     | Description                                                                                                       | Completed | Date       |
+| -------- | ----------------------------------------------------------------------------------------------------------------- | --------- | ---------- |
+| TASK-001 | Update `src/types/index.ts`: add `MotionStats` interface per spec and extend ship config types to include it.     | ✅        | 2025-09-22 |
+| TASK-002 | Update `src/game/ships.ts`: define default `MotionStats` per ship class; units consistent (deg/s, deg/s²).       | ✅        | 2025-09-22 |
+| TASK-003 | Add global renderer smoothing defaults in config (fallbacks) in `src/config/renderer.ts` if not present.         | ✅        | 2025-09-23 |
+| TASK-004 | Add validation helpers for stats ranges in `src/game/config.ts` or a new `src/game/validation.ts`.               | ✅        | 2025-09-23 |
 Completion criteria:
 
 - Types compile with `npm run typecheck`.
@@ -56,16 +55,15 @@ Completion criteria:
 
 - GOAL-002: Implement deterministic motion system (linear + angular PD control).
 
-| Task     | Description                                                                                                                                        | Completed | Date |
-| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
-| TASK-005 | Create `src/game/systems/motion.ts`: export `updateMotionSystem(state: GameState, dt: number)` implementation.                                     |           |      |
-| TASK-006 | Implement PD-like angular control: shortest-arc error, target angular velocity clamp by `maxTurnRate`, limit change by `angularAcceleration*dt`.   |           |      |
-| TASK-007 | Integrate angular damping with continuous decay `1 - exp(-angularDamping * dt)`; update entity quaternion by angular velocity.                     |           |      |
-| TASK-008 | Implement linear acceleration along forward: clamp by `linearAcceleration`; cap speed by `maxSpeed`; apply continuous linear damping.              |           |      |
-| TASK-009 | Optional lateral accel: apply strafe acceleration limited by `maxLateralAcceleration` if enabled.                                                  |           |      |
-| TASK-010 | Ensure no per-frame allocations; reuse vector/quaternion temporaries; add internal math helpers.                                                   |           |      |
-| TASK-011 | Wire system into main sim loop in `src/game/systems.ts` (call order after AI target selection, before collision/visual sync).                      |           |      |
-
+| Task     | Description                                                                                                      | Completed | Date       |
+| -------- | ---------------------------------------------------------------------------------------------------------------- | --------- | ---------- |
+| TASK-005 | Create `src/game/systems/motion.ts`: export `updateMotionSystem(state: GameState, dt: number)` implementation.    | ✅        | 2025-09-22 |
+| TASK-006 | Implement PD-like angular control: shortest-arc error, target angular velocity clamp by `maxTurnRate`, limit change by `angularAcceleration*dt`. | ✅        | 2025-09-22 |
+| TASK-007 | Integrate angular damping with continuous decay `1 - exp(-angularDamping * dt)`; update entity quaternion by angular velocity.                    | ✅        | 2025-09-22 |
+| TASK-008 | Implement linear acceleration along forward: clamp by `linearAcceleration`; cap speed by `maxSpeed`; apply continuous linear damping.             | ✅        | 2025-09-22 |
+| TASK-009 | Optional lateral accel: apply strafe acceleration limited by `maxLateralAcceleration` if enabled.               | ✅        | 2025-09-23 |
+| TASK-010 | Ensure no per-frame allocations; reuse vector/quaternion temporaries; add internal math helpers.                | ✅        | 2025-09-22 |
+| TASK-011 | Wire system into main sim loop in `src/game/systems.ts` (call order after AI target selection, before collision/visual sync).                     | ✅        | 2025-09-22 |
 Completion criteria:
 
 - Deterministic outputs for identical inputs across runs.
@@ -76,12 +74,11 @@ Completion criteria:
 
 - GOAL-003: Add renderer interpolation (visual-only).
 
-| Task     | Description                                                                                                                                          | Completed | Date |
-| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
-| TASK-012 | In `src/components/Ship.tsx`, track prev and current sim transforms per entity; compute alpha = (renderTime - simTickStart) / simDelta (clamped).   |           |      |
-| TASK-013 | Apply `lerp` to positions and `slerp` to rotations for visual transform; do not mutate GameState.                                                   |           |      |
-| TASK-014 | Guard teleports/spawns: reset prev state to current to avoid interpolation trails.                                                                  |           |      |
-
+| Task     | Description                                                                                                  | Completed | Date       |
+| -------- | ---------------------------------------------------------------------------------------------------------------- | --------- | ---------- |
+| TASK-012 | In `src/components/Ship.tsx`, track prev and current sim transforms per entity; compute alpha = (renderTime - simTickStart) / simDelta (clamped). | ✅        | 2025-09-23 |
+| TASK-013 | Apply `lerp` to positions and `slerp` to rotations for visual transform; do not mutate GameState.             | ✅        | 2025-09-23 |
+| TASK-014 | Guard teleports/spawns: reset prev state to current to avoid interpolation trails.                             | ✅        | 2025-09-23 |
 Completion criteria:
 
 - Visual motion remains smooth at 60 FPS when sim runs at 20 Hz.
@@ -91,12 +88,11 @@ Completion criteria:
 
 - GOAL-004: Add visual banking and VFX coupling.
 
-| Task     | Description                                                                                                                                   | Completed | Date |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
-| TASK-015 | In `src/components/Ship.tsx`, compute roll angle from yaw rate and/or lateral acceleration; clamp by `maxBankDeg`.                            |           |      |
-| TASK-016 | Smooth bank with a small low-pass filter to avoid jitter; apply as extra roll on top of sim rotation.                                        |           |      |
-| TASK-017 | Hook thruster VFX intensity to forward/lateral throttle where available (e.g., material uniforms or particle emitters).                       |           |      |
-
+| Task     | Description                                                                                                  | Completed | Date       |
+| -------- | ---------------------------------------------------------------------------------------------------------------- | --------- | ---------- |
+| TASK-015 | In `src/components/Ship.tsx`, compute roll angle from yaw rate and/or lateral acceleration; clamp by `maxBankDeg`. | ✅        | 2025-09-23 |
+| TASK-016 | Smooth bank with a small low-pass filter to avoid jitter; apply as extra roll on top of sim rotation.            | ✅        | 2025-09-23 |
+| TASK-017 | Hook thruster VFX intensity to forward/lateral throttle where available (e.g., material uniforms or particle emitters). | ✅        | 2025-09-23 |
 Completion criteria:
 
 - Ships visually bank into turns with stable roll.
@@ -106,12 +102,11 @@ Completion criteria:
 
 - GOAL-005: Add unit and integration tests for motion math and system behavior.
 
-| Task     | Description                                                                                                                                       | Completed | Date |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
-| TASK-018 | Create `test/vitest/motion.math.spec.ts`: angle wrap, PD step clamping, damping function, linear accel clamping tests.                            |           |      |
-| TASK-019 | Create `test/vitest/motion.system.spec.ts`: simulate 180° turn and forward accel; verify arrival times and caps within tolerances.                |           |      |
-| TASK-020 | Add determinism test: identical seeds/inputs produce identical state sequences over N ticks.                                                      |           |      |
-
+| Task     | Description                                                                                               | Completed | Date       |
+| -------- | --------------------------------------------------------------------------------------------------------- | --------- | ---------- |
+| TASK-018 | Create `test/vitest/motion.math.spec.ts`: angle wrap, PD step clamping, damping function, linear accel clamping tests. | ✅        | 2025-09-22 |
+| TASK-019 | Create `test/vitest/motion.system.spec.ts`: simulate 180° turn and forward accel; verify arrival times and caps within tolerances.                | ✅        | 2025-09-22 |
+| TASK-020 | Add determinism test: identical seeds/inputs produce identical state sequences over N ticks.               | ✅        | 2025-09-22 |
 Completion criteria:
 
 - Tests pass locally and in CI.
@@ -121,11 +116,10 @@ Completion criteria:
 
 - GOAL-006: Add basic Playwright E2E smoke for visuals.
 
-| Task     | Description                                                                                                                                             | Completed | Date |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
-| TASK-021 | Create `test/playwright/movement.spec.ts`: start scenario, spawn ships, assert angle/position changes are monotonic and not snapping (heuristic).      |           |      |
-| TASK-022 | Use role-based locators and web-first assertions; avoid hard waits; bind minimal time window to observe turning/accel.                                  |           |      |
-
+| Task     | Description                                                                                                   | Completed | Date       |
+| -------- | ----------------------------------------------------------------------------------------------------------------- | --------- | ---------- |
+| TASK-021 | Create `test/playwright/movement.spec.ts`: start scenario, spawn ships, assert angle/position changes are monotonic and not snapping (heuristic). | ✅        | 2025-09-24 |
+| TASK-022 | Use role-based locators and web-first assertions; avoid hard waits; bind minimal time window to observe turning/accel. | ✅        | 2025-09-24 |
 Completion criteria:
 
 - E2E smoke passes consistently on CI and local.
@@ -134,12 +128,11 @@ Completion criteria:
 
 - GOAL-007: Documentation, tuning defaults, and rollout.
 
-| Task     | Description                                                                                                                | Completed | Date |
-| -------- | -------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
-| TASK-023 | Update docs to link `spec/spec-physical-movement.md` from main docs index or README.                                       |           |      |
-| TASK-024 | Tune `src/game/ships.ts` MotionStats per class (Fighter/Corvette/Frigate/etc.); document tuning notes in code comments.    |           |      |
-| TASK-025 | Add troubleshooting notes (dt spikes, teleports, target flip-flop) to `docs/` or README.                                   |           |      |
-
+| Task     | Description                                                                                          | Completed | Date       |
+| -------- | ---------------------------------------------------------------------------------------------------- | --------- | ---------- |
+| TASK-023 | Update docs to link `spec/spec-physical-movement.md` from main docs index or README.                 | ✅        | 2025-09-24 |
+| TASK-024 | Tune `src/game/ships.ts` MotionStats per class (Fighter/Corvette/Frigate/etc.); document tuning notes in code comments. | ✅        | 2025-09-22 |
+| TASK-025 | Add troubleshooting notes (dt spikes, teleports, target flip-flop) to `docs/` or README.             | ✅        | 2025-09-24 |
 Completion criteria:
 
 - Defaults feel good in quick manual test.

--- a/src/components/Battlefield.tsx
+++ b/src/components/Battlefield.tsx
@@ -106,20 +106,43 @@ function BattlefieldSystems(): React.ReactElement {
     state.paused = paused;
     state.timeScale = timeScale;
 
-    if (paused) return;
-    const scaled = Math.min(delta * Math.max(timeScale, 0), 0.1);
+    if (paused) {
+      state.simulation.alpha = 0;
+      return;
+    }
+    const sim = state.simulation;
+    const step = sim.step;
+    const maxSteps = Math.max(1, sim.maxSubSteps);
+    const scaled = Math.max(0, delta * Math.max(timeScale, 0));
 
-    // Keep Rapier step in sync with visual rate; use integration parameters if available
+    if (step <= 0) {
+      updateGame(state, scaled);
+      sim.alpha = 0;
+      return;
+    }
+
+    // Prevent unbounded accumulation by clamping to a few steps worth of time.
+    const maxAccum = step * maxSteps;
+    sim.accumulator = Math.min(sim.accumulator + Math.min(scaled, maxAccum), maxAccum);
+
+    // Keep Rapier step aligned with the fixed time step when available.
     try {
       const params = (state.physicsWorld as any).integrationParameters;
       if (params && typeof params.dt === 'number') {
-        params.dt = scaled;
+        params.dt = step;
       }
     } catch {
       /* ignore */
     }
 
-    updateGame(state, scaled);
+    let steps = 0;
+    while (sim.accumulator >= step && steps < maxSteps) {
+      updateGame(state, step);
+      sim.accumulator -= step;
+      steps += 1;
+    }
+
+    sim.alpha = step > 0 ? Math.min(sim.accumulator / step, 1) : 0;
   });
   return <></>;
 }

--- a/src/components/Ship.tsx
+++ b/src/components/Ship.tsx
@@ -1,11 +1,17 @@
 import { useFrame } from '@react-three/fiber';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type React from 'react';
-import { Box3, Color, Sphere, type Group, type Mesh } from 'three';
+import { Box3, Color, MathUtils, Quaternion, Sphere, Vector3, type Group, type Mesh } from 'three';
 import type { GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { useGLTF } from '@react-three/drei';
 import type { ShipEntity, ShipHull } from '../types/index.js';
-import { getShieldVisuals, HULL_TINT, TEAM_COLORS, SHIELD_RIPPLE_TUNING } from '../config/renderer.js';
+import {
+  getShieldVisuals,
+  HULL_TINT,
+  TEAM_COLORS,
+  SHIELD_RIPPLE_TUNING,
+  resolveRendererMotionConfig,
+} from '../config/renderer.js';
 import { useFrame as useRenderFrame } from '@react-three/fiber';
 import { SHIP_MODEL_PATHS } from '../assets/ships.js';
 import { getMaterial } from '../renderer/materialRegistry.js';
@@ -20,6 +26,37 @@ export function resolveModelPath(modelKey?: string): string {
 
 export function ShipObject({ entity }: { entity: ShipEntity }): React.ReactElement {
   const group = useRef<Group>(null);
+  const state = useOptionalGameState();
+
+  const smoothing = useMemo(() => {
+    const cfg = resolveRendererMotionConfig(entity.ship.motion);
+    return {
+      ...cfg,
+      positionLerp: MathUtils.clamp(cfg.positionLerp, 0, 1),
+      rotationSlerp: MathUtils.clamp(cfg.rotationSlerp, 0, 1),
+      bankLerp: MathUtils.clamp(cfg.bankLerp, 0, 1),
+      teleportThresholdSq: Math.max(1, cfg.teleportDistance * cfg.teleportDistance),
+    };
+  }, [entity.ship.motion]);
+
+  const prevSimPosition = useMemo(() => new Vector3(), []);
+  const prevSimRotation = useMemo(() => new Quaternion(), []);
+  const currSimPosition = useMemo(() => new Vector3(), []);
+  const currSimRotation = useMemo(() => new Quaternion(), []);
+  const visualPosition = useMemo(() => new Vector3(), []);
+  const visualRotation = useMemo(() => new Quaternion(), []);
+  const interpPosition = useMemo(() => new Vector3(), []);
+  const interpRotation = useMemo(() => new Quaternion(), []);
+  const bankQuaternion = useMemo(() => new Quaternion(), []);
+  const forwardAxis = useMemo(() => new Vector3(0, 0, 1), []);
+  const finalRotation = useMemo(() => new Quaternion(), []);
+  const thrusterColorRef = useMemo(() => new Color(), []);
+  const bankValueRef = useRef(0);
+  const lastTickIndexRef = useRef(-1);
+
+  const thrusterMaterialsRef = useRef<
+    Array<{ material: any; baseEmissive?: Color; baseIntensity?: number }>
+  >([]);
 
   // Resolve path via helper to ensure it's always defined.
   const modelPath = resolveModelPath(entity.model);
@@ -29,11 +66,23 @@ export function ShipObject({ entity }: { entity: ShipEntity }): React.ReactEleme
   const gltf = hasValidPath ? (useGLTF(modelPath) as GLTF) : null;
   const scene = useMemo(() => (gltf ? gltf.scene.clone(true) : null), [gltf?.scene]);
 
+  useLayoutEffect(() => {
+    prevSimPosition.copy(entity.transform.position);
+    currSimPosition.copy(entity.transform.position);
+    visualPosition.copy(entity.transform.position);
+    prevSimRotation.copy(entity.transform.rotation);
+    currSimRotation.copy(entity.transform.rotation);
+    visualRotation.copy(entity.transform.rotation);
+    bankValueRef.current = 0;
+    lastTickIndexRef.current = state?.simulation.lastTickIndex ?? 0;
+  }, [entity.id, state?.simulation.lastTickIndex]);
+
   // Register engine-like meshes for selective bloom when available
   const bloomCtx = useBloomContext();
   useEffect(() => {
-    if (!scene || !bloomCtx) return;
+    if (!scene) return;
     const engines: any[] = [];
+    const thrusters: Array<{ material: any; baseEmissive?: Color; baseIntensity?: number }> = [];
     const nameMatch = (s: string | undefined) => {
       if (!s) return false;
       const n = s.toLowerCase();
@@ -41,12 +90,26 @@ export function ShipObject({ entity }: { entity: ShipEntity }): React.ReactEleme
     };
     scene.traverse((obj: any) => {
       if (obj && obj.isMesh) {
-        if (nameMatch(obj.name)) engines.push(obj);
+        const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+        if (nameMatch(obj.name)) {
+          engines.push(obj);
+          mats.forEach((m: any) => {
+            if (!m) return;
+            thrusters.push({
+              material: m,
+              baseEmissive:
+                m.emissive && typeof m.emissive.clone === 'function' ? m.emissive.clone() : undefined,
+              baseIntensity: typeof m.emissiveIntensity === 'number' ? m.emissiveIntensity : undefined,
+            });
+          });
+        }
       }
     });
-    engines.forEach((o) => bloomCtx.register(o));
+    thrusterMaterialsRef.current = thrusters;
+    if (bloomCtx) engines.forEach((o) => bloomCtx.register(o));
     return () => {
-      engines.forEach((o) => bloomCtx.unregister(o));
+      if (bloomCtx) engines.forEach((o) => bloomCtx.unregister(o));
+      thrusterMaterialsRef.current = [];
     };
   }, [scene, bloomCtx]);
 
@@ -95,9 +158,93 @@ export function ShipObject({ entity }: { entity: ShipEntity }): React.ReactEleme
   useFrame(() => {
     const ref = group.current;
     if (!ref) return;
-    ref.position.copy(entity.transform.position);
-    ref.quaternion.copy(entity.transform.rotation);
+
+    const sim = state?.simulation;
+    const tickIndex = sim?.lastTickIndex ?? lastTickIndexRef.current;
+
+    if (tickIndex !== lastTickIndexRef.current) {
+      prevSimPosition.copy(currSimPosition);
+      prevSimRotation.copy(currSimRotation);
+      currSimPosition.copy(entity.transform.position);
+      currSimRotation.copy(entity.transform.rotation);
+      lastTickIndexRef.current = tickIndex;
+
+      const distSq = prevSimPosition.distanceToSquared(currSimPosition);
+      if (distSq > smoothing.teleportThresholdSq) {
+        prevSimPosition.copy(currSimPosition);
+        prevSimRotation.copy(currSimRotation);
+        visualPosition.copy(currSimPosition);
+        visualRotation.copy(currSimRotation);
+      }
+    } else {
+      currSimPosition.copy(entity.transform.position);
+      currSimRotation.copy(entity.transform.rotation);
+    }
+
+    const alpha = sim ? MathUtils.clamp(sim.alpha, 0, 1) : 1;
+    interpPosition.copy(prevSimPosition).lerp(currSimPosition, alpha);
+    if (smoothing.positionLerp <= 0) {
+      visualPosition.copy(interpPosition);
+    } else {
+      visualPosition.lerp(interpPosition, smoothing.positionLerp);
+    }
+
+    interpRotation.copy(prevSimRotation).slerp(currSimRotation, alpha);
+    if (smoothing.rotationSlerp <= 0) {
+      visualRotation.copy(interpRotation);
+    } else {
+      visualRotation.slerp(interpRotation, smoothing.rotationSlerp);
+    }
+
+    const motion = entity.ship.motion;
+    const bankFactor = motion.visualBankFactor ?? smoothing.bankFactor;
+    const maxBankDeg = motion.maxBankDeg ?? smoothing.maxBankDeg;
+    let bankDeg = entity.ship.angularVelocity * bankFactor;
+
+    if (motion.maxLateralAcceleration && motion.maxLateralAcceleration > 0) {
+      const lateralRatio = MathUtils.clamp(
+        entity.ship.lateralAcceleration / motion.maxLateralAcceleration,
+        -1,
+        1,
+      );
+      bankDeg += lateralRatio * maxBankDeg * 0.5;
+    }
+
+    const targetBankRad = MathUtils.degToRad(MathUtils.clamp(bankDeg, -maxBankDeg, maxBankDeg));
+    bankValueRef.current =
+      smoothing.bankLerp <= 0
+        ? targetBankRad
+        : MathUtils.lerp(bankValueRef.current, targetBankRad, smoothing.bankLerp);
+
+    finalRotation.copy(visualRotation);
+    const bankRoll = bankValueRef.current;
+    if (Math.abs(bankRoll) > 1e-4) {
+      bankQuaternion.setFromAxisAngle(forwardAxis, -bankRoll);
+      finalRotation.multiply(bankQuaternion);
+    }
+
+    ref.position.copy(visualPosition);
+    ref.quaternion.copy(finalRotation);
     ref.scale.setScalar(entity.transform.scale);
+
+    const thrusters = thrusterMaterialsRef.current;
+    if (thrusters.length > 0) {
+      const throttle = MathUtils.clamp(entity.ai?.command?.thrust ?? 0, 0, 1);
+      const base = smoothing.thrusterIntensity.base;
+      const range = smoothing.thrusterIntensity.range;
+      for (const entry of thrusters) {
+        const mat = entry.material;
+        if (!mat) continue;
+        const baseIntensity = entry.baseIntensity ?? base;
+        if (typeof mat.emissiveIntensity === 'number') {
+          mat.emissiveIntensity = baseIntensity + range * throttle;
+        }
+        if (entry.baseEmissive && mat.emissive && typeof mat.emissive.copy === 'function') {
+          thrusterColorRef.copy(entry.baseEmissive).multiplyScalar(1 + throttle * 0.6);
+          mat.emissive.copy(thrusterColorRef);
+        }
+      }
+    }
   });
 
   // Ship object no longer renders turret gizmos or flashes; these are handled by TurretObject or projectile visuals.

--- a/src/config/renderer.ts
+++ b/src/config/renderer.ts
@@ -1,4 +1,44 @@
-import type { ShipHull } from '../types/index.js';
+import type { MotionStats, ShipHull } from '../types/index.js';
+
+export interface RendererMotionConfig {
+  /** Linear interpolation factor applied every render frame (0..1). */
+  positionLerp: number;
+  /** Spherical interpolation factor for rotation (0..1). */
+  rotationSlerp: number;
+  /** Low-pass filter factor for banking (0..1). */
+  bankLerp: number;
+  /** Maximum bank angle allowed for visuals (degrees). */
+  maxBankDeg: number;
+  /** Conversion factor from yaw rate (rad/s) to bank degrees. */
+  bankFactor: number;
+  /** Distance threshold (units) that resets interpolation to avoid trails. */
+  teleportDistance: number;
+  /** Thruster emissive intensity range scaled by throttle input. */
+  thrusterIntensity: { base: number; range: number };
+}
+
+export const RENDERER_MOTION_DEFAULTS: RendererMotionConfig = {
+  positionLerp: 0.18,
+  rotationSlerp: 0.25,
+  bankLerp: 0.15,
+  maxBankDeg: 32,
+  bankFactor: 18,
+  teleportDistance: 30,
+  thrusterIntensity: { base: 0.4, range: 1.2 },
+};
+
+export function resolveRendererMotionConfig(motion?: MotionStats): RendererMotionConfig {
+  const smoothing = motion?.smoothing;
+  return {
+    positionLerp: smoothing?.positionLerp ?? RENDERER_MOTION_DEFAULTS.positionLerp,
+    rotationSlerp: smoothing?.rotationSlerp ?? RENDERER_MOTION_DEFAULTS.rotationSlerp,
+    bankLerp: smoothing?.bankLerp ?? RENDERER_MOTION_DEFAULTS.bankLerp,
+    maxBankDeg: motion?.maxBankDeg ?? RENDERER_MOTION_DEFAULTS.maxBankDeg,
+    bankFactor: motion?.visualBankFactor ?? RENDERER_MOTION_DEFAULTS.bankFactor,
+    teleportDistance: smoothing?.teleportDistance ?? RENDERER_MOTION_DEFAULTS.teleportDistance,
+    thrusterIntensity: RENDERER_MOTION_DEFAULTS.thrusterIntensity,
+  };
+}
 
 export type ShieldMaterialKind = 'hex' | 'transmission';
 

--- a/src/game/aiScenarioHarness.ts
+++ b/src/game/aiScenarioHarness.ts
@@ -220,6 +220,7 @@ function createHarnessShip(
       bulletType: spec.bulletType ?? 'bullet:laser',
       velocity: new Vector3(0, 0, 0),
       angularVelocity: 0,
+      lateralAcceleration: 0,
       motion: createDefaultMotionStats(),
     },
     model: hull,

--- a/src/game/context.tsx
+++ b/src/game/context.tsx
@@ -35,6 +35,42 @@ export function GameProvider({ children }: { children: ReactNode }): React.React
                 ships: created.queries.ships.entities.length,
                 projectiles: created.queries.projectiles.entities.length
               }),
+              sampleShipMotion: () => {
+                try {
+                  const ships = created.queries.ships.entities;
+                  return {
+                    tick: created.simulation.lastTickIndex,
+                    time: created.time,
+                    ships: ships.map((entity) => {
+                      const transform = entity.transform;
+                      const ship = entity.ship;
+                      return {
+                        id: entity.id,
+                        team: ship?.team ?? null,
+                        hull: ship?.hull ?? null,
+                        position: transform
+                          ? { x: transform.position.x, y: transform.position.y, z: transform.position.z }
+                          : { x: 0, y: 0, z: 0 },
+                        rotation: transform
+                          ? {
+                              x: transform.rotation.x,
+                              y: transform.rotation.y,
+                              z: transform.rotation.z,
+                              w: transform.rotation.w
+                            }
+                          : { x: 0, y: 0, z: 0, w: 1 },
+                        velocity: ship
+                          ? { x: ship.velocity.x, y: ship.velocity.y, z: ship.velocity.z }
+                          : { x: 0, y: 0, z: 0 },
+                        angularVelocity: ship?.angularVelocity ?? 0,
+                        lateralAcceleration: ship?.lateralAcceleration ?? 0
+                      };
+                    })
+                  };
+                } catch {
+                  return { tick: created.simulation.lastTickIndex, time: created.time, ships: [] };
+                }
+              },
               // Advance the simulation by `steps` frames of `dt` seconds each
               tick: (steps = 1, dt = 1 / 60) => {
                 try {

--- a/src/game/ships.ts
+++ b/src/game/ships.ts
@@ -13,19 +13,31 @@ import type {
 import { registerTurret } from './turretRegistry.js';
 import { getDefaultProfileId } from './aiProfiles.js';
 import { generateTraitsFromSeed } from './aiTraits.js';
+import { validateMotionStats } from './validation.js';
 
 /** Create default motion stats for testing and fallback scenarios. */
 export function createDefaultMotionStats(): MotionStats {
-  return {
+  const stats: MotionStats = {
     mass: 1.0,
     maxSpeed: 10,
+    maxReverseSpeed: 3,
     linearAcceleration: 20,
     linearDamping: 2.0,
     maxTurnRate: Math.PI,
     angularAcceleration: Math.PI * 2,
     angularDamping: 5.0,
     maxLateralAcceleration: 8,
+    visualBankFactor: 16,
+    maxBankDeg: 28,
+    smoothing: {
+      positionLerp: 0.18,
+      rotationSlerp: 0.22,
+      bankLerp: 0.18,
+      teleportDistance: 40,
+    },
   };
+  validateMotionStats(stats);
+  return stats;
 }
 
 export const SHIP_STATS: Record<ShipHull, ShipStats> = {
@@ -46,12 +58,21 @@ export const SHIP_STATS: Record<ShipHull, ShipStats> = {
     motion: {
       mass: 1.0,
       maxSpeed: 14, // units/s - matches legacy speed
+      maxReverseSpeed: 5,
       linearAcceleration: 28, // units/s² - high acceleration for agility
       linearDamping: 3.0, // moderate damping
       maxTurnRate: Math.PI * 1.5, // rad/s - very agile turning (270°/s)
       angularAcceleration: Math.PI * 4, // rad/s² - fast turn acceleration
       angularDamping: 8.0, // high damping for responsive turning
       maxLateralAcceleration: 12, // units/s² - good strafe ability
+      visualBankFactor: 20,
+      maxBankDeg: 35,
+      smoothing: {
+        positionLerp: 0.2,
+        rotationSlerp: 0.28,
+        bankLerp: 0.2,
+        teleportDistance: 35,
+      },
     },
   },
   corvette: {
@@ -69,12 +90,21 @@ export const SHIP_STATS: Record<ShipHull, ShipStats> = {
     motion: {
       mass: 1.5,
       maxSpeed: 11, // units/s - matches legacy speed
+      maxReverseSpeed: 4,
       linearAcceleration: 20, // units/s² - good acceleration
       linearDamping: 2.5, // moderate damping
       maxTurnRate: Math.PI * 1.2, // rad/s - good turning (216°/s)
       angularAcceleration: Math.PI * 3.2, // rad/s² - solid turn acceleration
       angularDamping: 6.5, // good damping
       maxLateralAcceleration: 9, // units/s² - decent strafe
+      visualBankFactor: 16,
+      maxBankDeg: 30,
+      smoothing: {
+        positionLerp: 0.18,
+        rotationSlerp: 0.24,
+        bankLerp: 0.18,
+        teleportDistance: 38,
+      },
     },
     turrets: [
       {
@@ -120,12 +150,21 @@ export const SHIP_STATS: Record<ShipHull, ShipStats> = {
     motion: {
       mass: 2.5,
       maxSpeed: 9, // units/s - matches legacy speed
+      maxReverseSpeed: 3,
       linearAcceleration: 15, // units/s² - moderate acceleration
       linearDamping: 2.0, // less damping for heavier ship
       maxTurnRate: Math.PI * 0.9, // rad/s - slower turning (162°/s)
       angularAcceleration: Math.PI * 2.4, // rad/s² - moderate turn acceleration
       angularDamping: 5.0, // moderate damping
       maxLateralAcceleration: 6, // units/s² - limited strafe
+      visualBankFactor: 12,
+      maxBankDeg: 26,
+      smoothing: {
+        positionLerp: 0.16,
+        rotationSlerp: 0.22,
+        bankLerp: 0.16,
+        teleportDistance: 40,
+      },
     },
     turrets: [
       {
@@ -184,12 +223,21 @@ export const SHIP_STATS: Record<ShipHull, ShipStats> = {
     motion: {
       mass: 4.0,
       maxSpeed: 7, // units/s - matches legacy speed
+      maxReverseSpeed: 2.5,
       linearAcceleration: 10, // units/s² - slower acceleration
       linearDamping: 1.5, // low damping for heavy ship
       maxTurnRate: Math.PI * 0.6, // rad/s - slow turning (108°/s)
       angularAcceleration: Math.PI * 1.8, // rad/s² - slow turn acceleration
       angularDamping: 4.0, // moderate damping
       maxLateralAcceleration: 4, // units/s² - poor strafe
+      visualBankFactor: 10,
+      maxBankDeg: 22,
+      smoothing: {
+        positionLerp: 0.14,
+        rotationSlerp: 0.18,
+        bankLerp: 0.14,
+        teleportDistance: 42,
+      },
     },
     turrets: [
       {
@@ -261,12 +309,21 @@ export const SHIP_STATS: Record<ShipHull, ShipStats> = {
     motion: {
       mass: 6.0,
       maxSpeed: 5, // units/s - matches legacy speed
+      maxReverseSpeed: 2,
       linearAcceleration: 6, // units/s² - very slow acceleration
       linearDamping: 1.0, // minimal damping for massive ship
       maxTurnRate: Math.PI * 0.4, // rad/s - very slow turning (72°/s)
       angularAcceleration: Math.PI * 1.2, // rad/s² - very slow turn acceleration
       angularDamping: 3.0, // low damping
       maxLateralAcceleration: 2, // units/s² - minimal strafe
+      visualBankFactor: 8,
+      maxBankDeg: 18,
+      smoothing: {
+        positionLerp: 0.12,
+        rotationSlerp: 0.16,
+        bankLerp: 0.12,
+        teleportDistance: 45,
+      },
     },
     turrets: [
       {
@@ -325,6 +382,8 @@ export const SHIP_STATS: Record<ShipHull, ShipStats> = {
   },
 };
 
+Object.values(SHIP_STATS).forEach((stats) => validateMotionStats(stats.motion));
+
 // Note: each ShipStats entry may include `bulletType` which is a material/key string
 // used by the renderer to pick a projectile visual (e.g. 'bullet:laser'). When a ship
 // fires, its ShipComponent.bulletType is copied into the ProjectileComponent so the
@@ -372,6 +431,7 @@ export function spawnShip(state: GameState, blueprint: ShipBlueprint): ShipEntit
       bulletType: stats.bulletType,
       velocity: new Vector3(0, 0, 0),
       angularVelocity: 0,
+      lateralAcceleration: 0,
       motion: stats.motion,
     },
     model: blueprint.hull,

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -40,6 +40,15 @@ export async function createGameState(): Promise<GameState> {
     rng: new SeededRng(1337),
     paused: false,
     timeScale: 1,
+    simulation: {
+      step: 1 / 20,
+      accumulator: 0,
+      maxSubSteps: 5,
+      alpha: 0,
+      lastTickIndex: 0,
+      lastTickStart: 0,
+      lastTickDuration: 1 / 20,
+    },
     ai: {
       enabled: AI_CONFIG.v2Enabled,
       tickInterval: 1 / AI_CONFIG.tickRateHz,

--- a/src/game/systems.ts
+++ b/src/game/systems.ts
@@ -744,6 +744,11 @@ function writeCommand(
 }
 
 export function updateGame(state: GameState, delta: number): void {
+  const sim = state.simulation;
+  sim.lastTickStart = state.time;
+  sim.lastTickDuration = delta;
+  sim.lastTickIndex += 1;
+
   state.time += delta;
 
   updateDecisionSystem(state, delta);

--- a/src/game/systems/motion.ts
+++ b/src/game/systems/motion.ts
@@ -1,5 +1,5 @@
 import { Quaternion, Vector3 } from 'three';
-import type { GameState, ShipEntity } from '../../types/index.js';
+import type { AICommand, GameState, ShipEntity } from '../../types/index.js';
 import { clampToWorld } from '../config.js';
 
 // Reusable temporary objects to avoid per-frame allocations
@@ -8,6 +8,7 @@ const TEMP_TARGET_DIR = new Vector3();
 const TEMP_VELOCITY_CHANGE = new Vector3();
 const TEMP_ANGULAR_AXIS = new Vector3();
 const TEMP_ROTATION = new Quaternion();
+const TEMP_RIGHT = new Vector3();
 
 /**
  * Update physics-based motion for all ships using acceleration limits and damping.
@@ -30,7 +31,7 @@ export function updateMotionSystem(state: GameState, dt: number): void {
     updateAngularMotion(ship, command.heading, dt);
     
     // Update linear motion (thrust and velocity)
-    updateLinearMotion(ship, command.thrust, dt);
+    updateLinearMotion(ship, command, dt);
     
     // Apply velocity to position through physics
     applyVelocityToPhysics(ship, dt);
@@ -108,26 +109,47 @@ function updateAngularMotion(ship: ShipEntity, targetHeading: Vector3, dt: numbe
  * Update ship linear velocity based on thrust command.
  * Applies forward acceleration and lateral strafe if supported.
  */
-function updateLinearMotion(ship: ShipEntity, thrust: number, dt: number): void {
+function updateLinearMotion(ship: ShipEntity, command: AICommand, dt: number): void {
   const motion = ship.ship.motion;
   const velocity = ship.ship.velocity;
-  
+
   // Get forward direction for thrust
   TEMP_FORWARD.set(0, 0, 1).applyQuaternion(ship.transform.rotation);
-  
+
   // Apply forward thrust acceleration
-  const forwardAccel = thrust * motion.linearAcceleration;
+  const clampedThrust = Math.max(-1, Math.min(1, command.thrust));
+  const forwardAccel = clampedThrust * motion.linearAcceleration;
   TEMP_VELOCITY_CHANGE.copy(TEMP_FORWARD).multiplyScalar(forwardAccel * dt);
   velocity.add(TEMP_VELOCITY_CHANGE);
-  
-  // TODO: Add lateral acceleration support when AI commands include strafe
-  // const lateralAccel = command.strafe * motion.maxLateralAcceleration;
-  // Apply lateral thrust if supported...
-  
+
+  // Apply lateral acceleration when supported by motion stats and command input.
+  let lateralAccel = 0;
+  const maxStrafe = motion.maxLateralAcceleration ?? 0;
+  if (maxStrafe > 0) {
+    const strafeInput = Math.max(-1, Math.min(1, command.strafe ?? 0));
+    if (Math.abs(strafeInput) > 1e-4) {
+      lateralAccel = strafeInput * maxStrafe;
+      TEMP_RIGHT.set(1, 0, 0).applyQuaternion(ship.transform.rotation);
+      TEMP_VELOCITY_CHANGE.copy(TEMP_RIGHT).multiplyScalar(lateralAccel * dt);
+      velocity.add(TEMP_VELOCITY_CHANGE);
+    }
+  }
+  ship.ship.lateralAcceleration = lateralAccel;
+
   // Apply linear damping (velocity decay)
   const dampingFactor = Math.exp(-motion.linearDamping * dt);
   velocity.multiplyScalar(dampingFactor);
-  
+
+  // Clamp forward component to max speed / reverse speed limits.
+  const forwardSpeed = velocity.dot(TEMP_FORWARD);
+  if (forwardSpeed > motion.maxSpeed) {
+    const excess = forwardSpeed - motion.maxSpeed;
+    velocity.addScaledVector(TEMP_FORWARD, -excess);
+  } else if (motion.maxReverseSpeed != null && forwardSpeed < -motion.maxReverseSpeed) {
+    const deficit = -motion.maxReverseSpeed - forwardSpeed;
+    velocity.addScaledVector(TEMP_FORWARD, deficit);
+  }
+
   // Clamp velocity to maximum speed
   const speed = velocity.length();
   if (speed > motion.maxSpeed) {

--- a/src/game/validation.ts
+++ b/src/game/validation.ts
@@ -1,0 +1,47 @@
+import type { MotionStats } from '../types/index.js';
+
+function assertRange(name: string, value: number, opts: { min?: number; max?: number }): void {
+  if (Number.isNaN(value) || !Number.isFinite(value)) {
+    throw new Error(`${name} must be a finite number.`);
+  }
+  if (opts.min != null && value < opts.min) {
+    throw new Error(`${name} must be ≥ ${opts.min}. Received ${value}.`);
+  }
+  if (opts.max != null && value > opts.max) {
+    throw new Error(`${name} must be ≤ ${opts.max}. Received ${value}.`);
+  }
+}
+
+export function validateMotionStats(stats: MotionStats): void {
+  assertRange('motion.mass', stats.mass, { min: 0 });
+  assertRange('motion.maxSpeed', stats.maxSpeed, { min: 0 });
+  if (stats.maxReverseSpeed != null) {
+    assertRange('motion.maxReverseSpeed', stats.maxReverseSpeed, { min: 0 });
+  }
+  assertRange('motion.linearAcceleration', stats.linearAcceleration, { min: 0 });
+  assertRange('motion.linearDamping', stats.linearDamping, { min: 0 });
+  assertRange('motion.maxTurnRate', stats.maxTurnRate, { min: 0 });
+  assertRange('motion.angularAcceleration', stats.angularAcceleration, { min: 0 });
+  assertRange('motion.angularDamping', stats.angularDamping, { min: 0 });
+  if (stats.maxLateralAcceleration != null) {
+    assertRange('motion.maxLateralAcceleration', stats.maxLateralAcceleration, { min: 0 });
+  }
+  if (stats.maxBankDeg != null) {
+    assertRange('motion.maxBankDeg', stats.maxBankDeg, { min: 0, max: 90 });
+  }
+  if (stats.visualBankFactor != null) {
+    assertRange('motion.visualBankFactor', stats.visualBankFactor, { min: 0 });
+  }
+  if (stats.smoothing?.positionLerp != null) {
+    assertRange('motion.smoothing.positionLerp', stats.smoothing.positionLerp, { min: 0, max: 1 });
+  }
+  if (stats.smoothing?.rotationSlerp != null) {
+    assertRange('motion.smoothing.rotationSlerp', stats.smoothing.rotationSlerp, { min: 0, max: 1 });
+  }
+  if (stats.smoothing?.bankLerp != null) {
+    assertRange('motion.smoothing.bankLerp', stats.smoothing.bankLerp, { min: 0, max: 1 });
+  }
+  if (stats.smoothing?.teleportDistance != null) {
+    assertRange('motion.smoothing.teleportDistance', stats.smoothing.teleportDistance, { min: 0 });
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,8 @@ export interface ShipComponent {
   velocity: Vector3;
   /** Current angular velocity in radians per second around Y axis. */
   angularVelocity: number;
+  /** Most recent lateral acceleration applied in units per second squared. */
+  lateralAcceleration: number;
   /** Motion characteristics for physics-based movement. */
   motion: MotionStats;
 }
@@ -132,6 +134,8 @@ export type AIIntent =
 export interface AICommand {
   heading: Vector3;
   thrust: number;
+  /** Optional lateral strafe input in range [-1, 1]. */
+  strafe?: number;
   firePrimary: boolean;
   orbit?: number;
   targetId?: EntityId;
@@ -257,8 +261,27 @@ export interface GameState {
   paused: boolean;
   /** Global time scale multiplier (1 = real-time). */
   timeScale: number;
+  /** Simulation clock bookkeeping used for fixed-step integration and interpolation. */
+  simulation: SimulationClock;
   ai: AIManagerState;
   blackboard: AIBlackboard;
+}
+
+export interface SimulationClock {
+  /** Fixed step size in seconds for simulation updates. */
+  step: number;
+  /** Accumulated leftover time awaiting the next simulation step. */
+  accumulator: number;
+  /** Safety bound to avoid spiralling when frames are very long. */
+  maxSubSteps: number;
+  /** Normalised interpolation factor (0..1) between last and next sim states. */
+  alpha: number;
+  /** Monotonic tick counter incremented after each simulation step. */
+  lastTickIndex: number;
+  /** Simulation time at the start of the latest completed tick. */
+  lastTickStart: number;
+  /** Duration in seconds of the latest completed tick. */
+  lastTickDuration: number;
 }
 
 export interface ShipBlueprint {
@@ -295,6 +318,8 @@ export interface MotionStats {
   mass: number;
   /** Maximum linear speed in units per second. */
   maxSpeed: number;
+  /** Maximum reverse speed in units per second (defaults to 0 = no reverse). */
+  maxReverseSpeed?: number;
   /** Maximum linear acceleration in units per second squared. */
   linearAcceleration: number;
   /** Linear velocity damping factor (0 = no damping, higher = more damping). */
@@ -307,6 +332,24 @@ export interface MotionStats {
   angularDamping: number;
   /** Optional maximum lateral acceleration for strafe movement (units/s²). */
   maxLateralAcceleration?: number;
+  /** Optional renderer smoothing preferences for this hull. */
+  smoothing?: MotionSmoothingConfig;
+  /** Visual banking sensitivity (degrees per radian/second yaw by default). */
+  visualBankFactor?: number;
+  /** Maximum visual banking angle in degrees. */
+  maxBankDeg?: number;
+}
+
+/** Renderer smoothing configuration applied on top of physics state. */
+export interface MotionSmoothingConfig {
+  /** Linear interpolation factor applied each render frame (0..1). */
+  positionLerp?: number;
+  /** Spherical linear interpolation factor applied each render frame (0..1). */
+  rotationSlerp?: number;
+  /** Low-pass filter factor for visual banking (0..1). */
+  bankLerp?: number;
+  /** Threshold distance that resets interpolation to avoid trails. */
+  teleportDistance?: number;
 }
 
 /** Parameters for a shield ripple kick emitted on impact. */

--- a/test/playwright/movement.spec.ts
+++ b/test/playwright/movement.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test';
+
+interface Vector3Like {
+  x: number;
+  y: number;
+  z: number;
+}
+
+interface QuaternionLike {
+  x: number;
+  y: number;
+  z: number;
+  w: number;
+}
+
+function distance(a: Vector3Like, b: Vector3Like): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+function quaternionAngle(a: QuaternionLike, b: QuaternionLike): number {
+  const dot = Math.abs(a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w);
+  const clamped = Math.min(1, Math.max(-1, dot));
+  return 2 * Math.acos(clamped);
+}
+
+const SIM_STEP = 1 / 20;
+
+test.describe('Ship motion heuristics', () => {
+  test('ships move smoothly without teleporting between ticks', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(msg.text());
+    });
+
+    if ((test as any).info().project.name === 'webkit') {
+      test.skip(true, 'WebKit headless aggressively throttles timers in CI');
+    }
+
+    await page.goto('/spaceautobattler.html?e2e=1');
+
+    await expect(page.getByRole('button', { name: /start/i })).toBeVisible();
+
+    await page.waitForFunction(() => {
+      const api = (window as any).__SAB;
+      return Boolean(api?.getCounts && api?.tick);
+    });
+
+    await page.waitForFunction(() => {
+      const api = (window as any).__SAB;
+      if (!api?.getCounts) return false;
+      const counts = api.getCounts();
+      return counts && counts.ships >= 6;
+    });
+
+    const snapshots = await page.evaluate((step) => {
+      const api = (window as any).__SAB;
+      if (!api?.sampleShipMotion) throw new Error('sampleShipMotion helper missing');
+
+      api.tick?.(15, step);
+      const initial = api.sampleShipMotion();
+      const firstBlue = initial.ships.find((ship: any) => ship.team === 'blue');
+      if (!firstBlue) throw new Error('Unable to locate a blue ship');
+      const targetId = firstBlue.id;
+      const frames: Array<{ position: Vector3Like; rotation: QuaternionLike }> = [
+        { position: firstBlue.position, rotation: firstBlue.rotation }
+      ];
+
+      for (let i = 0; i < 32; i += 1) {
+        api.tick?.(1, step);
+        const snapshot = api.sampleShipMotion();
+        const entry = snapshot.ships.find((ship: any) => ship.id === targetId);
+        if (!entry) throw new Error('Tracked ship disappeared during sampling');
+        frames.push({ position: entry.position, rotation: entry.rotation });
+      }
+
+      return frames;
+    }, SIM_STEP);
+
+    await page.evaluate(() => {
+      const api = (window as any).__SAB;
+      api?.stopAutoTick?.();
+    });
+
+    expect(errors.join('\n')).toEqual('');
+
+    const displacements = snapshots
+      .slice(1)
+      .map((frame, index) => distance(frame.position, snapshots[index].position));
+
+    expect(displacements.length).toBeGreaterThan(0);
+    expect(displacements.some((d) => d > 0.05)).toBeTruthy();
+    expect(Math.max(...displacements)).toBeLessThan(12);
+
+    const rotationSteps = snapshots
+      .slice(1)
+      .map((frame, index) => quaternionAngle(frame.rotation, snapshots[index].rotation));
+
+    expect(rotationSteps.some((angle) => angle > 0.001)).toBeTruthy();
+    expect(Math.max(...rotationSteps)).toBeLessThan(1.2);
+  });
+});

--- a/test/vitest/ai-executor.spec.ts
+++ b/test/vitest/ai-executor.spec.ts
@@ -47,6 +47,15 @@ function createState(): GameState {
     rng: {} as never,
     paused: false,
     timeScale: 1,
+    simulation: {
+      step: 1 / 20,
+      accumulator: 0,
+      maxSubSteps: 5,
+      alpha: 0,
+      lastTickIndex: 0,
+      lastTickStart: 0,
+      lastTickDuration: 1 / 20,
+    },
   } as unknown as GameState;
 }
 
@@ -106,6 +115,7 @@ function createShip(
       bulletType: 'bullet:laser',
       velocity: new Vector3(0, 0, 0),
       angularVelocity: 0,
+      lateralAcceleration: 0,
       motion: createDefaultMotionStats(),
     },
     model: 'fighter',

--- a/test/vitest/ai-intercept.spec.ts
+++ b/test/vitest/ai-intercept.spec.ts
@@ -58,6 +58,15 @@ function createState(): GameState {
     time: 0,
     rng: {} as never,
     paused: false,
+    simulation: {
+      step: 1 / 20,
+      accumulator: 0,
+      maxSubSteps: 5,
+      alpha: 0,
+      lastTickIndex: 0,
+      lastTickStart: 0,
+      lastTickDuration: 1 / 20,
+    },
     timeScale: 1,
   } as unknown as GameState;
 }
@@ -117,6 +126,7 @@ function createShip(options: ShipOptions): ShipEntity {
       bulletType: 'bullet:laser',
       velocity: new Vector3(0, 0, 0),
       angularVelocity: 0,
+      lateralAcceleration: 0,
       motion: createDefaultMotionStats(),
     },
     model: options.hull ?? 'fighter',

--- a/test/vitest/ai-regression.spec.ts
+++ b/test/vitest/ai-regression.spec.ts
@@ -64,6 +64,15 @@ function createState(): GameState {
     rng: {} as never,
     paused: false,
     timeScale: 1,
+    simulation: {
+      step: 1 / 20,
+      accumulator: 0,
+      maxSubSteps: 5,
+      alpha: 0,
+      lastTickIndex: 0,
+      lastTickStart: 0,
+      lastTickDuration: 1 / 20,
+    },
   } as unknown as GameState;
 }
 
@@ -95,6 +104,7 @@ function createShip(id: number, team: 'blue' | 'red', position: Vector3) {
       bulletType: 'bullet:laser',
       velocity: new Vector3(0, 0, 0),
       angularVelocity: 0,
+      lateralAcceleration: 0,
       motion: createDefaultMotionStats(),
     },
     model: 'fighter',

--- a/test/vitest/ai-scorer.spec.ts
+++ b/test/vitest/ai-scorer.spec.ts
@@ -67,6 +67,7 @@ function createShip(options: {
       bulletType: 'bullet:laser',
       velocity: new Vector3(0, 0, 0),
       angularVelocity: 0,
+      lateralAcceleration: 0,
       motion: createDefaultMotionStats(),
     },
     model: options.hull ?? 'fighter',
@@ -104,16 +105,25 @@ function createState(): GameState {
     },
     queries: { ships: { entities: [] }, projectiles: { entities: [] }, turrets: { entities: [] } },
     world: {} as never,
-    physicsWorld: {} as never,
-    eventQueue: {} as never,
-    colliderLookup: new Map(),
-    rapier: {} as never,
-    nextEntityId: 1,
-    time: 0,
-    rng: {} as never,
-    paused: false,
-    timeScale: 1,
-  } as unknown as GameState;
+   physicsWorld: {} as never,
+   eventQueue: {} as never,
+   colliderLookup: new Map(),
+   rapier: {} as never,
+   nextEntityId: 1,
+   time: 0,
+   rng: {} as never,
+   paused: false,
+   timeScale: 1,
+    simulation: {
+      step: 1 / 20,
+      accumulator: 0,
+      maxSubSteps: 5,
+      alpha: 0,
+      lastTickIndex: 0,
+      lastTickStart: 0,
+      lastTickDuration: 1 / 20,
+    },
+ } as unknown as GameState;
 }
 
 describe('AI scorer snapshots', () => {

--- a/test/vitest/motion.system.spec.ts
+++ b/test/vitest/motion.system.spec.ts
@@ -35,6 +35,7 @@ function createMockShip(team: 'red' | 'blue', position: Vector3): ShipEntity {
       bulletType: 'bullet:laser',
       velocity: new Vector3(0, 0, 0),
       angularVelocity: 0,
+      lateralAcceleration: 0,
       motion: createDefaultMotionStats(),
     },
     model: 'fighter',

--- a/test/vitest/projectile-bullettype.spec.ts
+++ b/test/vitest/projectile-bullettype.spec.ts
@@ -62,6 +62,15 @@ function makeStateStub(): GameState {
     rng: { next: () => 0.5 } as any,
     paused: false,
     timeScale: 1,
+    simulation: {
+      step: 1 / 20,
+      accumulator: 0,
+      maxSubSteps: 5,
+      alpha: 0,
+      lastTickIndex: 0,
+      lastTickStart: 0,
+      lastTickDuration: 1 / 20,
+    },
   } as unknown as GameState;
 }
 

--- a/test/vitest/projectile-resolve.spec.ts
+++ b/test/vitest/projectile-resolve.spec.ts
@@ -67,6 +67,15 @@ function makeStateStub(): GameState {
     rng: { next: () => 0.5 } as any,
     paused: false,
     timeScale: 1,
+    simulation: {
+      step: 1 / 20,
+      accumulator: 0,
+      maxSubSteps: 5,
+      alpha: 0,
+      lastTickIndex: 0,
+      lastTickStart: 0,
+      lastTickDuration: 1 / 20,
+    },
   } as GameState;
 }
 
@@ -93,6 +102,7 @@ function makeShip(id: number, team: 'blue'|'red', position: Vector3, hp=10, shie
       bulletType: 'bullet:laser',
       velocity: new Vector3(0, 0, 0),
       angularVelocity: 0,
+      lateralAcceleration: 0,
       motion: createDefaultMotionStats(),
     },
     model: 'fighter' as any,

--- a/test/vitest/shield-regen.spec.ts
+++ b/test/vitest/shield-regen.spec.ts
@@ -62,6 +62,15 @@ function makeStateStub(): GameState {
     rng: { next: () => 0.5 } as any,
     paused: false,
     timeScale: 1,
+    simulation: {
+      step: 1 / 20,
+      accumulator: 0,
+      maxSubSteps: 5,
+      alpha: 0,
+      lastTickIndex: 0,
+      lastTickStart: 0,
+      lastTickDuration: 1 / 20,
+    },
   } as GameState;
 }
 
@@ -89,6 +98,7 @@ function makeShip(id: number, team: 'blue'|'red', position: Vector3, hp=10, shie
       bulletType: 'bullet:laser',
       velocity: new Vector3(0, 0, 0),
       angularVelocity: 0,
+      lateralAcceleration: 0,
       motion: createDefaultMotionStats(),
     },
     model: 'fighter' as any,

--- a/test/vitest/targeting.spec.ts
+++ b/test/vitest/targeting.spec.ts
@@ -29,6 +29,7 @@ function createShip(id: number, team: 'blue' | 'red', position: Vector3): ShipEn
       speed: 5,
       velocity: new Vector3(0, 0, 0),
       angularVelocity: 0,
+      lateralAcceleration: 0,
       motion: createDefaultMotionStats(),
     },
     model: 'fighter',

--- a/test/vitest/turret-destroy.spec.ts
+++ b/test/vitest/turret-destroy.spec.ts
@@ -95,6 +95,15 @@ function makeStateStub(): GameState {
     rng: { next: () => 0.5 } as any,
     paused: false,
     timeScale: 1,
+    simulation: {
+      step: 1 / 20,
+      accumulator: 0,
+      maxSubSteps: 5,
+      alpha: 0,
+      lastTickIndex: 0,
+      lastTickStart: 0,
+      lastTickDuration: 1 / 20,
+    },
   } as GameState;
 }
 
@@ -121,6 +130,7 @@ function makeShipAndTurret(state: GameState): { ship: ShipEntity; turret: Turret
       bulletType: '',
       velocity: new Vector3(0, 0, 0),
       angularVelocity: 0,
+      lateralAcceleration: 0,
       motion: createDefaultMotionStats(),
     },
     model: 'corvette' as any,

--- a/test/vitest/turrets.spec.ts
+++ b/test/vitest/turrets.spec.ts
@@ -106,6 +106,15 @@ function makeStateStub(): GameState {
     rng: { next: () => 0.5 } as any,
     paused: false,
     timeScale: 1,
+    simulation: {
+      step: 1 / 20,
+      accumulator: 0,
+      maxSubSteps: 5,
+      alpha: 0,
+      lastTickIndex: 0,
+      lastTickStart: 0,
+      lastTickDuration: 1 / 20,
+    },
   } as GameState;
 }
 
@@ -140,6 +149,7 @@ function makeShipWithTurret(
       bulletType: 'bullet:heavy', // different from turret to verify override
       velocity: new Vector3(0, 0, 0),
       angularVelocity: 0,
+      lateralAcceleration: 0,
       motion: createDefaultMotionStats(),
     },
     model: 'corvette' as any,
@@ -194,6 +204,7 @@ describe('Turret system', () => {
         bulletType: 'bullet:ion',
         velocity: new Vector3(0, 0, 0),
         angularVelocity: 0,
+        lateralAcceleration: 0,
         motion: createDefaultMotionStats(),
       },
       model: 'fighter' as any,


### PR DESCRIPTION
## Summary
- expose deterministic ship motion snapshots through the E2E helper and document the motion spec/troubleshooting guidance
- add a Playwright movement heuristic that samples ship transforms to guard against teleports
- refresh the motion plan and memory task to reflect completion of phases 6 and 7

## Testing
- npm run typecheck
- npm test
- npm run test:playwright *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bf773b4c832a9f5e006eb49e4ab0