### PR TITLE
feat: add carrier fighter launch system

### DIFF
--- a/src/config/carriers.ts
+++ b/src/config/carriers.ts
@@ -1,0 +1,30 @@
+import type { CarrierLaunchConfig, CarrierLaunchSlot } from '../types/index.js';
+
+/**
+ * Default launch formation offsets relative to the carrier hull. Forward distances are tuned
+ * so fighters appear in front of the hangar without clipping the hull, while lateral offsets
+ * stagger the squad to avoid immediate overlap when several fighters deploy in succession.
+ */
+const DEFAULT_LAUNCH_FORMATION: readonly CarrierLaunchSlot[] = Object.freeze([
+  { forward: 14, lateral: 0, vertical: 0 },
+  { forward: 16, lateral: 4, vertical: 0 },
+  { forward: 16, lateral: -4, vertical: 0 },
+  { forward: 18, lateral: 8, vertical: 1 },
+  { forward: 18, lateral: -8, vertical: 1 },
+  { forward: 20, lateral: 0, vertical: 2 },
+]);
+
+/**
+ * Authoring note: cooldown stays in seconds to align with the simulation delta values. The
+ * jitter radius is intentionally small – just enough to break up visual uniformity without
+ * compromising deterministic behaviour (all randomness flows through the seeded RNG).
+ */
+export const CARRIER_LAUNCH_CONFIG: CarrierLaunchConfig = Object.freeze({
+  maxActive: 6,
+  cooldownSeconds: 1.5,
+  batchSize: 1,
+  formation: DEFAULT_LAUNCH_FORMATION,
+  jitterRadius: 1.25,
+});
+
+export type { CarrierLaunchConfig };

--- a/src/game/ships.ts
+++ b/src/game/ships.ts
@@ -14,6 +14,7 @@ import { registerTurret } from './turretRegistry.js';
 import { getDefaultProfileId } from './aiProfiles.js';
 import { generateTraitsFromSeed } from './aiTraits.js';
 import { validateMotionStats } from './validation.js';
+import { CARRIER_LAUNCH_CONFIG } from '../config/carriers.js';
 
 /** Create default motion stats for testing and fallback scenarios. */
 export function createDefaultMotionStats(): MotionStats {
@@ -429,6 +430,7 @@ export function spawnShip(state: GameState, blueprint: ShipBlueprint): ShipEntit
       range: stats.range,
       speed: stats.speed,
       bulletType: stats.bulletType,
+      parentCarrierId: blueprint.parentCarrierId,
       velocity: new Vector3(0, 0, 0),
       angularVelocity: 0,
       lateralAcceleration: 0,
@@ -447,6 +449,15 @@ export function spawnShip(state: GameState, blueprint: ShipBlueprint): ShipEntit
     })),
     ai: createInitialAIState(state, blueprint.hull),
   };
+
+  if (blueprint.hull === 'carrier') {
+    entity.carrier = {
+      launchCooldownRemaining: 0,
+      activeFighterIds: [],
+      launchIndex: 0,
+      config: CARRIER_LAUNCH_CONFIG,
+    };
+  }
 
   const registered = state.world.createEntity(entity) as ShipEntity;
   state.colliderLookup.set(collider.handle, registered);

--- a/src/game/systems.ts
+++ b/src/game/systems.ts
@@ -20,6 +20,7 @@ import { PROJECTILE_CONFIG, DEFAULT_PROJECTILE_CONFIG } from '../config/projecti
 import { resolveBehaviorProfile } from './aiProfiles.js';
 import { generateTraitsFromSeed } from './aiTraits.js';
 import { updateMotionSystem } from './systems/motion.js';
+import { updateCarrierLaunchSystem } from './systems/carriers.js';
 
 const FORWARD = new Vector3(0, 0, 1);
 const TEMP_DIR = new Vector3();
@@ -754,6 +755,7 @@ export function updateGame(state: GameState, delta: number): void {
   updateDecisionSystem(state, delta);
 
   prepareShips(state, delta);
+  updateCarrierLaunchSystem(state, delta);
   updateTurrets(state, delta);
   
   // Apply physics-based motion after AI decisions but before physics step

--- a/src/game/systems/carriers.ts
+++ b/src/game/systems/carriers.ts
@@ -1,0 +1,132 @@
+import { Quaternion, Vector3 } from 'three';
+import type {
+  CarrierComponent,
+  CarrierLaunchConfig,
+  CarrierLaunchSlot,
+  GameState,
+  ShipEntity,
+} from '../../types/index.js';
+import { spawnShip } from '../ships.js';
+
+const TEMP_FORWARD = new Vector3();
+const TEMP_RIGHT = new Vector3();
+const TEMP_UP = new Vector3();
+const TEMP_OFFSET = new Vector3();
+const TEMP_POS = new Vector3();
+const GLOBAL_FORWARD = new Vector3(0, 0, 1);
+const GLOBAL_UP = new Vector3(0, 1, 0);
+const FALLBACK_SLOT: CarrierLaunchSlot = { forward: 14, lateral: 0, vertical: 0 };
+
+/**
+ * Spawn fighters from carrier hulls while respecting cooldowns and active caps. The system is
+ * deterministic: all positional jitter draws from the seeded RNG carried on the GameState.
+ */
+export function updateCarrierLaunchSystem(state: GameState, dt: number): void {
+  const ships = state.queries.ships.entities as ShipEntity[] | undefined;
+  if (!ships || ships.length === 0) return;
+
+  const aliveById = new Map<number, ShipEntity>();
+  for (const ship of ships) aliveById.set(ship.id, ship);
+
+  for (const ship of ships) {
+    const carrier = ship.carrier;
+    if (!carrier) continue;
+    if (ship.ship.hp <= 0) {
+      carrier.activeFighterIds.length = 0;
+      continue;
+    }
+
+    pruneTrackedFighters(carrier, aliveById, ship.id);
+    carrier.launchCooldownRemaining = Math.max(0, carrier.launchCooldownRemaining - dt);
+
+    const availableSlots = carrier.config.maxActive - carrier.activeFighterIds.length;
+    if (availableSlots <= 0) continue;
+    if (carrier.launchCooldownRemaining > 0) continue;
+
+    const launches = Math.min(carrier.config.batchSize, availableSlots);
+    if (launches <= 0) continue;
+
+    let spawned = 0;
+    for (; spawned < launches; spawned += 1) {
+      const slotIndex = (carrier.launchIndex + spawned) % Math.max(1, carrier.config.formation.length);
+      const slot = carrier.config.formation[slotIndex] ?? FALLBACK_SLOT;
+      const spawnPosition = computeLaunchPosition(ship, carrier.config, slot, state);
+      const heading = computeHeadingYaw(ship.transform.rotation);
+      const fighter = spawnShip(state, {
+        hull: 'fighter',
+        team: ship.ship.team,
+        position: spawnPosition,
+        heading,
+        parentCarrierId: ship.id,
+      });
+      carrier.activeFighterIds.push(fighter.id);
+      aliveById.set(fighter.id, fighter);
+    }
+
+    carrier.launchIndex += spawned;
+    carrier.launchCooldownRemaining = carrier.config.cooldownSeconds;
+  }
+}
+
+function pruneTrackedFighters(
+  carrier: CarrierComponent,
+  aliveById: Map<number, ShipEntity>,
+  carrierId: number,
+): void {
+  if (carrier.activeFighterIds.length === 0) return;
+  let write = 0;
+  for (let i = 0; i < carrier.activeFighterIds.length; i += 1) {
+    const fighterId = carrier.activeFighterIds[i];
+    const fighter = aliveById.get(fighterId);
+    if (!fighter) continue;
+    const component = fighter.ship;
+    if (!component) continue;
+    if (component.parentCarrierId !== carrierId) continue;
+    if (component.hp <= 0) continue;
+    carrier.activeFighterIds[write] = fighterId;
+    write += 1;
+  }
+  carrier.activeFighterIds.length = write;
+}
+
+function computeHeadingYaw(rotation: Quaternion): number {
+  const forward = TEMP_FORWARD.copy(GLOBAL_FORWARD).applyQuaternion(rotation);
+  forward.y = 0;
+  if (forward.lengthSq() < 1e-6) return 0;
+  forward.normalize();
+  return Math.atan2(forward.x, forward.z);
+}
+
+function computeLaunchPosition(
+  carrier: ShipEntity,
+  config: CarrierLaunchConfig,
+  slot: CarrierLaunchSlot,
+  state: GameState,
+): Vector3 {
+  const forward = TEMP_FORWARD.copy(GLOBAL_FORWARD).applyQuaternion(carrier.transform.rotation);
+  if (forward.lengthSq() < 1e-6) forward.copy(GLOBAL_FORWARD);
+  forward.normalize();
+
+  const up = TEMP_UP.copy(GLOBAL_UP).applyQuaternion(carrier.transform.rotation);
+  if (up.lengthSq() < 1e-6) up.copy(GLOBAL_UP);
+  up.normalize();
+
+  const right = TEMP_RIGHT.copy(forward).cross(up);
+  if (right.lengthSq() < 1e-6) {
+    right.copy(GLOBAL_FORWARD).cross(GLOBAL_UP).normalize();
+  } else {
+    right.normalize();
+  }
+
+  const offset = TEMP_OFFSET.copy(forward).multiplyScalar(slot.forward);
+  offset.addScaledVector(right, slot.lateral);
+  if (slot.vertical != null && slot.vertical !== 0) offset.addScaledVector(up, slot.vertical);
+
+  const jitterRadius = config.jitterRadius ?? 0;
+  if (jitterRadius > 0) {
+    const jitter = (state.rng.next() * 2 - 1) * jitterRadius;
+    offset.addScaledVector(right, jitter);
+  }
+
+  return TEMP_POS.copy(carrier.transform.position).add(offset);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,39 @@ export type Team = 'blue' | 'red';
 
 export type ShipHull = 'fighter' | 'corvette' | 'frigate' | 'destroyer' | 'carrier';
 
+export interface CarrierLaunchSlot {
+  /** Forward offset in world units relative to the carrier's origin. */
+  forward: number;
+  /** Lateral offset in world units relative to the carrier's right vector. */
+  lateral: number;
+  /** Optional vertical offset in world units relative to the carrier's up vector. */
+  vertical?: number;
+}
+
+export interface CarrierLaunchConfig {
+  /** Maximum number of alive fighters this carrier may field simultaneously. */
+  maxActive: number;
+  /** Cooldown in seconds between launch attempts. */
+  cooldownSeconds: number;
+  /** Number of fighters released per launch cycle (respecting the active cap). */
+  batchSize: number;
+  /** Launch pattern offsets relative to the carrier. */
+  formation: readonly CarrierLaunchSlot[];
+  /** Optional lateral jitter radius applied when spawning fighters. */
+  jitterRadius?: number;
+}
+
+export interface CarrierComponent {
+  /** Countdown timer before the carrier may launch another batch. */
+  launchCooldownRemaining: number;
+  /** List of fighter entity ids that are currently alive and tracked by the carrier. */
+  activeFighterIds: number[];
+  /** Cursor used to rotate through launch formation slots deterministically. */
+  launchIndex: number;
+  /** Launch behaviour configuration, usually sourced from CARRIER_LAUNCH_CONFIG. */
+  config: CarrierLaunchConfig;
+}
+
 export interface TransformComponent {
   transform: {
     position: Vector3;
@@ -39,6 +72,8 @@ export interface ShipComponent {
   speed: number;
   /** Key for the projectile material/type this ship fires (e.g. 'bullet:laser') */
   bulletType?: string;
+  /** Optional identifier if this ship was launched from a parent carrier. */
+  parentCarrierId?: number;
   /** Current linear velocity in world space (units/s). */
   velocity: Vector3;
   /** Current angular velocity in radians per second around Y axis. */
@@ -222,6 +257,7 @@ export interface GameEntity extends TransformComponent {
   ship?: ShipComponent;
   projectile?: ProjectileComponent;
   turret?: TurretComponent;
+  carrier?: CarrierComponent;
   ai?: AIState;
   /** Unit direction vector used for projectile integration. */
   direction?: Vector3;
@@ -289,6 +325,7 @@ export interface ShipBlueprint {
   team: Team;
   position: Vector3;
   heading: number;
+  parentCarrierId?: number;
 }
 
 export interface ShipStats {

--- a/test/vitest/carrier-launch.spec.ts
+++ b/test/vitest/carrier-launch.spec.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Quaternion, Vector3 } from 'three';
+
+vi.mock('../../src/game/ships.js', () => ({
+  spawnShip: vi.fn(),
+}));
+
+import { updateCarrierLaunchSystem } from '../../src/game/systems/carriers.js';
+import { spawnShip } from '../../src/game/ships.js';
+import { CARRIER_LAUNCH_CONFIG } from '../../src/config/carriers.js';
+import type {
+  CarrierLaunchConfig,
+  GameState,
+  MotionStats,
+  ShipBlueprint,
+  ShipEntity,
+} from '../../src/types/index.js';
+import { SeededRng } from '../../src/utils/rng.js';
+
+const MOTION_STUB: MotionStats = {
+  mass: 1,
+  maxSpeed: 12,
+  maxReverseSpeed: 4,
+  linearAcceleration: 14,
+  linearDamping: 2,
+  maxTurnRate: Math.PI,
+  angularAcceleration: Math.PI,
+  angularDamping: 2,
+  maxLateralAcceleration: 5,
+};
+
+const spawnShipMock = vi.mocked(spawnShip);
+let nextEntityId = 1000;
+
+beforeEach(() => {
+  nextEntityId = 1000;
+  spawnShipMock.mockReset();
+  spawnShipMock.mockImplementation((state: GameState, blueprint: ShipBlueprint) => {
+    const fighter = createFighterEntity(nextEntityId++, blueprint);
+    const ships = state.queries.ships.entities as ShipEntity[];
+    ships.push(fighter);
+    return fighter;
+  });
+});
+
+describe('carrier launch system', () => {
+  it('spawns fighters until reaching the active cap and respects cooldowns', () => {
+    const config = makeConfig({ cooldownSeconds: 0.25, maxActive: 4 });
+    const carrier = createCarrierEntity(1, config);
+    const ships: ShipEntity[] = [carrier];
+    const state = createState(ships);
+
+    updateCarrierLaunchSystem(state, 0);
+    expect(spawnShipMock).toHaveBeenCalledTimes(1);
+    expect(carrier.carrier?.activeFighterIds.length).toBe(1);
+
+    for (let i = 0; i < 10; i += 1) {
+      updateCarrierLaunchSystem(state, config.cooldownSeconds);
+    }
+
+    expect(carrier.carrier?.activeFighterIds.length).toBe(config.maxActive);
+    expect(spawnShipMock).toHaveBeenCalledTimes(config.maxActive);
+  });
+
+  it('launches replacement fighters after tracked fighters are destroyed', () => {
+    const config = makeConfig({ cooldownSeconds: 0.3 });
+    const carrier = createCarrierEntity(2, config);
+    const ships: ShipEntity[] = [carrier];
+    const state = createState(ships);
+
+    updateCarrierLaunchSystem(state, 0);
+    expect(carrier.carrier?.activeFighterIds.length).toBe(1);
+    expect(spawnShipMock).toHaveBeenCalledTimes(1);
+
+    ships.splice(1); // drop the spawned fighter from the live ship list
+
+    updateCarrierLaunchSystem(state, config.cooldownSeconds);
+
+    expect(carrier.carrier?.activeFighterIds.length).toBe(1);
+    expect(spawnShipMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores fighters that were not launched by the carrier', () => {
+    const config = makeConfig({ cooldownSeconds: 0.2, maxActive: 2 });
+    const carrier = createCarrierEntity(3, config);
+    const otherCarrier = createCarrierEntity(4, config);
+    const ships: ShipEntity[] = [carrier];
+    const state = createState(ships);
+
+    updateCarrierLaunchSystem(state, 0);
+    expect(spawnShipMock).toHaveBeenCalledTimes(1);
+
+    const otherFighter = createFighterEntity(9000, {
+      hull: 'fighter',
+      team: otherCarrier.ship.team,
+      position: new Vector3(),
+      heading: 0,
+      parentCarrierId: otherCarrier.id,
+    });
+    carrier.carrier?.activeFighterIds.push(otherFighter.id);
+    ships.push(otherFighter);
+
+    updateCarrierLaunchSystem(state, config.cooldownSeconds);
+
+    expect(spawnShipMock).toHaveBeenCalledTimes(2);
+    expect(carrier.carrier?.activeFighterIds.length).toBe(2);
+    const foreignIds = carrier.carrier?.activeFighterIds.filter((id) => id === otherFighter.id) ?? [];
+    expect(foreignIds.length).toBe(0);
+  });
+});
+
+function makeConfig(overrides: Partial<CarrierLaunchConfig> = {}): CarrierLaunchConfig {
+  return {
+    maxActive: overrides.maxActive ?? CARRIER_LAUNCH_CONFIG.maxActive,
+    cooldownSeconds: overrides.cooldownSeconds ?? CARRIER_LAUNCH_CONFIG.cooldownSeconds,
+    batchSize: overrides.batchSize ?? CARRIER_LAUNCH_CONFIG.batchSize,
+    formation: overrides.formation ?? Array.from(CARRIER_LAUNCH_CONFIG.formation),
+    jitterRadius: overrides.jitterRadius ?? CARRIER_LAUNCH_CONFIG.jitterRadius,
+  };
+}
+
+function createCarrierEntity(id: number, config: CarrierLaunchConfig): ShipEntity {
+  return {
+    id,
+    rigidBody: {} as any,
+    collider: {} as any,
+    transform: {
+      position: new Vector3(0, 0, 0),
+      rotation: new Quaternion(),
+      scale: 1,
+    },
+    ship: {
+      team: 'blue',
+      hull: 'carrier',
+      hp: 400,
+      maxHp: 400,
+      shield: 200,
+      maxShield: 200,
+      shieldRegen: 5,
+      cooldown: 0,
+      fireRate: 2,
+      damage: 0,
+      projectileSpeed: 0,
+      range: 0,
+      speed: 0,
+      bulletType: undefined,
+      velocity: new Vector3(),
+      angularVelocity: 0,
+      lateralAcceleration: 0,
+      motion: MOTION_STUB,
+    },
+    model: 'carrier',
+    carrier: {
+      launchCooldownRemaining: 0,
+      activeFighterIds: [],
+      launchIndex: 0,
+      config,
+    },
+  } as ShipEntity;
+}
+
+function createFighterEntity(id: number, blueprint: ShipBlueprint): ShipEntity {
+  return {
+    id,
+    rigidBody: {} as any,
+    collider: {} as any,
+    transform: {
+      position: blueprint.position.clone(),
+      rotation: new Quaternion().setFromAxisAngle(new Vector3(0, 1, 0), blueprint.heading),
+      scale: 1,
+    },
+    ship: {
+      team: blueprint.team,
+      hull: 'fighter',
+      hp: 40,
+      maxHp: 40,
+      shield: 12,
+      maxShield: 12,
+      shieldRegen: 1,
+      cooldown: 0,
+      fireRate: 1,
+      damage: 4,
+      projectileSpeed: 20,
+      range: 120,
+      speed: 18,
+      bulletType: 'bullet:laser',
+      parentCarrierId: blueprint.parentCarrierId,
+      velocity: new Vector3(),
+      angularVelocity: 0,
+      lateralAcceleration: 0,
+      motion: MOTION_STUB,
+    },
+    model: 'fighter',
+  } as ShipEntity;
+}
+
+function createState(ships: ShipEntity[]): GameState {
+  return {
+    rng: new SeededRng(1234),
+    queries: {
+      ships: { entities: ships },
+    },
+  } as unknown as GameState;
+}


### PR DESCRIPTION
## Summary
- add carrier launch configuration and entity components for tracking spawned fighters
- implement a deterministic carrier launch system and wire it into the main update loop
- cover the behaviour with new Vitest specs for cooldowns, pruning, and foreign fighter handling

## Testing
- npx tsc --noEmit
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d254c97ca8832ab0f3b37f88174dd2