### PR TITLE
Fix shield bubble visibility for regenerating shields

### DIFF
--- a/memory/tasks/TASK225-shield-bubble-visibility.md
+++ b/memory/tasks/TASK225-shield-bubble-visibility.md
@@ -1,0 +1,60 @@
+# [TASK225] - Fix Missing Shield Bubble Rendering
+
+**Status:** Completed
+**Added:** 2025-02-14
+**Updated:** 2025-02-14
+
+## Original Request
+
+Investigate reports that some ships show full shield bars in the HUD but do not render the protective shield bubble. Identify the root cause and implement a fix so visual shields always appear when shield capacity is available. Ensure full test suite passes.
+
+## Thought Process
+
+Initial hypotheses:
+
+1. **Visibility Threshold:** The renderer may hide shields below a minimum fraction (e.g., <1%). If HUD displays full shields but renderer hides them, the threshold logic might misinterpret data (e.g., stale maxShield values, ratios >1). Need to inspect `Ship.tsx` shield rendering code.
+2. **State Sync:** Entities may have `ship.shield` populated but `renderer` uses stale values or clamps differently. Confirm entity data path from simulation to renderer.
+3. **Material Registration:** Ensure shield material is created/registered for affected hulls. Missing material fallback could prevent mesh creation.
+4. **Geometry Scale:** If shield scale is zero or extremely small (due to config defaults), bubble may not be visible. Check per-hull `shieldScale` config.
+5. **Culling/Visibility Flags:** Verify mesh visibility toggles or group filters aren't forcing invisibility.
+
+Plan: reproduce issue via unit/integration tests or inspect game loop to confirm `ship.shield` and `ship.maxShield` values. Adjust renderer logic to ensure shields render whenever `maxShield > 0` and `shield > 0`, with sensible lower bounds and consistent scaling.
+
+## Implementation Plan
+
+- Review `Ship.tsx` shield mesh creation and visibility thresholds.
+- Audit data flow from simulation to renderer to ensure `maxShield` stays positive and shield ratios clamp correctly.
+- Add defensive logic ensuring shield mesh remains visible at reasonable shield fractions (e.g., avoid overly aggressive `minShieldThreshold`).
+- Update related configuration or hooks to maintain consistency (e.g., ensure `shieldScale` defaults applied).
+- Add regression tests covering cases with low but non-zero shields to ensure bubble renders.
+- Validate using unit tests and targeted renderer tests if feasible.
+
+## Progress Tracking
+
+**Overall Status:** Completed - 100%
+
+### Subtasks
+
+| ID  | Description                                       | Status      | Updated    | Notes |
+| --- | ------------------------------------------------- | ----------- | ---------- | ----- |
+| 1.1 | Create task file and update tasks index           | Complete    | 2025-02-14 |       |
+| 1.2 | Investigate renderer shield visibility conditions | Complete    | 2025-02-14 | Identified stale fraction state issue |
+| 1.3 | Implement fix ensuring shields render             | Complete    | 2025-02-14 | Added reactive shield fraction tracking |
+| 1.4 | Add regression tests for shield visibility        | Complete    | 2025-02-14 | Updated heuristics to cover state sync |
+| 1.5 | Run full test suite                               | Complete    | 2025-02-14 | `npx tsc --noEmit`, `npm test`        |
+| 1.6 | Update task progress summary                      | Complete    | 2025-02-14 | Documented resolution                 |
+
+## Progress Log
+
+### 2025-02-14
+
+- Created task file capturing hypotheses and plan for missing shield bubble rendering.
+- Pending: Deep dive into `Ship.tsx` shield visibility logic.
+
+### 2025-02-14 (Later)
+
+- Confirmed root cause: `ShieldBubble` calculated shield fraction only during initial render, so ships that spawned with depleted shields never re-rendered the bubble when shields regenerated.
+- Added reactive shield fraction state with frame-level polling to detect visibility transitions and update material opacity.
+- Updated static analysis specs to assert new state-based logic and guard against regressions.
+- Ran `npx tsc --noEmit` and `npm test` — all 303 tests pass.
+

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -12,6 +12,7 @@ This index tracks active tasks and their memory files. Use the `tasks/` folder f
 ## Completed
 
 - [TASK154](TASK154-rapier-reset-stability.md) — Implemented deferred reset execution to eliminate Rapier console errors during reset button usage (2025-01-27).
+- [TASK225](TASK225-shield-bubble-visibility.md) — Fixed missing shield bubble rendering when shields regenerate after spawning depleted (2025-02-14).
 - [TASK153](TASK153-level-bonus-caps.md) — Enforced level bonus caps so leveling respects progression limits and subsystem repair rates plateau at configured maxima (2025-09-29).
 - [TASK152](TASK152-fix-progression-tests.md) — Hardened Vitest ship stubs with progression defaults; full suite passes (2025-09-29).
 - [TASK145](TASK145-ai-determinism-overhaul.md) — Implement AI determinism-focused scoring, targeting, responsiveness, vertical, and diagnostics improvements per design memo.

--- a/src/components/Ship.tsx
+++ b/src/components/Ship.tsx
@@ -387,6 +387,44 @@ function ShieldBubble({ entity, radius, hullMaterialsRef }: { entity: ShipEntity
   const [rippleTick, setRippleTick] = useState(0);
   const lastCountRef = useRef<number>(0);
   const lastT0Ref = useRef<number>(-Infinity);
+  const minShieldThreshold = 0.01; // 1% shields minimum to show bubble
+
+  const computeShieldFraction = () => {
+    const maxShield = entity.ship.maxShield;
+    const shield = entity.ship.shield;
+    if (!Number.isFinite(maxShield) || maxShield <= 0) {
+      return 0;
+    }
+    if (!Number.isFinite(shield)) {
+      return 0;
+    }
+    const ratio = shield / Math.max(1, maxShield);
+    if (!Number.isFinite(ratio)) {
+      return 0;
+    }
+    return MathUtils.clamp(ratio, 0, 1);
+  };
+
+  const [shieldFraction, setShieldFraction] = useState(() => computeShieldFraction());
+  const shieldFractionRef = useRef(shieldFraction);
+  const shieldVisibleRef = useRef(shieldFraction >= minShieldThreshold);
+
+  useEffect(() => {
+    shieldFractionRef.current = shieldFraction;
+    shieldVisibleRef.current = shieldFraction >= minShieldThreshold;
+  }, [shieldFraction, minShieldThreshold]);
+
+  useRenderFrame(() => {
+    const nextFraction = computeShieldFraction();
+    const nextVisible = nextFraction >= minShieldThreshold;
+    const prevFraction = shieldFractionRef.current;
+    const fractionDelta = Math.abs(nextFraction - prevFraction);
+    if (fractionDelta > 0.0005 || nextVisible !== shieldVisibleRef.current) {
+      shieldFractionRef.current = nextFraction;
+      shieldVisibleRef.current = nextVisible;
+      setShieldFraction(nextFraction);
+    }
+  });
 
   useRenderFrame((_, dt) => {
     const mesh = meshRef.current;
@@ -455,12 +493,10 @@ function ShieldBubble({ entity, radius, hullMaterialsRef }: { entity: ShipEntity
     }
   });
   // Derived props for material
-  const s = entity.ship.shield / Math.max(1, entity.ship.maxShield);
-  const opacity = Math.max(0, Math.min(1, s));
-  
+  const opacity = Math.max(0, Math.min(1, shieldFraction));
+
   // Only render shield bubble if shields are above minimal threshold
-  const minShieldThreshold = 0.01; // 1% shields minimum to show bubble
-  if (s < minShieldThreshold) {
+  if (shieldFraction < minShieldThreshold) {
     return <></>;
   }
   

--- a/test/vitest/shield-bubble-visibility.spec.tsx
+++ b/test/vitest/shield-bubble-visibility.spec.tsx
@@ -8,14 +8,18 @@ describe('ShieldBubble visibility behavior (static analysis)', () => {
 
   it('includes conditional rendering for low shield levels', () => {
     const txt = fs.readFileSync(shipFilePath, 'utf-8');
-    
+
     // Ensure shield bubble is conditionally rendered when shields are very low
     expect(txt).toContain('minShieldThreshold');
-    expect(txt).toContain('if (s < minShieldThreshold)');
+    expect(txt).toContain('if (shieldFraction < minShieldThreshold)');
     expect(txt).toContain('return <></>;');
-    
+
     // Ensure the threshold is set to a reasonable value (like 0.01 for 1%)
     expect(txt).toMatch(/minShieldThreshold\s*=\s*0\.0[1-9]/);
+
+    // Ensure we track shield changes reactively via state updates
+    expect(txt).toContain('const [shieldFraction, setShieldFraction] = useState');
+    expect(txt).toContain('setShieldFraction(nextFraction);');
   });
 
   it('fixes HULL_TINT threshold to prevent always-on hull tinting', () => {
@@ -29,10 +33,11 @@ describe('ShieldBubble visibility behavior (static analysis)', () => {
 
   it('ensures shield bubble logic prevents rendering at exactly 0 shields', () => {
     const txt = fs.readFileSync(shipFilePath, 'utf-8');
-    
+
     // Test the mathematical logic: shield fraction calculation should work correctly
-    expect(txt).toContain('entity.ship.shield / Math.max(1, entity.ship.maxShield)');
-    
+    expect(txt).toContain('const ratio = shield / Math.max(1, maxShield);');
+    expect(txt).toContain('MathUtils.clamp(ratio, 0, 1)');
+
     // With 0 shields and any maxShield > 0, the fraction should be 0
     // And 0 < minShieldThreshold (0.01) should be true, causing early return
     const shieldFraction = 0 / Math.max(1, 100);  // 0

--- a/test/vitest/shield-bubble.spec.ts
+++ b/test/vitest/shield-bubble.spec.ts
@@ -21,7 +21,7 @@ describe('ShieldBubble anchoring (static check)', () => {
     const txt = fs.readFileSync(file, 'utf-8');
     // Ensure shield bubble is conditionally rendered when shields are very low
     expect(txt).toContain('minShieldThreshold');
-    expect(txt).toContain('if (s < minShieldThreshold)');
+    expect(txt).toContain('if (shieldFraction < minShieldThreshold)');
     expect(txt).toContain('return <></>;');
   });
 });


### PR DESCRIPTION
## Summary
- keep ShieldBubble mesh reactive by sampling shield fraction each frame and updating visibility when shields return
- extend shield bubble static-analysis specs to assert the new state-driven logic
- document TASK225 in the memory bank and move it to the completed list

## Testing
- npx tsc --noEmit
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68da8687ebd0832ab7c5e9d0c979665f