### PR TITLE
feat: finalize ship visual smoothing system

### DIFF
--- a/memory/designs/design-visual-smoothing.md
+++ b/memory/designs/design-visual-smoothing.md
@@ -81,6 +81,13 @@ Testing and validation
 - Phase 2: Add local visualRef group and migrate visuals to child offsets (ship view change). Add bob/sway minimal implementation and UX clamps.
 - Phase 3: Add critically-damped bank spring option and performance/QA signoff. Switch default to spring if preferred after playtests.
 
+## Implementation Notes (2025-10-05)
+- Introduced a reusable `kToAlpha(k, dt)` helper and refactored `useShipInterpolation` to maintain both world and local visual offsets, updating an inverse root quaternion for reuse and applying smoothing only when the global/per-hull toggles allow it.
+- Critically damped bank spring now preserves a velocity term and resets on teleports, with Vitest coverage ensuring no overshoot across varied deltas.
+- Bob offsets are computed in local space with amplitude scaled by speed and yaw, fading when speed <5% of max and clamped to per-hull `maxAmp`. The child `visualRef` receives only the local offset, keeping the physics root deterministic.
+- Added optional Rapier CCD enablement via `motion.visual.enableCcd` to mitigate tunnelling for fast hulls without impacting ships that keep the flag disabled.
+- Test suite validates dt convergence, toggle bypass behaviour, bob amplitude clamping, and bank spring stability to guard regressions.
+
 ---
 
 Design recorded by: GitHub Copilot

--- a/memory/tasks/TASK244-visual-smoothing.md
+++ b/memory/tasks/TASK244-visual-smoothing.md
@@ -1,8 +1,8 @@
 # [TASK244] - Visual smoothing and local visual offsets for ships
 
-**Status:** In Progress  
-**Added:** 2025-10-04  
-**Updated:** 2025-10-04
+**Status:** Completed
+**Added:** 2025-10-04
+**Updated:** 2025-10-05
 
 ## Original Request
 Improve ship visuals by adding robust dt-independent smoothing, per-hull overrides, and an advanced critically-damped bank spring. Provide a global toggle and task out implementation & tests.
@@ -39,21 +39,21 @@ Improve ship visuals by adding robust dt-independent smoothing, per-hull overrid
 | ID | Description | Status | Updated | Notes |
 |---:|-------------|--------|---------|-------|
 | 244.1 | Add `motion.visual` config + global toggle | completed | 2025-10-04 | default mapping for existing ships; shipStats updated; renderer global toggle added |
-| 244.2 | Add `visualRef` child group to `ShipView` | not-started |  | minimal UI change |
+| 244.2 | Add `visualRef` child group to `ShipView` | completed | 2025-10-05 | renderer now writes local offsets to nested group |
 | 244.3 | Convert smoothing to dt-independent exponential filters | completed | 2025-10-04 | `useShipInterpolation` updated to accept `dt`, compute alpha from k, and apply per-frame exponential smoothing; bank spring implemented (critically-damped) |
-| 244.4 | Implement critically-damped bank spring (config) | not-started |  | unit tested |
-| 244.5 | Implement bob/sway minimal safe defaults | not-started |  | clamped & faded amplitude |
-| 244.6 | Wire CCD toggle into Rapier entity creation | not-started |  | opt-in only |
-| 244.7 | Add unit & integration tests | not-started |  | vitest + integration checks |
-| 244.8 | Update docs & memory bank | not-started |  | link design + task files |
+| 244.4 | Implement critically-damped bank spring (config) | completed | 2025-10-05 | analytic spring wired with dt-aware integration |
+| 244.5 | Implement bob/sway minimal safe defaults | completed | 2025-10-05 | local-space bob scaled by speed/turn with amplitude clamp |
+| 244.6 | Wire CCD toggle into Rapier entity creation | completed | 2025-10-05 | main hull body respects `visual.enableCcd` |
+| 244.7 | Add unit & integration tests | completed | 2025-10-05 | Vitest coverage for alpha conversion, spring, bob, toggle |
+| 244.8 | Update docs & memory bank | completed | 2025-10-05 | design + task record refreshed |
 
 ## Acceptance Criteria
-- [ ] Global toggle disables all per-ship smoothing, visuals match physics-interp directly.
-- [ ] Per-hull config overrides exist and default mapping preserves legacy feel where requested.
-- [ ] Smoothing is dt-independent: tests demonstrate consistent behavior across variable dt sequences.
-- [ ] Bank spring option prevents oscillation across dt changes and has bounded settle time.
-- [ ] Bob/sway is local-space, amplitude scales with speed/turn, and clamps/fades correctly.
-- [ ] Collisions/raycasts remain governed by physics pose (visual changes do not influence gameplay correctness).
+- [x] Global toggle disables all per-ship smoothing, visuals match physics-interp directly.
+- [x] Per-hull config overrides exist and default mapping preserves legacy feel where requested.
+- [x] Smoothing is dt-independent: tests demonstrate consistent behavior across variable dt sequences.
+- [x] Bank spring option prevents oscillation across dt changes and has bounded settle time.
+- [x] Bob/sway is local-space, amplitude scales with speed/turn, and clamps/fades correctly.
+- [x] Collisions/raycasts remain governed by physics pose (visual changes do not influence gameplay correctness).
 
 ## Progress Log
 ### 2025-10-04
@@ -69,11 +69,21 @@ Improve ship visuals by adding robust dt-independent smoothing, per-hull overrid
 - Completed subtask `244.3`: converted runtime smoothing to dt-based semantics and wired visual child group.
   - Key files changed:
     - `src/hooks/useShipInterpolation.ts` — pass `dt` from `useFrame`, compute smoothing alpha via `1 - exp(-k*dt)`, added legacy mapping fallback, implemented critically-damped bank spring and bank velocity state.
-    - `src/components/Ship.tsx` — create `rootGroup` and `visualGroup` refs and pass both into the interpolation hook.
+  - `src/components/Ship.tsx` — create `rootGroup` and `visualGroup` refs and pass both into the interpolation hook.
     - `src/components/ship/ShipView.tsx` — render nested `visualRef` group so visual offsets are local to the child.
   - Changed default bank behavior to use critically-damped spring by default for all hulls.
 
-Next: run vitest unit tests for filter convergence and add unit coverage for spring step (subtask `244.7`).
+### 2025-10-05
+
+- Finalized dt-aware smoothing system and local offsets:
+  - Refactored `useShipInterpolation` with exponential `kToAlpha` helper, local offset tracking, critically damped bank spring, and bob amplitude clamps with speed fade.
+  - Added bob offset computation in local space and ensured global toggle/per-hull disable short-circuit smoothing.
+  - Ensured teleports reset smoothing/bank state and that visual offsets are applied on the child group only.
+- Physics integration:
+  - Enabled optional Rapier CCD when `motion.visual.enableCcd` is true during ship spawn.
+- Testing & docs:
+  - Authored Vitest coverage for alpha conversion, dt convergence, critically damped spring stability, global toggle bypass, and bob amplitude limits.
+  - Updated memory/design documentation for rollout and task completion.
 
 ---
 

--- a/src/game/ships.ts
+++ b/src/game/ships.ts
@@ -41,6 +41,9 @@ export function spawnShip(state: GameState, blueprint: ShipBlueprint): ShipEntit
   const bodyDesc = state.rapier.RigidBodyDesc.kinematicPositionBased()
     .setTranslation(position.x, position.y, position.z)
     .setRotation({ x: rotation.x, y: rotation.y, z: rotation.z, w: rotation.w });
+  if (stats.motion.visual?.enableCcd) {
+    bodyDesc.setCcdEnabled(true);
+  }
   const body = state.physicsWorld.createRigidBody(bodyDesc);
 
   const colliderDesc = state.rapier.ColliderDesc.capsule(0.8, 0.6)

--- a/src/hooks/useShipInterpolation.ts
+++ b/src/hooks/useShipInterpolation.ts
@@ -14,8 +14,12 @@ export interface InterpolationState {
   currSimRotation: Quaternion;
   visualPosition: Vector3;
   visualRotation: Quaternion;
+  targetVisualPosition: Vector3;
+  visualLocalOffset: Vector3;
+  visualOffset: Vector3;
   interpPosition: Vector3;
   interpRotation: Quaternion;
+  inverseInterpRotation: Quaternion;
   bankQuaternion: Quaternion;
   forwardAxis: Vector3;
   finalRotation: Quaternion;
@@ -31,6 +35,13 @@ export interface SmoothingConfig {
   bankFactor: number;
   maxBankDeg: number;
   thrusterIntensity: { base: number; range: number };
+}
+
+export function kToAlpha(k: number | undefined, dt: number): number {
+  if (!k || k <= 0 || dt <= 0) {
+    return 0;
+  }
+  return 1 - Math.exp(-k * dt);
 }
 
 export function useShipInterpolation(
@@ -62,9 +73,13 @@ export function useShipInterpolation(
   const currSimPosition = useMemo(() => new Vector3(), []);
   const currSimRotation = useMemo(() => new Quaternion(), []);
   const visualPosition = useMemo(() => new Vector3(), []);
+  const targetVisualPosition = useMemo(() => new Vector3(), []);
+  const visualLocalOffset = useMemo(() => new Vector3(), []);
+  const visualOffset = useMemo(() => new Vector3(), []);
   const visualRotation = useMemo(() => new Quaternion(), []);
   const interpPosition = useMemo(() => new Vector3(), []);
   const interpRotation = useMemo(() => new Quaternion(), []);
+  const inverseInterpRotation = useMemo(() => new Quaternion(), []);
   const bankQuaternion = useMemo(() => new Quaternion(), []);
   const forwardAxis = useMemo(() => new Vector3(0, 0, 1), []);
   const finalRotation = useMemo(() => new Quaternion(), []);
@@ -79,23 +94,42 @@ export function useShipInterpolation(
     currSimRotation,
     visualPosition,
     visualRotation,
+    targetVisualPosition,
+    visualLocalOffset,
+    visualOffset,
     interpPosition,
     interpRotation,
+    inverseInterpRotation,
     bankQuaternion,
     forwardAxis,
     finalRotation,
     get bankValue() { return bankValueRef.current; },
     get lastTickIndex() { return lastTickIndexRef.current; },
   }), [
-    prevSimPosition, prevSimRotation, currSimPosition, currSimRotation,
-    visualPosition, visualRotation, interpPosition, interpRotation,
-    bankQuaternion, forwardAxis, finalRotation
+    prevSimPosition,
+    prevSimRotation,
+    currSimPosition,
+    currSimRotation,
+    visualPosition,
+    visualRotation,
+    targetVisualPosition,
+    visualLocalOffset,
+    visualOffset,
+    interpPosition,
+    interpRotation,
+    inverseInterpRotation,
+    bankQuaternion,
+    forwardAxis,
+    finalRotation,
   ]);
 
   useLayoutEffect(() => {
     prevSimPosition.copy(entity.transform.position);
     currSimPosition.copy(entity.transform.position);
     visualPosition.copy(entity.transform.position);
+    targetVisualPosition.copy(entity.transform.position);
+    visualLocalOffset.set(0, 0, 0);
+    visualOffset.set(0, 0, 0);
     prevSimRotation.copy(entity.transform.rotation);
     currSimRotation.copy(entity.transform.rotation);
     visualRotation.copy(entity.transform.rotation);
@@ -110,6 +144,7 @@ export function useShipInterpolation(
     const sim = state?.simulation;
     const tickIndex = sim?.lastTickIndex ?? lastTickIndexRef.current;
     const alpha = sim ? MathUtils.clamp(sim.alpha, 0, 1) : 1;
+    const time = state?.time ?? 0;
 
     updateInterpolation(
       entity,
@@ -117,6 +152,7 @@ export function useShipInterpolation(
       smoothing,
       alpha,
       dt,
+      time,
       tickIndex,
       bankValueRef,
       bankVelocityRef,
@@ -130,11 +166,12 @@ export function useShipInterpolation(
 
     if (visualRef && visualRef.current) {
       const vRef = visualRef.current;
-      // local position = visualWorld - interpWorld
-      vRef.position.copy(interpolationState.visualPosition).sub(interpolationState.interpPosition);
+      // local position provided as visual offset (local-space)
+      vRef.position.copy(interpolationState.visualOffset);
       // local rotation = interpRotation^-1 * finalRotation
-      const inv = interpolationState.interpRotation.clone().invert();
-      vRef.quaternion.copy(inv).multiply(interpolationState.finalRotation);
+      vRef.quaternion
+        .copy(interpolationState.inverseInterpRotation)
+        .multiply(interpolationState.finalRotation);
       vRef.scale.setScalar(entity.transform.scale);
     }
   });
@@ -151,6 +188,7 @@ export function updateInterpolation(
   smoothing: SmoothingConfig,
   alpha: number,
   dt: number,
+  time: number,
   tickIndex: number,
   bankValueRef: MutableRefObject<number>,
   bankVelocityRef: MutableRefObject<number>,
@@ -169,6 +207,11 @@ export function updateInterpolation(
       state.prevSimRotation.copy(state.currSimRotation);
       state.visualPosition.copy(state.currSimPosition);
       state.visualRotation.copy(state.currSimRotation);
+      state.targetVisualPosition.copy(state.currSimPosition);
+      state.visualLocalOffset.set(0, 0, 0);
+      state.visualOffset.set(0, 0, 0);
+      bankValueRef.current = 0;
+      bankVelocityRef.current = 0;
     }
   } else {
     state.currSimPosition.copy(entity.transform.position);
@@ -176,85 +219,148 @@ export function updateInterpolation(
   }
 
   state.interpPosition.copy(state.prevSimPosition).lerp(state.currSimPosition, alpha);
-  // Position smoothing: prefer new time-constant semantics when available
+  state.interpRotation.copy(state.prevSimRotation).slerp(state.currSimRotation, alpha);
+  state.inverseInterpRotation.copy(state.interpRotation).invert();
+
   const motion = entity.ship.motion;
   const visualCfg: MotionVisualConfig | undefined = motion.visual;
   const globalVisualEnabled = RENDERER_VISUAL_CONFIG.enableShipVisualSmoothing;
+  const visualEnabled = visualCfg?.enabled ?? true;
+  const smoothingEnabled = globalVisualEnabled && visualEnabled;
 
-  const frameDt = RENDERER_VISUAL_CONFIG.legacyFrameDt;
-  const legacyToAlpha = (f: number) => (f <= 0 ? 0 : 1 - Math.pow(1 - f, dt / frameDt));
+  state.targetVisualPosition.copy(state.interpPosition);
+  state.visualLocalOffset.set(0, 0, 0);
 
-  let posAlpha = 1;
-  if (globalVisualEnabled && visualCfg?.position?.k != null && visualCfg.position.k > 0) {
-    posAlpha = 1 - Math.exp(-visualCfg.position.k * Math.max(dt, 1e-6));
-  } else {
-    posAlpha = legacyToAlpha(smoothing.positionLerp);
-  }
+  const frameDt = Math.max(RENDERER_VISUAL_CONFIG.legacyFrameDt, 1e-6);
+  const legacyToAlpha = (f: number) => {
+    if (f <= 0 || dt <= 0) return 0;
+    const clamped = MathUtils.clamp(f, 0, 1);
+    return 1 - Math.pow(1 - clamped, Math.max(dt, 1e-6) / frameDt);
+  };
 
-  if (posAlpha <= 0) {
-    state.visualPosition.copy(state.interpPosition);
-  } else {
-    state.visualPosition.lerp(state.interpPosition, posAlpha);
-  }
+  if (smoothingEnabled && visualCfg?.bob && visualCfg.bob.enabled !== false) {
+    const baseAmp = Math.max(0, visualCfg.bob.baseAmp ?? 0);
+    const freq = Math.max(0, visualCfg.bob.freq ?? 0);
+    const speedScale = Math.max(0, visualCfg.bob.speedScale ?? 0);
+    const maxAmp = Math.max(baseAmp, visualCfg.bob.maxAmp ?? baseAmp);
+    if (freq > 0 && (baseAmp > 0 || speedScale > 0)) {
+      const speed = entity.ship.velocity.length();
+      const maxSpeed = Math.max(motion.maxSpeed, 1e-3);
+      const speedRatio = MathUtils.clamp(speed / maxSpeed, 0, 1);
+      const turnRate = Math.abs(entity.ship.angularVelocity.y);
+      const maxTurn = Math.max(motion.maxTurnRate, 1e-3);
+      const turnRatio = MathUtils.clamp(turnRate / maxTurn, 0, 1);
 
-  state.interpRotation.copy(state.prevSimRotation).slerp(state.currSimRotation, alpha);
-  let rotAlpha = 1;
-  if (globalVisualEnabled && visualCfg?.rotation?.k != null && visualCfg.rotation.k > 0) {
-    rotAlpha = 1 - Math.exp(-visualCfg.rotation.k * Math.max(dt, 1e-6));
-  } else {
-    rotAlpha = legacyToAlpha(smoothing.rotationSlerp);
-  }
+      let amplitude = baseAmp + baseAmp * speedScale * speedRatio;
+      amplitude += baseAmp * 0.25 * turnRatio;
+      amplitude = Math.min(maxAmp, amplitude);
 
-  if (rotAlpha <= 0) {
-    state.visualRotation.copy(state.interpRotation);
-  } else {
-    state.visualRotation.slerp(state.interpRotation, rotAlpha);
-  }
+      if (speedRatio < 0.05) {
+        const fade = speedRatio / 0.05;
+        amplitude *= MathUtils.clamp(fade, 0, 1);
+      }
 
-  const bankFactor = motion.visualBankFactor ?? smoothing.bankFactor;
-  const maxBankDeg = motion.maxBankDeg ?? smoothing.maxBankDeg;
-  const yawRate = entity.ship.angularVelocity.y;
-  let bankDeg = yawRate * bankFactor;
-
-  if (motion.maxLateralAcceleration && motion.maxLateralAcceleration > 0) {
-    const lateralRatio = MathUtils.clamp(
-      entity.ship.lateralAcceleration / motion.maxLateralAcceleration,
-      -1,
-      1,
-    );
-    bankDeg += lateralRatio * maxBankDeg * 0.5;
-  }
-
-  const targetBankRad = MathUtils.degToRad(MathUtils.clamp(bankDeg, -maxBankDeg, maxBankDeg));
-  // Bank smoothing: support critically-damped spring when configured
-  if (globalVisualEnabled && visualCfg?.bank?.useCriticallyDamped && visualCfg.bank.k && visualCfg.bank.k > 0) {
-    const omega = visualCfg.bank.k; // natural frequency
-    // Critically-damped exact integration
-    const x = bankValueRef.current;
-    const v = bankVelocityRef.current;
-    const C1 = x - targetBankRad;
-    const C2 = v + omega * C1;
-    const expTerm = Math.exp(-omega * dt);
-    const xNew = targetBankRad + (C1 + C2 * dt) * expTerm;
-    const vNew = (C2 - omega * (C1 + C2 * dt)) * expTerm;
-    bankValueRef.current = xNew;
-    bankVelocityRef.current = vNew;
-  } else {
-    // fallback to time-constant or legacy per-frame smoothing
-    let bankAlpha = 1;
-    if (globalVisualEnabled && visualCfg?.bank?.k != null && visualCfg.bank.k > 0) {
-      bankAlpha = 1 - Math.exp(-visualCfg.bank.k * Math.max(dt, 1e-6));
-    } else {
-      bankAlpha = legacyToAlpha(smoothing.bankLerp);
+      if (amplitude > 1e-5) {
+        const phase = time * freq * Math.PI * 2;
+        const vertical = Math.sin(phase) * amplitude;
+        const lateralSign = Math.sign(entity.ship.angularVelocity.y);
+        const lateral = Math.cos(phase * 0.5) * amplitude * 0.35 * lateralSign * turnRatio;
+        state.visualLocalOffset.set(lateral, vertical, 0);
+        state.visualOffset.copy(state.visualLocalOffset).applyQuaternion(state.interpRotation);
+        state.targetVisualPosition.add(state.visualOffset);
+        state.visualOffset.set(0, 0, 0);
+      }
     }
-    bankValueRef.current = bankAlpha <= 0 ? targetBankRad : MathUtils.lerp(bankValueRef.current, targetBankRad, bankAlpha);
   }
+
+  if (!smoothingEnabled) {
+    state.visualPosition.copy(state.targetVisualPosition);
+    state.visualRotation.copy(state.interpRotation);
+    bankValueRef.current = 0;
+    bankVelocityRef.current = 0;
+  } else {
+    const posAlpha =
+      visualCfg?.position?.k != null && visualCfg.position.k > 0
+        ? kToAlpha(visualCfg.position.k, dt)
+        : legacyToAlpha(smoothing.positionLerp);
+
+    if (posAlpha <= 0) {
+      state.visualPosition.copy(state.targetVisualPosition);
+    } else if (posAlpha >= 1) {
+      state.visualPosition.copy(state.targetVisualPosition);
+    } else {
+      state.visualPosition.lerp(state.targetVisualPosition, MathUtils.clamp(posAlpha, 0, 1));
+    }
+
+    const rotAlpha =
+      visualCfg?.rotation?.k != null && visualCfg.rotation.k > 0
+        ? kToAlpha(visualCfg.rotation.k, dt)
+        : legacyToAlpha(smoothing.rotationSlerp);
+
+    if (rotAlpha <= 0) {
+      state.visualRotation.copy(state.interpRotation);
+    } else if (rotAlpha >= 1) {
+      state.visualRotation.copy(state.interpRotation);
+    } else {
+      state.visualRotation.slerp(state.interpRotation, MathUtils.clamp(rotAlpha, 0, 1));
+    }
+
+    const bankFactor = motion.visualBankFactor ?? smoothing.bankFactor;
+    const maxBankDeg = visualCfg?.bank?.maxDeg ?? motion.maxBankDeg ?? smoothing.maxBankDeg;
+    const yawRate = entity.ship.angularVelocity.y;
+    let bankDeg = yawRate * bankFactor;
+
+    if (motion.maxLateralAcceleration && motion.maxLateralAcceleration > 0) {
+      const lateralRatio = MathUtils.clamp(
+        entity.ship.lateralAcceleration / motion.maxLateralAcceleration,
+        -1,
+        1,
+      );
+      bankDeg += lateralRatio * maxBankDeg * 0.5;
+    }
+
+    const targetBankRad = MathUtils.degToRad(MathUtils.clamp(bankDeg, -maxBankDeg, maxBankDeg));
+    const safeDt = Math.max(dt, 1e-6);
+
+    if (visualCfg?.bank?.useCriticallyDamped && visualCfg.bank.k && visualCfg.bank.k > 0) {
+      const omega = visualCfg.bank.k;
+      const x = bankValueRef.current;
+      const v = bankVelocityRef.current;
+      const C1 = x - targetBankRad;
+      const C2 = v + omega * C1;
+      const expTerm = Math.exp(-omega * safeDt);
+      const xNew = targetBankRad + (C1 + C2 * safeDt) * expTerm;
+      const vNew = (C2 - omega * (C1 + C2 * safeDt)) * expTerm;
+      bankValueRef.current = xNew;
+      bankVelocityRef.current = vNew;
+    } else {
+      const bankAlpha =
+        visualCfg?.bank?.k != null && visualCfg.bank.k > 0
+          ? kToAlpha(visualCfg.bank.k, dt)
+          : legacyToAlpha(smoothing.bankLerp);
+      if (bankAlpha <= 0) {
+        bankValueRef.current = targetBankRad;
+      } else if (bankAlpha >= 1) {
+        bankValueRef.current = targetBankRad;
+      } else {
+        bankValueRef.current = MathUtils.lerp(bankValueRef.current, targetBankRad, MathUtils.clamp(bankAlpha, 0, 1));
+      }
+      bankVelocityRef.current = 0;
+    }
+  }
+
+  state.visualOffset
+    .copy(state.visualPosition)
+    .sub(state.interpPosition)
+    .applyQuaternion(state.inverseInterpRotation);
 
   state.finalRotation.copy(state.visualRotation);
-  const bankRoll = bankValueRef.current;
-  if (Math.abs(bankRoll) > 1e-4) {
-    state.bankQuaternion.setFromAxisAngle(state.forwardAxis, -bankRoll);
-    state.finalRotation.multiply(state.bankQuaternion);
+  if (smoothingEnabled) {
+    const bankRoll = bankValueRef.current;
+    if (Math.abs(bankRoll) > 1e-4) {
+      state.bankQuaternion.setFromAxisAngle(state.forwardAxis, -bankRoll);
+      state.finalRotation.multiply(state.bankQuaternion);
+    }
   }
 }
 

--- a/test/vitest/ship-interpolation.spec.ts
+++ b/test/vitest/ship-interpolation.spec.ts
@@ -1,254 +1,329 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { Quaternion, Vector3 } from 'three';
-import { updateInterpolation, type InterpolationState, type SmoothingConfig } from '../../src/hooks/useShipInterpolation.js';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { MathUtils, Quaternion, Vector3 } from 'three';
+import {
+  updateInterpolation,
+  kToAlpha,
+  type InterpolationState,
+  type SmoothingConfig,
+} from '../../src/hooks/useShipInterpolation.js';
 import type { ShipEntity } from '../../src/types/index.js';
+import { RENDERER_VISUAL_CONFIG } from '../../src/config/renderer.js';
 
-describe('Ship Interpolation', () => {
-  let mockEntity: ShipEntity;
-  let interpolationState: InterpolationState;
-  let smoothingConfig: SmoothingConfig;
-  let bankValueRef: { current: number };
-  let lastTickIndexRef: { current: number };
+interface Ref<T> {
+  current: T;
+}
+
+function createTestEntity(): ShipEntity {
+  return {
+    id: 1,
+    transform: {
+      position: new Vector3(0, 0, 0),
+      rotation: new Quaternion(),
+      scale: 1,
+    },
+    ship: {
+      motion: {
+        mass: 1,
+        maxSpeed: 40,
+        maxReverseSpeed: 5,
+        linearAcceleration: 30,
+        linearDamping: 2,
+        maxTurnRate: Math.PI * 1.5,
+        angularAcceleration: Math.PI * 3,
+        angularDamping: 5,
+        turnKp: 4,
+        turnKd: 1,
+        angularSettlingRate: 0.01,
+        angularSettleToleranceDeg: 3,
+        maxLateralAcceleration: 10,
+        visualBankFactor: 18,
+        maxBankDeg: 32,
+        visual: {
+          enabled: true,
+          position: { k: 12 },
+          rotation: { k: 30 },
+          bank: { k: 18, maxDeg: 32, useCriticallyDamped: true },
+          bob: { enabled: true, baseAmp: 0.08, freq: 1.2, speedScale: 1, maxAmp: 0.22 },
+          teleportDistance: 35,
+        },
+      },
+      angularVelocity: new Vector3(0, 0, 0),
+      velocity: new Vector3(0, 0, 0),
+      lateralAcceleration: 0,
+    },
+  } as ShipEntity;
+}
+
+function createSmoothingConfig(): SmoothingConfig {
+  return {
+    positionLerp: 0.18,
+    rotationSlerp: 0.25,
+    bankLerp: 0.15,
+    teleportThresholdSq: 900,
+    bankFactor: 18,
+    maxBankDeg: 32,
+    thrusterIntensity: { base: 0.4, range: 1.2 },
+  };
+}
+
+function createInterpolationState(
+  bankValueRef: Ref<number>,
+  bankVelocityRef: Ref<number>,
+  lastTickIndexRef: Ref<number>,
+): InterpolationState {
+  const state: Partial<InterpolationState> = {
+    prevSimPosition: new Vector3(),
+    prevSimRotation: new Quaternion(),
+    currSimPosition: new Vector3(),
+    currSimRotation: new Quaternion(),
+    visualPosition: new Vector3(),
+    visualRotation: new Quaternion(),
+    targetVisualPosition: new Vector3(),
+    visualLocalOffset: new Vector3(),
+    visualOffset: new Vector3(),
+    interpPosition: new Vector3(),
+    interpRotation: new Quaternion(),
+    inverseInterpRotation: new Quaternion(),
+    bankQuaternion: new Quaternion(),
+    forwardAxis: new Vector3(0, 0, 1),
+    finalRotation: new Quaternion(),
+  };
+
+  Object.defineProperties(state, {
+    bankValue: { get: () => bankValueRef.current },
+    lastTickIndex: { get: () => lastTickIndexRef.current },
+  });
+
+  return state as InterpolationState;
+}
+
+function initialiseState(
+  state: InterpolationState,
+  entity: ShipEntity,
+  bankValueRef: Ref<number>,
+  bankVelocityRef: Ref<number>,
+  lastTickIndexRef: Ref<number>,
+): void {
+  state.prevSimPosition.copy(entity.transform.position);
+  state.currSimPosition.copy(entity.transform.position);
+  state.visualPosition.copy(entity.transform.position);
+  state.targetVisualPosition.copy(entity.transform.position);
+  state.visualLocalOffset.set(0, 0, 0);
+  state.visualOffset.set(0, 0, 0);
+  state.interpPosition.copy(entity.transform.position);
+  state.interpRotation.copy(entity.transform.rotation);
+  state.inverseInterpRotation.copy(entity.transform.rotation).invert();
+  state.visualRotation.copy(entity.transform.rotation);
+  state.finalRotation.copy(entity.transform.rotation);
+  bankValueRef.current = 0;
+  bankVelocityRef.current = 0;
+  lastTickIndexRef.current = 0;
+}
+
+describe('useShipInterpolation helpers', () => {
+  let originalToggle: boolean;
 
   beforeEach(() => {
-    mockEntity = {
-      id: 1,
-      transform: {
-        position: new Vector3(10, 0, 5),
-        rotation: new Quaternion().setFromAxisAngle(new Vector3(0, 1, 0), Math.PI / 4),
-        scale: 1,
-      },
-      ship: {
-        motion: {
-          maxLateralAcceleration: 100,
-          visualBankFactor: 1.0,
-          maxBankDeg: 30,
-        },
-        angularVelocity: new Vector3(0, 0.5, 0),
-        lateralAcceleration: 50,
-      },
-    } as ShipEntity;
+    originalToggle = RENDERER_VISUAL_CONFIG.enableShipVisualSmoothing;
+    RENDERER_VISUAL_CONFIG.enableShipVisualSmoothing = true;
+  });
 
-    interpolationState = {
-      prevSimPosition: new Vector3(0, 0, 0),
-      prevSimRotation: new Quaternion(),
-      currSimPosition: new Vector3(0, 0, 0),
-      currSimRotation: new Quaternion(),
-      visualPosition: new Vector3(0, 0, 0),
-      visualRotation: new Quaternion(),
-      interpPosition: new Vector3(0, 0, 0),
-      interpRotation: new Quaternion(),
-      bankQuaternion: new Quaternion(),
-      forwardAxis: new Vector3(0, 0, 1),
-      finalRotation: new Quaternion(),
-      bankValue: 0,
-      lastTickIndex: 0,
-    };
+  afterEach(() => {
+    RENDERER_VISUAL_CONFIG.enableShipVisualSmoothing = originalToggle;
+  });
 
-    smoothingConfig = {
-      positionLerp: 0.1,
-      rotationSlerp: 0.1,
-      bankLerp: 0.05,
-      teleportThresholdSq: 100,
-      bankFactor: 1.0,
-      maxBankDeg: 30,
-      thrusterIntensity: { base: 0.5, range: 0.3 },
-    };
+  describe('kToAlpha', () => {
+    it('returns zero for non-positive values', () => {
+      expect(kToAlpha(0, 1 / 60)).toBe(0);
+      expect(kToAlpha(12, 0)).toBe(0);
+    });
 
-    bankValueRef = { current: 0 };
-    lastTickIndexRef = { current: 0 };
+    it('scales alpha relative to dt', () => {
+      const fast = kToAlpha(12, 1 / 30);
+      const slow = kToAlpha(12, 1 / 120);
+      expect(fast).toBeGreaterThan(slow);
+      expect(fast).toBeCloseTo(1 - Math.exp(-12 / 30), 5);
+    });
   });
 
   describe('updateInterpolation', () => {
-    it('updates simulation positions when tick index changes', () => {
-      const newTickIndex = 1;
-      
-      updateInterpolation(
-        mockEntity,
-        interpolationState,
-        smoothingConfig,
-        0.5,
-        newTickIndex,
-        bankValueRef,
-        lastTickIndexRef,
-      );
+    it('converges consistently across variable dt sequences', () => {
+      const smoothing = createSmoothingConfig();
 
-      expect(lastTickIndexRef.current).toBe(1);
-      expect(interpolationState.currSimPosition).toEqual(mockEntity.transform.position);
-      expect(interpolationState.currSimRotation).toEqual(mockEntity.transform.rotation);
+      function runSequence(dts: number[]): number {
+        const entity = createTestEntity();
+        entity.transform.position.set(10, 0, 0);
+        entity.ship.motion.visual!.position = { k: 16 };
+        entity.ship.motion.visual!.rotation = { k: 30 };
+        entity.ship.angularVelocity.set(0, 0, 0);
+        entity.ship.velocity.set(0, 0, 0);
+        entity.ship.lateralAcceleration = 0;
+
+        const bankValueRef: Ref<number> = { current: 0 };
+        const bankVelocityRef: Ref<number> = { current: 0 };
+        const lastTickIndexRef: Ref<number> = { current: 0 };
+        const state = createInterpolationState(bankValueRef, bankVelocityRef, lastTickIndexRef);
+        initialiseState(state, entity, bankValueRef, bankVelocityRef, lastTickIndexRef);
+
+        let accumulatedTime = 0;
+        for (const dt of dts) {
+          accumulatedTime += dt;
+          updateInterpolation(
+            entity,
+            state,
+            smoothing,
+            1,
+            dt,
+            accumulatedTime,
+            0,
+            bankValueRef,
+            bankVelocityRef,
+            lastTickIndexRef,
+          );
+        }
+
+        return state.visualPosition.x;
+      }
+
+      const uniformDts = Array.from({ length: 60 }, () => 1 / 60);
+      const variedBase = [1 / 30, 1 / 45, 1 / 50, 1 / 90, 1 / 70, 1 / 40];
+      const total = variedBase.reduce((sum, dt) => sum + dt, 0);
+      const variedDts = variedBase.map((dt) => dt / total);
+
+      const uniformResult = runSequence(uniformDts);
+      const variedResult = runSequence(variedDts);
+
+      expect(uniformResult).toBeCloseTo(10, 0);
+      expect(variedResult).toBeCloseTo(10, 1);
+      expect(Math.abs(uniformResult - variedResult)).toBeLessThan(0.05);
     });
 
-    it('interpolates position correctly with alpha', () => {
-      // Set up initial state
-      interpolationState.prevSimPosition.set(0, 0, 0);
-      interpolationState.currSimPosition.set(10, 0, 0);
-      // Update entity position to match currSimPosition
-      mockEntity.transform.position.set(10, 0, 0);
-      
-      updateInterpolation(
-        mockEntity,
-        interpolationState,
-        smoothingConfig,
-        0.5, // 50% interpolation
-        lastTickIndexRef.current, // Same tick
-        bankValueRef,
-        lastTickIndexRef,
+    it('keeps critically damped bank within target bounds across dt changes', () => {
+      const smoothing = createSmoothingConfig();
+      const entity = createTestEntity();
+      entity.ship.motion.visual!.bank = { k: 20, maxDeg: 30, useCriticallyDamped: true };
+      entity.ship.angularVelocity.set(0, 0.6, 0);
+      entity.ship.lateralAcceleration = 0;
+
+      const maxBankDeg = entity.ship.motion.visual!.bank!.maxDeg ?? 30;
+      const targetBankRad = MathUtils.degToRad(
+        Math.min(maxBankDeg, entity.ship.angularVelocity.y * (entity.ship.motion.visualBankFactor ?? smoothing.bankFactor)),
       );
 
-      // Should interpolate to midpoint
-      expect(interpolationState.interpPosition.x).toBeCloseTo(5);
-      expect(interpolationState.interpPosition.y).toBeCloseTo(0);
-      expect(interpolationState.interpPosition.z).toBeCloseTo(0);
+      const bankValueRef: Ref<number> = { current: 0 };
+      const bankVelocityRef: Ref<number> = { current: 0 };
+      const lastTickIndexRef: Ref<number> = { current: 0 };
+      const state = createInterpolationState(bankValueRef, bankVelocityRef, lastTickIndexRef);
+      initialiseState(state, entity, bankValueRef, bankVelocityRef, lastTickIndexRef);
+
+      const dts = [1 / 120, 1 / 60, 1 / 45, 1 / 30, 1 / 20];
+      let time = 0;
+      for (const dt of dts) {
+        time += dt;
+        updateInterpolation(
+          entity,
+          state,
+          smoothing,
+          1,
+          dt,
+          time,
+          0,
+          bankValueRef,
+          bankVelocityRef,
+          lastTickIndexRef,
+        );
+
+        expect(Math.abs(bankValueRef.current)).toBeLessThanOrEqual(Math.abs(targetBankRad) + 1e-3);
+      }
+
+      expect(bankValueRef.current).toBeCloseTo(targetBankRad, 1);
     });
 
-    it('handles teleport threshold correctly', () => {
-      const farPosition = new Vector3(1000, 0, 0);
-      mockEntity.transform.position = farPosition;
-      
-      // Set previous position close to origin
-      interpolationState.prevSimPosition.set(0, 0, 0);
-      interpolationState.visualPosition.set(0, 0, 0);
-      
+    it('bypasses smoothing when the global toggle is disabled', () => {
+      const smoothing = createSmoothingConfig();
+      const entity = createTestEntity();
+      entity.ship.motion.visual!.enabled = true;
+
+      const bankValueRef: Ref<number> = { current: 0 };
+      const bankVelocityRef: Ref<number> = { current: 0 };
+      const lastTickIndexRef: Ref<number> = { current: 0 };
+      const state = createInterpolationState(bankValueRef, bankVelocityRef, lastTickIndexRef);
+      initialiseState(state, entity, bankValueRef, bankVelocityRef, lastTickIndexRef);
+
+      RENDERER_VISUAL_CONFIG.enableShipVisualSmoothing = false;
+
       updateInterpolation(
-        mockEntity,
-        interpolationState,
-        smoothingConfig,
-        0.5,
-        1, // New tick index
+        entity,
+        state,
+        smoothing,
+        1,
+        1 / 60,
+        1 / 60,
+        0,
         bankValueRef,
+        bankVelocityRef,
         lastTickIndexRef,
       );
 
-      // Should teleport instead of interpolate
-      expect(interpolationState.visualPosition).toEqual(farPosition);
+      expect(state.visualPosition.equals(state.interpPosition)).toBe(true);
+      expect(state.visualRotation.equals(state.interpRotation)).toBe(true);
+      expect(state.visualOffset.length()).toBeLessThan(1e-6);
     });
 
-    it('calculates banking based on angular velocity', () => {
-      mockEntity.ship.angularVelocity.y = 1.0; // 1 rad/s yaw rate
-      
+    it('applies bob offsets scaled by speed and clamped to maximum amplitude', () => {
+      const smoothing = createSmoothingConfig();
+      const entity = createTestEntity();
+      const bob = entity.ship.motion.visual!.bob!;
+      bob.enabled = true;
+      bob.baseAmp = 0.08;
+      bob.maxAmp = 0.2;
+      bob.freq = 1.0;
+      bob.speedScale = 1.0;
+      entity.ship.motion.visual!.position = { k: 60 };
+      entity.ship.motion.visual!.rotation = { k: 60 };
+
+      const bankValueRef: Ref<number> = { current: 0 };
+      const bankVelocityRef: Ref<number> = { current: 0 };
+      const lastTickIndexRef: Ref<number> = { current: 0 };
+      const state = createInterpolationState(bankValueRef, bankVelocityRef, lastTickIndexRef);
+      initialiseState(state, entity, bankValueRef, bankVelocityRef, lastTickIndexRef);
+
+      // Low speed should fade the bob nearly to zero
+      entity.ship.velocity.set(0.1, 0, 0);
       updateInterpolation(
-        mockEntity,
-        interpolationState,
-        smoothingConfig,
-        0.5,
-        lastTickIndexRef.current,
+        entity,
+        state,
+        smoothing,
+        1,
+        1 / 60,
+        1 / 60,
+        0,
         bankValueRef,
+        bankVelocityRef,
+        lastTickIndexRef,
+      );
+      expect(Math.abs(state.visualOffset.y)).toBeLessThan(0.01);
+
+      // High speed should push towards the configured max amplitude
+      initialiseState(state, entity, bankValueRef, bankVelocityRef, lastTickIndexRef);
+      entity.ship.velocity.set(entity.ship.motion.maxSpeed, 0, 0);
+      const phaseTime = 0.25 / bob.freq;
+      updateInterpolation(
+        entity,
+        state,
+        smoothing,
+        1,
+        phaseTime,
+        phaseTime,
+        0,
+        bankValueRef,
+        bankVelocityRef,
         lastTickIndexRef,
       );
 
-      // Bank angle should be affected by yaw rate
-      expect(Math.abs(bankValueRef.current)).toBeGreaterThan(0);
-      expect(Math.abs(bankValueRef.current)).toBeLessThanOrEqual(Math.PI / 6); // 30 degrees max
-    });
-
-    it('applies lateral acceleration to banking', () => {
-      mockEntity.ship.angularVelocity.y = 0; // No yaw
-      mockEntity.ship.lateralAcceleration = 100; // Max lateral acceleration
-      
-      updateInterpolation(
-        mockEntity,
-        interpolationState,
-        smoothingConfig,
-        0.5,
-        lastTickIndexRef.current,
-        bankValueRef,
-        lastTickIndexRef,
-      );
-
-      // Should have banking from lateral acceleration
-      expect(Math.abs(bankValueRef.current)).toBeGreaterThan(0);
-    });
-
-    it('respects maximum bank angle limits', () => {
-      mockEntity.ship.angularVelocity.y = 10.0; // Very high yaw rate
-      mockEntity.ship.lateralAcceleration = 1000; // Very high lateral acceleration
-      
-      updateInterpolation(
-        mockEntity,
-        interpolationState,
-        smoothingConfig,
-        0.5,
-        lastTickIndexRef.current,
-        bankValueRef,
-        lastTickIndexRef,
-      );
-
-      const maxBankRad = Math.PI / 6; // 30 degrees
-      expect(Math.abs(bankValueRef.current)).toBeLessThanOrEqual(maxBankRad + 0.01); // Small tolerance
-    });
-
-    it('applies banking smoothing', () => {
-      const initialBank = bankValueRef.current;
-      mockEntity.ship.angularVelocity.y = 1.0;
-      
-      updateInterpolation(
-        mockEntity,
-        interpolationState,
-        smoothingConfig,
-        0.5,
-        lastTickIndexRef.current,
-        bankValueRef,
-        lastTickIndexRef,
-      );
-
-      const firstUpdate = bankValueRef.current;
-      
-      updateInterpolation(
-        mockEntity,
-        interpolationState,
-        smoothingConfig,
-        0.5,
-        lastTickIndexRef.current,
-        bankValueRef,
-        lastTickIndexRef,
-      );
-
-      const secondUpdate = bankValueRef.current;
-      
-      // Bank value should smooth towards target, not jump immediately
-      expect(Math.abs(secondUpdate - firstUpdate)).toBeLessThan(Math.abs(firstUpdate - initialBank));
-    });
-
-    it('applies banking rotation to final rotation', () => {
-      bankValueRef.current = Math.PI / 12; // 15 degrees
-      interpolationState.visualRotation.identity();
-      
-      updateInterpolation(
-        mockEntity,
-        interpolationState,
-        smoothingConfig,
-        0.5,
-        lastTickIndexRef.current,
-        bankValueRef,
-        lastTickIndexRef,
-      );
-
-      // Final rotation should be different from visual rotation due to banking
-      expect(interpolationState.finalRotation.equals(interpolationState.visualRotation)).toBe(false);
-    });
-
-    it('skips banking when bank value is very small', () => {
-      bankValueRef.current = 0.00001; // Very small bank value
-      interpolationState.visualRotation.identity();
-      interpolationState.finalRotation.identity();
-      
-      // Zero out entity motion to prevent banking calculation
-      mockEntity.ship.angularVelocity.set(0, 0, 0);
-      mockEntity.ship.lateralAcceleration = 0;
-      
-      updateInterpolation(
-        mockEntity,
-        interpolationState,
-        smoothingConfig,
-        0.5,
-        lastTickIndexRef.current,
-        bankValueRef,
-        lastTickIndexRef,
-      );
-
-      // Final rotation should be very close to visual rotation when bank is negligible
-      const angleDiff = interpolationState.finalRotation.angleTo(interpolationState.visualRotation);
-      expect(angleDiff).toBeLessThan(0.001); // Very small angle difference
+      expect(Math.abs(state.visualOffset.y)).toBeGreaterThan(0.05);
+      expect(Math.abs(state.visualOffset.y)).toBeLessThanOrEqual(bob.maxAmp! + 1e-3);
     });
   });
 });
+


### PR DESCRIPTION
## Summary
- refactor ship interpolation to use dt-aware smoothing, local bob offsets, and critically damped banking with a reusable `kToAlpha` helper
- add opt-in CCD wiring when spawning ship bodies and document rollout completion in memory records
- expand ship interpolation tests to cover alpha conversion, bank stability, toggle bypass, and bob amplitude behaviour

## Testing
- npx tsc --noEmit
- npm test -- test/vitest/ship-interpolation.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e06e291218832aa3f62378b6c03068