### PR TITLE
feat: add saturation-aware instanced effects

### DIFF
--- a/src/components/explosions/ExplosionRendererCore.tsx
+++ b/src/components/explosions/ExplosionRendererCore.tsx
@@ -3,6 +3,7 @@ import { useFrame } from '@react-three/fiber';
 import { Color, InstancedMesh, Object3D, Quaternion, Vector3 } from 'three';
 import { useBloomRegistration } from '../../renderer/BloomProvider.js';
 import { useGameState } from '../../game/context.js';
+import { createSaturationWarningState, warnOnSaturation } from '../layers/saturationWarning.js';
 import {
   DEBRIS_CAPACITY,
   FIREBALL_CAPACITY,
@@ -51,8 +52,12 @@ export function ExplosionRendererCore(): React.ReactElement {
   const tmpQuat = useMemo(() => new Quaternion(), []);
   const tmpVec = useMemo(() => new Vector3(), []);
   const color = useMemo(() => new Color(), []);
+  const warningStateRef = useRef(createSaturationWarningState());
+  const frameRef = useRef(0);
 
   useFrame(({ camera }) => {
+    frameRef.current += 1;
+    const frameId = frameRef.current;
     const refs: InstancedMeshRefs = {
       flash: flashRef.current,
       shockwave: shockwaveRef.current,
@@ -85,6 +90,16 @@ export function ExplosionRendererCore(): React.ReactElement {
       smoke: 0,
     };
 
+    const saturationState: Record<keyof EffectCounts, boolean> = {
+      flash: false,
+      shockwave: false,
+      fireball: false,
+      debris: false,
+      sparks: false,
+      plasma: false,
+      smoke: false,
+    };
+
     for (const event of state.explosions) {
       const time = event.elapsed;
       const derived = getDerived(event);
@@ -100,16 +115,44 @@ export function ExplosionRendererCore(): React.ReactElement {
         color,
       };
 
-      counts.flash += updateFlash(ctx, refs.flash, counts.flash, FLASH_CAPACITY);
-      counts.shockwave += updateShockwave(ctx, refs.shockwave, counts.shockwave, SHOCKWAVE_CAPACITY);
-      counts.fireball += updateFireball(ctx, refs.fireball, counts.fireball, FIREBALL_CAPACITY);
-      counts.debris += updateDebris(ctx, refs.debris, counts.debris, DEBRIS_CAPACITY);
-      counts.sparks += updateSparks(ctx, refs.sparks, counts.sparks, SPARKS_CAPACITY);
-      counts.plasma += updatePlasma(ctx, refs.plasma, counts.plasma, PLASMA_CAPACITY);
-      counts.smoke += updateSmoke(ctx, refs.smoke, counts.smoke, SMOKE_CAPACITY);
+      const flashResult = updateFlash(ctx, refs.flash, counts.flash, FLASH_CAPACITY);
+      counts.flash += flashResult.count;
+      saturationState.flash ||= flashResult.saturated;
+
+      const shockwaveResult = updateShockwave(ctx, refs.shockwave, counts.shockwave, SHOCKWAVE_CAPACITY);
+      counts.shockwave += shockwaveResult.count;
+      saturationState.shockwave ||= shockwaveResult.saturated;
+
+      const fireballResult = updateFireball(ctx, refs.fireball, counts.fireball, FIREBALL_CAPACITY);
+      counts.fireball += fireballResult.count;
+      saturationState.fireball ||= fireballResult.saturated;
+
+      const debrisResult = updateDebris(ctx, refs.debris, counts.debris, DEBRIS_CAPACITY);
+      counts.debris += debrisResult.count;
+      saturationState.debris ||= debrisResult.saturated;
+
+      const sparksResult = updateSparks(ctx, refs.sparks, counts.sparks, SPARKS_CAPACITY);
+      counts.sparks += sparksResult.count;
+      saturationState.sparks ||= sparksResult.saturated;
+
+      const plasmaResult = updatePlasma(ctx, refs.plasma, counts.plasma, PLASMA_CAPACITY);
+      counts.plasma += plasmaResult.count;
+      saturationState.plasma ||= plasmaResult.saturated;
+
+      const smokeResult = updateSmoke(ctx, refs.smoke, counts.smoke, SMOKE_CAPACITY);
+      counts.smoke += smokeResult.count;
+      saturationState.smoke ||= smokeResult.saturated;
     }
 
     finalizeInstancedMeshes(refs, counts);
+
+    const saturated = Object.values(saturationState).some(Boolean);
+    warnOnSaturation({
+      saturated,
+      frameId,
+      state: warningStateRef.current,
+      message: '[ExplosionRendererCore] Capacity saturated, clamping explosion visuals.',
+    });
   });
 
   return (

--- a/src/components/explosions/effectUpdaters/debrisUpdater.ts
+++ b/src/components/explosions/effectUpdaters/debrisUpdater.ts
@@ -1,7 +1,7 @@
 import type { InstancedMesh } from 'three';
 import { DEBRIS_DELAY } from '../constants.js';
 import { clamp01, getCachedColor } from '../derived.js';
-import type { EffectUpdateContext, EffectUpdater } from './types.js';
+import { EMPTY_EFFECT_RESULT, type EffectUpdateContext, type EffectUpdater, type EffectUpdateResult } from './types.js';
 
 /**
  * Updates debris effect instances.
@@ -11,20 +11,26 @@ export const updateDebris: EffectUpdater = (
   ctx: EffectUpdateContext,
   mesh: InstancedMesh,
   startIndex: number,
-  capacity: number
-): number => {
+  capacity: number,
+): EffectUpdateResult => {
   const { event, time, derived, dummy, tmpQuat, tmpVec, color } = ctx;
 
   const debrisT = time - DEBRIS_DELAY;
   if (debrisT < 0) {
-    return 0;
+    return EMPTY_EFFECT_RESULT;
   }
 
   let count = 0;
+  let saturated = false;
 
   for (const shard of derived.debris) {
-    if (debrisT > shard.lifetime || startIndex + count >= capacity) {
+    if (debrisT > shard.lifetime) {
       continue;
+    }
+
+    if (startIndex + count >= capacity) {
+      saturated = true;
+      break;
     }
 
     const shardProgress = clamp01(debrisT / shard.lifetime);
@@ -50,5 +56,5 @@ export const updateDebris: EffectUpdater = (
     count += 1;
   }
 
-  return count;
+  return { count, saturated };
 };

--- a/src/components/explosions/effectUpdaters/fireballUpdater.ts
+++ b/src/components/explosions/effectUpdaters/fireballUpdater.ts
@@ -1,6 +1,6 @@
 import type { InstancedMesh } from 'three';
 import { clamp01, getCachedColor } from '../derived.js';
-import type { EffectUpdateContext, EffectUpdater } from './types.js';
+import { EMPTY_EFFECT_RESULT, type EffectUpdateContext, type EffectUpdater, type EffectUpdateResult } from './types.js';
 
 /**
  * Updates fireball effect instances.
@@ -10,13 +10,17 @@ export const updateFireball: EffectUpdater = (
   ctx: EffectUpdateContext,
   mesh: InstancedMesh,
   startIndex: number,
-  _capacity: number
-): number => {
+  capacity: number,
+): EffectUpdateResult => {
   const { event, time, dummy, color } = ctx;
 
   const fireballT = time - event.fireball.delay;
   if (fireballT < 0 || fireballT > event.fireball.duration) {
-    return 0;
+    return EMPTY_EFFECT_RESULT;
+  }
+
+  if (startIndex >= capacity) {
+    return { count: 0, saturated: true };
   }
 
   const firePhase = clamp01(fireballT / event.fireball.duration);
@@ -34,5 +38,5 @@ export const updateFireball: EffectUpdater = (
   color.copy(hotColor).lerp(coolColor, firePhase * 0.65);
   mesh.setColorAt(startIndex, color);
 
-  return 1;
+  return { count: 1, saturated: false };
 };

--- a/src/components/explosions/effectUpdaters/flashUpdater.ts
+++ b/src/components/explosions/effectUpdaters/flashUpdater.ts
@@ -1,7 +1,7 @@
 import type { InstancedMesh } from 'three';
 import { FLASH_DURATION } from '../constants.js';
 import { clamp01, easeOutQuad, getCachedColor } from '../derived.js';
-import type { EffectUpdateContext, EffectUpdater } from './types.js';
+import { EMPTY_EFFECT_RESULT, type EffectUpdateContext, type EffectUpdater, type EffectUpdateResult } from './types.js';
 
 /**
  * Updates flash effect instances.
@@ -11,12 +11,16 @@ export const updateFlash: EffectUpdater = (
   ctx: EffectUpdateContext,
   mesh: InstancedMesh,
   startIndex: number,
-  _capacity: number
-): number => {
+  capacity: number,
+): EffectUpdateResult => {
   const { event, time, camera, derived, dummy, color } = ctx;
 
   if (time > FLASH_DURATION) {
-    return 0;
+    return EMPTY_EFFECT_RESULT;
+  }
+
+  if (startIndex >= capacity) {
+    return { count: 0, saturated: true };
   }
 
   const flashT = clamp01(time / FLASH_DURATION);
@@ -33,5 +37,5 @@ export const updateFlash: EffectUpdater = (
   color.copy(getCachedColor(event.palette.flash)).multiplyScalar(Math.max(0.3, intensity));
   mesh.setColorAt(startIndex, color);
 
-  return 1;
+  return { count: 1, saturated: false };
 };

--- a/src/components/explosions/effectUpdaters/index.ts
+++ b/src/components/explosions/effectUpdaters/index.ts
@@ -5,4 +5,4 @@ export { updateDebris } from './debrisUpdater.js';
 export { updateSparks } from './sparksUpdater.js';
 export { updatePlasma } from './plasmaUpdater.js';
 export { updateSmoke } from './smokeUpdater.js';
-export type { EffectUpdateContext, EffectUpdater } from './types.js';
+export type { EffectUpdateContext, EffectUpdater, EffectUpdateResult } from './types.js';

--- a/src/components/explosions/effectUpdaters/plasmaUpdater.ts
+++ b/src/components/explosions/effectUpdaters/plasmaUpdater.ts
@@ -1,7 +1,7 @@
 import type { InstancedMesh } from 'three';
 import { PLASMA_DELAY } from '../constants.js';
 import { clamp01, getCachedColor } from '../derived.js';
-import type { EffectUpdateContext, EffectUpdater } from './types.js';
+import { EMPTY_EFFECT_RESULT, type EffectUpdateContext, type EffectUpdater, type EffectUpdateResult } from './types.js';
 
 /**
  * Updates plasma effect instances.
@@ -11,20 +11,26 @@ export const updatePlasma: EffectUpdater = (
   ctx: EffectUpdateContext,
   mesh: InstancedMesh,
   startIndex: number,
-  capacity: number
-): number => {
+  capacity: number,
+): EffectUpdateResult => {
   const { event, time, derived, dummy, tmpQuat, tmpVec, color } = ctx;
 
   const plasmaT = time - PLASMA_DELAY;
   if (plasmaT < 0) {
-    return 0;
+    return EMPTY_EFFECT_RESULT;
   }
 
   let count = 0;
+  let saturated = false;
 
   for (const plume of derived.plasma) {
-    if (plasmaT > plume.lifetime || startIndex + count >= capacity) {
+    if (plasmaT > plume.lifetime) {
       continue;
+    }
+
+    if (startIndex + count >= capacity) {
+      saturated = true;
+      break;
     }
 
     const plumeProgress = clamp01(plasmaT / plume.lifetime);
@@ -50,5 +56,5 @@ export const updatePlasma: EffectUpdater = (
     count += 1;
   }
 
-  return count;
+  return { count, saturated };
 };

--- a/src/components/explosions/effectUpdaters/shockwaveUpdater.ts
+++ b/src/components/explosions/effectUpdaters/shockwaveUpdater.ts
@@ -1,6 +1,6 @@
 import type { InstancedMesh } from 'three';
 import { clamp01, easeOutQuad, getCachedColor } from '../derived.js';
-import type { EffectUpdateContext, EffectUpdater } from './types.js';
+import { EMPTY_EFFECT_RESULT, type EffectUpdateContext, type EffectUpdater, type EffectUpdateResult } from './types.js';
 
 /**
  * Updates shockwave effect instances.
@@ -10,13 +10,17 @@ export const updateShockwave: EffectUpdater = (
   ctx: EffectUpdateContext,
   mesh: InstancedMesh,
   startIndex: number,
-  _capacity: number
-): number => {
+  capacity: number,
+): EffectUpdateResult => {
   const { event, time, camera, dummy, color } = ctx;
 
   const shockwaveT = time - event.shockwave.delay;
   if (shockwaveT < 0 || shockwaveT > event.shockwave.duration) {
-    return 0;
+    return EMPTY_EFFECT_RESULT;
+  }
+
+  if (startIndex >= capacity) {
+    return { count: 0, saturated: true };
   }
 
   const phase = clamp01(shockwaveT / event.shockwave.duration);
@@ -34,5 +38,5 @@ export const updateShockwave: EffectUpdater = (
     .multiplyScalar(Math.max(0.2, 1 - phase * 0.9));
   mesh.setColorAt(startIndex, color);
 
-  return 1;
+  return { count: 1, saturated: false };
 };

--- a/src/components/explosions/effectUpdaters/smokeUpdater.ts
+++ b/src/components/explosions/effectUpdaters/smokeUpdater.ts
@@ -1,7 +1,7 @@
 import type { InstancedMesh } from 'three';
 import { SMOKE_DELAY } from '../constants.js';
 import { clamp01, getCachedColor } from '../derived.js';
-import type { EffectUpdateContext, EffectUpdater } from './types.js';
+import { EMPTY_EFFECT_RESULT, type EffectUpdateContext, type EffectUpdater, type EffectUpdateResult } from './types.js';
 
 /**
  * Updates smoke effect instances.
@@ -11,20 +11,26 @@ export const updateSmoke: EffectUpdater = (
   ctx: EffectUpdateContext,
   mesh: InstancedMesh,
   startIndex: number,
-  capacity: number
-): number => {
+  capacity: number,
+): EffectUpdateResult => {
   const { event, time, camera, derived, dummy, tmpVec, color } = ctx;
 
   const smokeT = time - SMOKE_DELAY;
   if (smokeT < 0) {
-    return 0;
+    return EMPTY_EFFECT_RESULT;
   }
 
   let count = 0;
+  let saturated = false;
 
   for (const wisp of derived.smoke) {
-    if (smokeT > wisp.lifetime || startIndex + count >= capacity) {
+    if (smokeT > wisp.lifetime) {
       continue;
+    }
+
+    if (startIndex + count >= capacity) {
+      saturated = true;
+      break;
     }
 
     const wispProgress = clamp01(smokeT / wisp.lifetime);
@@ -48,5 +54,5 @@ export const updateSmoke: EffectUpdater = (
     count += 1;
   }
 
-  return count;
+  return { count, saturated };
 };

--- a/src/components/explosions/effectUpdaters/sparksUpdater.ts
+++ b/src/components/explosions/effectUpdaters/sparksUpdater.ts
@@ -1,7 +1,7 @@
 import type { InstancedMesh } from 'three';
 import { SPARKS_DELAY } from '../constants.js';
 import { clamp01, getCachedColor } from '../derived.js';
-import type { EffectUpdateContext, EffectUpdater } from './types.js';
+import { EMPTY_EFFECT_RESULT, type EffectUpdateContext, type EffectUpdater, type EffectUpdateResult } from './types.js';
 
 /**
  * Updates sparks effect instances.
@@ -11,20 +11,26 @@ export const updateSparks: EffectUpdater = (
   ctx: EffectUpdateContext,
   mesh: InstancedMesh,
   startIndex: number,
-  capacity: number
-): number => {
+  capacity: number,
+): EffectUpdateResult => {
   const { event, time, camera, derived, dummy, tmpVec, color } = ctx;
 
   const sparksT = time - SPARKS_DELAY;
   if (sparksT < 0) {
-    return 0;
+    return EMPTY_EFFECT_RESULT;
   }
 
   let count = 0;
+  let saturated = false;
 
   for (const spark of derived.sparks) {
-    if (sparksT > spark.lifetime || startIndex + count >= capacity) {
+    if (sparksT > spark.lifetime) {
       continue;
+    }
+
+    if (startIndex + count >= capacity) {
+      saturated = true;
+      break;
     }
 
     const sparkProgress = clamp01(sparksT / spark.lifetime);
@@ -49,5 +55,5 @@ export const updateSparks: EffectUpdater = (
     count += 1;
   }
 
-  return count;
+  return { count, saturated };
 };

--- a/src/components/explosions/effectUpdaters/types.ts
+++ b/src/components/explosions/effectUpdaters/types.ts
@@ -16,13 +16,23 @@ export interface EffectUpdateContext {
   color: Color;
 }
 
+export interface EffectUpdateResult {
+  count: number;
+  saturated: boolean;
+}
+
 /**
  * Effect updater function signature.
- * Returns the number of instances used for this effect.
+ * Returns the number of instances used for this effect and whether capacity was saturated.
  */
 export type EffectUpdater = (
   ctx: EffectUpdateContext,
   mesh: InstancedMesh,
   startIndex: number,
   capacity: number
-) => number;
+) => EffectUpdateResult;
+
+export const EMPTY_EFFECT_RESULT: EffectUpdateResult = Object.freeze({
+  count: 0,
+  saturated: false,
+});

--- a/src/components/layers/MuzzleFlashInstancedLayer.tsx
+++ b/src/components/layers/MuzzleFlashInstancedLayer.tsx
@@ -14,7 +14,7 @@ import type { Archetype, GameEntity, TurretEntity, MuzzleFlash } from '../../typ
 import { useArchetypeEntities } from '../../hooks/useArchetypeEntities.js';
 import { useGameState } from '../../game/context.js';
 import { useBloomRegistration } from '../../renderer/BloomProvider.js';
-import { createInstancedMaterial } from '../../renderer/materialRegistry.js';
+import { getInstanceFriendlyMaterial } from '../../renderer/materialRegistry.js';
 import { InstanceAllocator } from './instanceAllocator.js';
 import { computeMuzzleFlashVisuals } from './muzzleFlashMath.js';
 import { createSaturationWarningState, warnOnSaturation } from './saturationWarning.js';
@@ -58,7 +58,10 @@ export function MuzzleFlashInstancedLayer({
   const frameRef = useRef(0);
   const state = useGameState();
 
-  const materialInfo = useMemo(() => createInstancedMaterial('muzzle:flash'), []);
+  const materialInfo = useMemo(
+    () => getInstanceFriendlyMaterial('muzzle:flash', { requireInstanceColor: true }),
+    [],
+  );
   const geometry = useMemo(() => new SphereGeometry(1, 10, 10), []);
 
   useBloomRegistration(meshRef, { group: 'muzzleFlashes' });

--- a/src/renderer/materialRegistry.tsx
+++ b/src/renderer/materialRegistry.tsx
@@ -81,6 +81,78 @@ export function createInstancedMaterial(
   };
 }
 
+export interface InstanceFriendlyMaterialOptions {
+  requireInstanceColor?: boolean;
+  fallbackKey?: MaterialKey;
+  fallbackFactory?: () => InstancedMaterialInfo;
+  onFallback?: (details: InstanceFriendlyFallbackDetails) => void;
+}
+
+export interface InstanceFriendlyFallbackDetails {
+  requestedKey: MaterialKey;
+  resolvedKey: MaterialKey | null;
+  reason: 'missing' | 'no-instance-color';
+}
+
+const defaultInstanceColorFactory = (): InstancedMaterialInfo => {
+  const material = new MeshStandardMaterial({
+    color: '#ffffff',
+    emissive: '#000000',
+    emissiveIntensity: 1,
+    vertexColors: true,
+    transparent: true,
+    opacity: 1,
+    roughness: 0.4,
+    metalness: 0.05,
+  });
+  material.name = 'instance-friendly-fallback';
+  return {
+    material,
+    supportsInstanceColor: true,
+  };
+};
+
+export function getInstanceFriendlyMaterial(
+  key: MaterialKey,
+  options: InstanceFriendlyMaterialOptions = {},
+): InstancedMaterialInfo {
+  const {
+    requireInstanceColor = false,
+    fallbackKey,
+    fallbackFactory = defaultInstanceColorFactory,
+    onFallback,
+  } = options;
+
+  const entry = registry.get(key);
+  const info = createInstancedMaterial(key, fallbackFactory);
+  if (!requireInstanceColor) {
+    return info;
+  }
+
+  if (info.supportsInstanceColor) {
+    return info;
+  }
+
+  if (fallbackKey && fallbackKey !== key) {
+    const fallbackInfo = getInstanceFriendlyMaterial(fallbackKey, {
+      requireInstanceColor: true,
+      fallbackFactory,
+      onFallback,
+    });
+
+    if (fallbackInfo.supportsInstanceColor) {
+      onFallback?.({ requestedKey: key, resolvedKey: fallbackKey, reason: 'no-instance-color' });
+      info.material.dispose();
+      return fallbackInfo;
+    }
+  }
+
+  const reason: InstanceFriendlyFallbackDetails['reason'] = entry ? 'no-instance-color' : 'missing';
+  onFallback?.({ requestedKey: key, resolvedKey: null, reason });
+  info.material.dispose();
+  return fallbackFactory();
+}
+
 // Register built-in materials
 registerMaterial('shield:hex', ShieldHexMaterial);
 registerMaterial('shield:meshtransmission', ShieldTransmissionMaterial);

--- a/src/renderer/textureAtlas.ts
+++ b/src/renderer/textureAtlas.ts
@@ -1,0 +1,108 @@
+export interface TextureAtlasRegion {
+  key: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  uvOffset: readonly [number, number];
+  uvScale: readonly [number, number];
+}
+
+export interface UVTransform {
+  offset: readonly [number, number];
+  scale: readonly [number, number];
+}
+
+export class TextureAtlasBuilder {
+  private readonly regions = new Map<string, TextureAtlasRegion>();
+  private cursorX = 0;
+  private cursorY = 0;
+  private rowHeight = 0;
+
+  constructor(
+    private readonly atlasWidth: number,
+    private readonly atlasHeight: number,
+    private readonly padding = 1,
+  ) {
+    if (atlasWidth <= 0 || atlasHeight <= 0) {
+      throw new Error('TextureAtlasBuilder dimensions must be positive');
+    }
+  }
+
+  add(key: string, width: number, height: number): TextureAtlasRegion {
+    if (this.regions.has(key)) {
+      throw new Error(`TextureAtlasBuilder already contains key "${key}"`);
+    }
+
+    if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+      throw new Error('TextureAtlasBuilder requires positive finite region sizes');
+    }
+
+    if (width > this.atlasWidth || height > this.atlasHeight) {
+      throw new Error('Region size exceeds atlas dimensions');
+    }
+
+    const paddedWidth = Math.ceil(width);
+    const paddedHeight = Math.ceil(height);
+
+    if (this.cursorX + paddedWidth > this.atlasWidth) {
+      this.cursorX = 0;
+      this.cursorY += this.rowHeight + this.padding;
+      this.rowHeight = 0;
+    }
+
+    if (this.cursorY + paddedHeight > this.atlasHeight) {
+      throw new Error('TextureAtlasBuilder ran out of vertical space');
+    }
+
+    const region: TextureAtlasRegion = {
+      key,
+      x: this.cursorX,
+      y: this.cursorY,
+      width: paddedWidth,
+      height: paddedHeight,
+      uvOffset: [this.cursorX / this.atlasWidth, this.cursorY / this.atlasHeight],
+      uvScale: [paddedWidth / this.atlasWidth, paddedHeight / this.atlasHeight],
+    };
+
+    this.regions.set(key, region);
+    this.cursorX += paddedWidth + this.padding;
+    if (paddedHeight > this.rowHeight) {
+      this.rowHeight = paddedHeight;
+    }
+
+    return region;
+  }
+
+  build(): TextureAtlas {
+    return new TextureAtlas(this.atlasWidth, this.atlasHeight, new Map(this.regions));
+  }
+}
+
+export class TextureAtlas {
+  constructor(
+    public readonly width: number,
+    public readonly height: number,
+    private readonly regions: Map<string, TextureAtlasRegion>,
+  ) {}
+
+  getRegion(key: string): TextureAtlasRegion {
+    const region = this.regions.get(key);
+    if (!region) {
+      throw new Error(`TextureAtlas missing region for key "${key}"`);
+    }
+    return region;
+  }
+
+  getUVTransform(key: string): UVTransform {
+    const region = this.getRegion(key);
+    return {
+      offset: region.uvOffset,
+      scale: region.uvScale,
+    };
+  }
+
+  listRegions(): TextureAtlasRegion[] {
+    return Array.from(this.regions.values());
+  }
+}

--- a/test/components/explosions/effectUpdaters/debrisUpdater.spec.ts
+++ b/test/components/explosions/effectUpdaters/debrisUpdater.spec.ts
@@ -58,21 +58,23 @@ describe('debrisUpdater', () => {
 
   it('should not create debris instances before delay', () => {
     ctx.time = 0.1;
-    const count = updateDebris(ctx, mesh, 0, 100);
-    expect(count).toBe(0);
+    const result = updateDebris(ctx, mesh, 0, 100);
+    expect(result.count).toBe(0);
+    expect(result.saturated).toBe(false);
   });
 
   it('should create multiple debris instances after delay', () => {
     ctx.time = 0.3;
-    const count = updateDebris(ctx, mesh, 0, 100);
-    expect(count).toBeGreaterThan(0);
-    expect(count).toBeLessThanOrEqual(event.debris.count);
+    const result = updateDebris(ctx, mesh, 0, 100);
+    expect(result.count).toBeGreaterThan(0);
+    expect(result.count).toBeLessThanOrEqual(event.debris.count);
+    expect(result.saturated).toBe(false);
   });
 
   it('should respect capacity limits', () => {
     ctx.time = 0.3;
-    const count = updateDebris(ctx, mesh, 0, 5);
-    expect(count).toBeLessThanOrEqual(5);
+    const result = updateDebris(ctx, mesh, 0, 5);
+    expect(result.count).toBeLessThanOrEqual(5);
   });
 
   it('should move debris away from explosion center', () => {
@@ -96,13 +98,21 @@ describe('debrisUpdater', () => {
   });
 
   it('should be deterministic with same seed', () => {
-    const count1 = updateDebris(ctx, mesh, 0, 100);
+    const result1 = updateDebris(ctx, mesh, 0, 100);
 
     const ctx2 = { ...ctx, event: { ...event } };
     ctx2.derived = getDerived(ctx2.event);
     const mesh2 = new InstancedMesh(new SphereGeometry(1), new MeshBasicMaterial(), 100);
-    const count2 = updateDebris(ctx2, mesh2, 0, 100);
+    const result2 = updateDebris(ctx2, mesh2, 0, 100);
 
-    expect(count1).toBe(count2);
+    expect(result1.count).toBe(result2.count);
+    expect(result1.saturated).toBe(result2.saturated);
+  });
+
+  it('marks saturation when debris exceed capacity', () => {
+    ctx.time = 0.3;
+    const result = updateDebris(ctx, mesh, 0, 1);
+    expect(result.count).toBeLessThanOrEqual(1);
+    expect(result.saturated).toBe(true);
   });
 });

--- a/test/components/explosions/effectUpdaters/fireballUpdater.spec.ts
+++ b/test/components/explosions/effectUpdaters/fireballUpdater.spec.ts
@@ -58,20 +58,23 @@ describe('fireballUpdater', () => {
 
   it('should not create fireball before delay', () => {
     ctx.time = 0.01;
-    const count = updateFireball(ctx, mesh, 0, 10);
-    expect(count).toBe(0);
+    const result = updateFireball(ctx, mesh, 0, 10);
+    expect(result.count).toBe(0);
+    expect(result.saturated).toBe(false);
   });
 
   it('should create fireball after delay', () => {
     ctx.time = 0.1;
-    const count = updateFireball(ctx, mesh, 0, 10);
-    expect(count).toBe(1);
+    const result = updateFireball(ctx, mesh, 0, 10);
+    expect(result.count).toBe(1);
+    expect(result.saturated).toBe(false);
   });
 
   it('should not create fireball after duration ends', () => {
     ctx.time = 0.7;
-    const count = updateFireball(ctx, mesh, 0, 10);
-    expect(count).toBe(0);
+    const result = updateFireball(ctx, mesh, 0, 10);
+    expect(result.count).toBe(0);
+    expect(result.saturated).toBe(false);
   });
 
   it('should transition color from hot to cool', () => {
@@ -105,5 +108,11 @@ describe('fireballUpdater', () => {
     const scale2 = dummy2.scale.x;
 
     expect(scale2).toBeLessThan(scale1);
+  });
+
+  it('reports saturation when start index exceeds capacity', () => {
+    const result = updateFireball(ctx, mesh, 10, 10);
+    expect(result.count).toBe(0);
+    expect(result.saturated).toBe(true);
   });
 });

--- a/test/components/explosions/effectUpdaters/flashUpdater.spec.ts
+++ b/test/components/explosions/effectUpdaters/flashUpdater.spec.ts
@@ -61,14 +61,16 @@ describe('flashUpdater', () => {
   });
 
   it('should create flash instance when within flash duration', () => {
-    const count = updateFlash(ctx, mesh, 0, 10);
-    expect(count).toBe(1);
+    const result = updateFlash(ctx, mesh, 0, 10);
+    expect(result.count).toBe(1);
+    expect(result.saturated).toBe(false);
   });
 
   it('should not create flash instance when time exceeds flash duration', () => {
     ctx.time = 0.15;
-    const count = updateFlash(ctx, mesh, 0, 10);
-    expect(count).toBe(0);
+    const result = updateFlash(ctx, mesh, 0, 10);
+    expect(result.count).toBe(0);
+    expect(result.saturated).toBe(false);
   });
 
   it('should set correct matrix and color for flash instance', () => {
@@ -102,19 +104,26 @@ describe('flashUpdater', () => {
   });
 
   it('should be deterministic with same seed', () => {
-    const count1 = updateFlash(ctx, mesh, 0, 10);
+    const result1 = updateFlash(ctx, mesh, 0, 10);
     const color1 = new Color();
     mesh.getColorAt(0, color1);
 
     const ctx2 = { ...ctx, event: { ...event } };
     const mesh2 = new InstancedMesh(new SphereGeometry(1), new MeshBasicMaterial(), 10);
-    const count2 = updateFlash(ctx2, mesh2, 0, 10);
+    const result2 = updateFlash(ctx2, mesh2, 0, 10);
     const color2 = new Color();
     mesh2.getColorAt(0, color2);
 
-    expect(count1).toBe(count2);
+    expect(result1.count).toBe(result2.count);
+    expect(result1.saturated).toBe(result2.saturated);
     expect(color1.r).toBeCloseTo(color2.r, 5);
     expect(color1.g).toBeCloseTo(color2.g, 5);
     expect(color1.b).toBeCloseTo(color2.b, 5);
+  });
+
+  it('reports saturation when start index exceeds capacity', () => {
+    const result = updateFlash(ctx, mesh, 10, 10);
+    expect(result.count).toBe(0);
+    expect(result.saturated).toBe(true);
   });
 });

--- a/test/components/explosions/effectUpdaters/plasmaUpdater.spec.ts
+++ b/test/components/explosions/effectUpdaters/plasmaUpdater.spec.ts
@@ -58,21 +58,23 @@ describe('plasmaUpdater', () => {
 
   it('should not create plasma before delay', () => {
     ctx.time = 0.1;
-    const count = updatePlasma(ctx, mesh, 0, 100);
-    expect(count).toBe(0);
+    const result = updatePlasma(ctx, mesh, 0, 100);
+    expect(result.count).toBe(0);
+    expect(result.saturated).toBe(false);
   });
 
   it('should create multiple plasma instances', () => {
     ctx.time = 0.4;
-    const count = updatePlasma(ctx, mesh, 0, 100);
-    expect(count).toBeGreaterThan(0);
-    expect(count).toBeLessThanOrEqual(event.particles.plasma);
+    const result = updatePlasma(ctx, mesh, 0, 100);
+    expect(result.count).toBeGreaterThan(0);
+    expect(result.count).toBeLessThanOrEqual(event.particles.plasma);
+    expect(result.saturated).toBe(false);
   });
 
   it('should respect capacity limits', () => {
     ctx.time = 0.4;
-    const count = updatePlasma(ctx, mesh, 0, 5);
-    expect(count).toBeLessThanOrEqual(5);
+    const result = updatePlasma(ctx, mesh, 0, 5);
+    expect(result.count).toBeLessThanOrEqual(5);
   });
 
   it('should move plasma plumes outward', () => {
@@ -94,13 +96,21 @@ describe('plasmaUpdater', () => {
   });
 
   it('should be deterministic with same seed', () => {
-    const count1 = updatePlasma(ctx, mesh, 0, 100);
+    const result1 = updatePlasma(ctx, mesh, 0, 100);
 
     const ctx2 = { ...ctx, event: { ...event } };
     ctx2.derived = getDerived(ctx2.event);
     const mesh2 = new InstancedMesh(new SphereGeometry(1), new MeshBasicMaterial(), 100);
-    const count2 = updatePlasma(ctx2, mesh2, 0, 100);
+    const result2 = updatePlasma(ctx2, mesh2, 0, 100);
 
-    expect(count1).toBe(count2);
+    expect(result1.count).toBe(result2.count);
+    expect(result1.saturated).toBe(result2.saturated);
+  });
+
+  it('flags saturation when plasma count exceeds capacity', () => {
+    ctx.time = 0.4;
+    const result = updatePlasma(ctx, mesh, 0, 1);
+    expect(result.count).toBeLessThanOrEqual(1);
+    expect(result.saturated).toBe(true);
   });
 });

--- a/test/components/explosions/effectUpdaters/shockwaveUpdater.spec.ts
+++ b/test/components/explosions/effectUpdaters/shockwaveUpdater.spec.ts
@@ -59,20 +59,23 @@ describe('shockwaveUpdater', () => {
 
   it('should not create shockwave instance before delay', () => {
     ctx.time = 0.05;
-    const count = updateShockwave(ctx, mesh, 0, 10);
-    expect(count).toBe(0);
+    const result = updateShockwave(ctx, mesh, 0, 10);
+    expect(result.count).toBe(0);
+    expect(result.saturated).toBe(false);
   });
 
   it('should create shockwave instance after delay and within duration', () => {
     ctx.time = 0.2;
-    const count = updateShockwave(ctx, mesh, 0, 10);
-    expect(count).toBe(1);
+    const result = updateShockwave(ctx, mesh, 0, 10);
+    expect(result.count).toBe(1);
+    expect(result.saturated).toBe(false);
   });
 
   it('should not create shockwave instance after duration ends', () => {
     ctx.time = 0.6;
-    const count = updateShockwave(ctx, mesh, 0, 10);
-    expect(count).toBe(0);
+    const result = updateShockwave(ctx, mesh, 0, 10);
+    expect(result.count).toBe(0);
+    expect(result.saturated).toBe(false);
   });
 
   it('should expand shockwave radius over time', () => {
@@ -107,5 +110,11 @@ describe('shockwaveUpdater', () => {
     const intensity2 = color2.r + color2.g + color2.b;
 
     expect(intensity2).toBeLessThan(intensity1);
+  });
+
+  it('reports saturation when start index exceeds capacity', () => {
+    const result = updateShockwave(ctx, mesh, 10, 10);
+    expect(result.count).toBe(0);
+    expect(result.saturated).toBe(true);
   });
 });

--- a/test/components/explosions/effectUpdaters/smokeUpdater.spec.ts
+++ b/test/components/explosions/effectUpdaters/smokeUpdater.spec.ts
@@ -59,21 +59,23 @@ describe('smokeUpdater', () => {
 
   it('should not create smoke before delay', () => {
     ctx.time = 0.1;
-    const count = updateSmoke(ctx, mesh, 0, 100);
-    expect(count).toBe(0);
+    const result = updateSmoke(ctx, mesh, 0, 100);
+    expect(result.count).toBe(0);
+    expect(result.saturated).toBe(false);
   });
 
   it('should create multiple smoke instances', () => {
     ctx.time = 0.5;
-    const count = updateSmoke(ctx, mesh, 0, 100);
-    expect(count).toBeGreaterThan(0);
-    expect(count).toBeLessThanOrEqual(event.particles.smoke);
+    const result = updateSmoke(ctx, mesh, 0, 100);
+    expect(result.count).toBeGreaterThan(0);
+    expect(result.count).toBeLessThanOrEqual(event.particles.smoke);
+    expect(result.saturated).toBe(false);
   });
 
   it('should respect capacity limits', () => {
     ctx.time = 0.5;
-    const count = updateSmoke(ctx, mesh, 0, 5);
-    expect(count).toBeLessThanOrEqual(5);
+    const result = updateSmoke(ctx, mesh, 0, 5);
+    expect(result.count).toBeLessThanOrEqual(5);
   });
 
   it('should drift smoke wisps over time', () => {
@@ -109,5 +111,12 @@ describe('smokeUpdater', () => {
     const intensity2 = color2.r + color2.g + color2.b;
 
     expect(intensity2).toBeLessThan(intensity1);
+  });
+
+  it('flags saturation when smoke exceeds capacity', () => {
+    ctx.time = 0.5;
+    const result = updateSmoke(ctx, mesh, 0, 1);
+    expect(result.count).toBeLessThanOrEqual(1);
+    expect(result.saturated).toBe(true);
   });
 });

--- a/test/components/explosions/effectUpdaters/sparksUpdater.spec.ts
+++ b/test/components/explosions/effectUpdaters/sparksUpdater.spec.ts
@@ -59,21 +59,23 @@ describe('sparksUpdater', () => {
 
   it('should not create sparks before delay', () => {
     ctx.time = 0.1;
-    const count = updateSparks(ctx, mesh, 0, 100);
-    expect(count).toBe(0);
+    const result = updateSparks(ctx, mesh, 0, 100);
+    expect(result.count).toBe(0);
+    expect(result.saturated).toBe(false);
   });
 
   it('should create multiple spark instances', () => {
     ctx.time = 0.3;
-    const count = updateSparks(ctx, mesh, 0, 100);
-    expect(count).toBeGreaterThan(0);
-    expect(count).toBeLessThanOrEqual(event.particles.sparks);
+    const result = updateSparks(ctx, mesh, 0, 100);
+    expect(result.count).toBeGreaterThan(0);
+    expect(result.count).toBeLessThanOrEqual(event.particles.sparks);
+    expect(result.saturated).toBe(false);
   });
 
   it('should respect capacity limits', () => {
     ctx.time = 0.3;
-    const count = updateSparks(ctx, mesh, 0, 5);
-    expect(count).toBeLessThanOrEqual(5);
+    const result = updateSparks(ctx, mesh, 0, 5);
+    expect(result.count).toBeLessThanOrEqual(5);
   });
 
   it('should face camera', () => {
@@ -93,5 +95,12 @@ describe('sparksUpdater', () => {
     expect(dummy.quaternion.y).toBeCloseTo(camera.quaternion.y, 2);
     expect(dummy.quaternion.z).toBeCloseTo(camera.quaternion.z, 2);
     expect(dummy.quaternion.w).toBeCloseTo(camera.quaternion.w, 2);
+  });
+
+  it('marks saturation when sparks exceed capacity', () => {
+    ctx.time = 0.3;
+    const result = updateSparks(ctx, mesh, 0, 1);
+    expect(result.count).toBeLessThanOrEqual(1);
+    expect(result.saturated).toBe(true);
   });
 });

--- a/test/renderer/materialRegistry.spec.ts
+++ b/test/renderer/materialRegistry.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getInstanceFriendlyMaterial } from '../../src/renderer/materialRegistry.js';
+
+describe('materialRegistry instance-friendly helpers', () => {
+  it('returns original material when instance colors are supported', () => {
+    const info = getInstanceFriendlyMaterial('muzzle:flash', { requireInstanceColor: true });
+    expect(info.supportsInstanceColor).toBe(true);
+    expect(info.material).toBeDefined();
+    info.material.dispose();
+  });
+
+  it('falls back to provided key when base material lacks instance colors', () => {
+    const fallbackSpy = vi.fn();
+    const info = getInstanceFriendlyMaterial('bullet:laser', {
+      requireInstanceColor: true,
+      fallbackKey: 'muzzle:flash',
+      onFallback: fallbackSpy,
+    });
+    expect(info.supportsInstanceColor).toBe(true);
+    expect(fallbackSpy).toHaveBeenCalledWith({
+      requestedKey: 'bullet:laser',
+      resolvedKey: 'muzzle:flash',
+      reason: 'no-instance-color',
+    });
+    info.material.dispose();
+  });
+
+  it('uses default atlas-friendly fallback when material is missing', () => {
+    const fallbackSpy = vi.fn();
+    const info = getInstanceFriendlyMaterial('missing:key', {
+      requireInstanceColor: true,
+      onFallback: fallbackSpy,
+    });
+    expect(info.supportsInstanceColor).toBe(true);
+    expect(fallbackSpy).toHaveBeenCalledWith({
+      requestedKey: 'missing:key',
+      resolvedKey: null,
+      reason: 'missing',
+    });
+    info.material.dispose();
+  });
+});

--- a/test/renderer/textureAtlas.spec.ts
+++ b/test/renderer/textureAtlas.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { TextureAtlasBuilder } from '../../src/renderer/textureAtlas.js';
+
+describe('TextureAtlasBuilder', () => {
+  it('packs regions using shelf packing and exposes UV transforms', () => {
+    const builder = new TextureAtlasBuilder(64, 64, 2);
+    const regionA = builder.add('a', 16, 16);
+    const regionB = builder.add('b', 24, 12);
+    const regionC = builder.add('c', 32, 20);
+
+    expect(regionA.x).toBe(0);
+    expect(regionB.x).toBeGreaterThan(regionA.x);
+    expect(regionC.y).toBeGreaterThanOrEqual(regionA.y);
+
+    const atlas = builder.build();
+    expect(atlas.width).toBe(64);
+    expect(atlas.height).toBe(64);
+
+    const transform = atlas.getUVTransform('b');
+    expect(transform.scale[0]).toBeCloseTo(regionB.width / 64, 5);
+    expect(transform.offset[0]).toBeCloseTo(regionB.x / 64, 5);
+  });
+
+  it('throws when adding duplicate keys or overflowing space', () => {
+    const builder = new TextureAtlasBuilder(16, 16, 0);
+    builder.add('tile', 8, 8);
+    expect(() => builder.add('tile', 4, 4)).toThrow(/already contains key/);
+    expect(() => builder.add('big', 32, 8)).toThrow(/Region size exceeds atlas dimensions/);
+  });
+
+  it('throws when atlas runs out of vertical space', () => {
+    const builder = new TextureAtlasBuilder(16, 16, 0);
+    builder.add('a', 16, 8);
+    builder.add('b', 16, 8);
+    expect(() => builder.add('c', 16, 2)).toThrow(/ran out of vertical space/);
+  });
+});


### PR DESCRIPTION
## Summary
- add saturation tracking to explosion instancing and surface warnings via the shared saturation helper
- update explosion effect updaters to report saturation status and expand their unit coverage
- extend material registry with instance-friendly helpers and introduce a lightweight texture atlas builder with tests

## Testing
- npx tsc --noEmit
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e1b222abe0832a9def72131bcc22c3