### PR TITLE
feat: migrate thruster trails to gpu buffers

### DIFF
--- a/memory/designs/DESIGN003-thruster-trails-gpu.md
+++ b/memory/designs/DESIGN003-thruster-trails-gpu.md
@@ -1,0 +1,151 @@
+# DESIGN003 — Thruster trail GPU buffer migration
+
+Date: 2025-10-06
+Author: Codex (GPT-5 Codex agent)
+
+Confidence: 88% — Instanced buffer authoring and shader wiring are familiar; R3F testing requires careful mocks but follows existing StarDisk patterns.
+
+## Goal
+
+Move thruster trail rendering from a CPU-managed particle pool to GPU-driven instanced buffers so large fleets no longer bottleneck the main thread while keeping deterministic spawn jitter and visual parity with the prior system.
+
+## Context & Problem Statement
+
+- `src/components/ParticleTrails.tsx` preallocates `Particle[]` objects, iterates every slot each frame, and clones vectors during spawn updates, which scales poorly beyond a few hundred ships.
+- GLTF-derived thruster anchors are already memoised, but world transforms still allocate `Vector3` instances in fallback paths.
+- Trails only need spawn metadata (position, velocity, lifetime, scale); the GPU can evolve positions and fade over time via instanced attributes and a shader uniform clock.
+- We must preserve deterministic jitter to keep profiling consistent and supply tests that assert GPU resource shape and per-frame uniform updates.
+
+## Scope
+
+In scope:
+- `src/components/ParticleTrails.tsx` (rewrite to GPU buffers, optional test hooks, disposal logic).
+- New Vitest coverage under `test/vitest/particle-trails-gpu.spec.tsx`.
+- Memory bank updates (requirements, task file, index) and documentation for design/plan.
+
+Out of scope:
+- Changing renderer config defaults (color, spawn rate, lifetime).
+- Overhauling bloom registration or integrating additional post-processing.
+- Compute shader / transform feedback implementation (instanced attributes with custom shader only).
+
+## Proposed Architecture
+
+1. **GPU Resource Factory**
+   - Introduce `createParticleTrailResources(maxParticles, config)` returning:
+     - `InstancedBufferGeometry` cloned from a low-poly sphere with instanced attributes for spawn position, velocity, spawn time, lifetime, and scale (all marked `DynamicDrawUsage`).
+     - `ShaderMaterial` that accepts uniforms `uTime`, `uColor`, `uOpacity` and handles additive blending/depth flags per config.
+     - Typed array views (`Float32Array`) backing each instanced attribute for direct writes.
+   - Export the factory for unit tests and allow the component to reuse injected resources (via optional `resources` prop) to avoid duplicate allocations in tests.
+
+2. **Ring Buffer State**
+   - Replace the CPU particle pool with refs storing:
+     - `nextIndex` (0..max-1), `filledCount` (min(total spawned, maxParticles)).
+     - `spawnRemainders` map keyed by `shipId:anchorIndex` accumulating fractional spawn counts to simulate continuous emission without randomness spikes.
+     - `SeededRng` instance seeded with a stable constant so jitter remains deterministic.
+   - Each spawn writes directly into attribute arrays (position, velocity, lifetime, scale, spawn time) and flags the corresponding attribute's `.needsUpdate`.
+
+3. **Shader-Driven Evolution**
+   - Vertex shader computes current position as `spawnPos + velocity * age`, scales the sphere by `scale * fade(age)`, and passes the fade factor to the fragment shader.
+   - Fragment shader multiplies base color by fade-derived alpha and discards fragments with negligible alpha.
+   - The render loop only updates `uTime` uniform; no per-particle CPU updates.
+
+4. **Anchor Computation Cache**
+   - Maintain `Map<number, Vector3[]>` storing per-ship world-space anchor buffers that are mutated in-place each frame, reusing `Vector3` instances to avoid allocations.
+   - GLTF-based local anchors remain memoised; fallback heuristics populate the cache lazily when GLTF data is unavailable.
+
+5. **Lifecycle Management**
+   - Dispose geometry/material in a cleanup `useEffect` to prevent leaks.
+   - Clamp `instanceCount` to the filled slot count and keep mesh `visible = filledCount > 0` for free culling.
+
+## Data Flow
+
+```
+CPU (ships, throttle)
+   │
+   │ useFrame (delta, time)
+   ├─► spawn loop → typed arrays (position/velocity/lifetime/scale/spawnTime)
+   │               └─ updates InstancedBufferAttributes (DynamicDrawUsage)
+   │
+   └─► shader uniform update (`uTime`)
+
+GPU vertex shader
+   ├─ reads instanced attributes
+   ├─ computes age = uTime - spawnTime
+   ├─ calculates position = spawnPos + velocity * age
+   └─ sets scale & fade for fragment shader
+```
+
+## Interfaces & Contracts
+
+```ts
+export interface ParticleTrailResources {
+  geometry: InstancedBufferGeometry;
+  material: ShaderMaterial;
+  attributes: {
+    spawnPosition: InstancedBufferAttribute;
+    velocity: InstancedBufferAttribute;
+    spawnTime: InstancedBufferAttribute;
+    lifetime: InstancedBufferAttribute;
+    scale: InstancedBufferAttribute;
+  };
+  arrays: {
+    spawnPosition: Float32Array;
+    velocity: Float32Array;
+    spawnTime: Float32Array;
+    lifetime: Float32Array;
+    scale: Float32Array;
+  };
+}
+
+export function createParticleTrailResources(
+  maxParticles: number,
+  config: Pick<ParticleTrailsConfig, 'size' | 'color' | 'opacity' | 'additiveBlending' | 'depthTest' | 'depthWrite'>,
+): ParticleTrailResources;
+```
+
+Component contract adjustments:
+- `ParticleTrails` accepts optional `resources?: ParticleTrailResources` (primarily for tests) and still renders nothing when `PARTICLE_TRAILS_CONFIG.enabled` is false.
+
+## Error Handling Matrix
+
+| Scenario | Detection | Response | Notes |
+| --- | --- | --- | --- |
+| GLTF scene missing or bounds zero | `makeAnchors` receives `null` | Return empty anchors; fallback heuristic populates cache lazily | Matches current behavior, avoids crashes |
+| Geometry allocation failure | Factory throws | Propagate error (surface during development); component unmounts cleanly | Low risk, but documented |
+| Spawn ring saturation | `filledCount` reaches `maxParticles` | Continue overwriting oldest particles (ring buffer) while keeping `instanceCount = maxParticles` | Matches previous pool semantics |
+| Negative throttle or invalid config | Throttle check + clamps | Skip spawning, leave existing particles unaffected | Prevents NaN velocities |
+
+## Testing Strategy
+
+- **Unit/Vitest (`test/vitest/particle-trails-gpu.spec.tsx`):**
+  - Assert `createParticleTrailResources` builds instanced attributes sized to config `maxParticles`.
+  - Mount `ParticleTrails` with injected resources, mock `useFrame`, and drive a frame where a fighter throttles above `minThrottle`; verify the ring buffer records spawn data and increments `instanceCount` deterministically.
+  - Advance successive frames to confirm `uTime` uniform updates monotonically without CPU pool iteration.
+- **Regression:** Run `npx tsc --noEmit` and `npm test` locally.
+- **Manual (optional):** Inspect large fleet scene to confirm visual continuity (document in reflection if executed).
+
+## Work Plan
+
+1. Publish requirements (done) and this design; register TASK246 with subtasks covering implementation, testing, and documentation updates.
+2. Implement GPU resource factory, refactor `ParticleTrails` to consume it, add optional `resources` prop, and wire deterministic spawner + shader.
+3. Add Vitest coverage with mocked `useFrame`/`useGLTF` leveraging injected resources.
+4. Run validation commands (`npx tsc --noEmit`, `npm test`), capture results.
+5. Update task progress log, note reflections/technical debt, and prepare PR summary referencing this design.
+
+## Risks & Mitigations
+
+- **Risk:** Shader mistakes could yield invisible particles. *Mitigation:* Keep shader minimal, verify alpha fade logic in tests, and expose color/opacity uniforms for debugging.*
+- **Risk:** Remainder map growth if ships churn rapidly. *Mitigation:* Clean stale map entries when ships array omits prior keys (e.g., prune each frame for absent ships).
+- **Risk:** Tests might fail due to actual Three.js constructors executing. *Mitigation:* Use real classes but inject resources, mocking only `useFrame`/`useGLTF` similar to existing component tests.
+
+## Open Questions
+
+- Should trail color/opacity become uniforms configurable per faction? (Out of scope; note as potential enhancement.)
+- Would a compute-based approach outperform instanced attributes for >10k particles? (Candidate for future research.)
+
+## References
+
+- `src/components/ParticleTrails.tsx` (current CPU pool implementation).
+- `src/config/renderer.ts` (trail configuration constants).
+- `docs/reports/v0.1.4b/high-impact-ideas.md` (motivation for GPU migration).
+- `memory/tasks/TASK006-instanced-particles-explosions.md` (related instancing work).

--- a/memory/requirements.md
+++ b/memory/requirements.md
@@ -1,3 +1,9 @@
+## 2025-10-06 — Thruster Trail GPU Migration (TASK246)
+
+1. **WHEN** the `ParticleTrails` component initialises with GPU buffers enabled, **THE SYSTEM SHALL** allocate an `InstancedBufferGeometry` populated with spawn position, velocity, lifetime, and scale attributes sized to `PARTICLE_TRAILS_CONFIG.maxParticles`. *(Acceptance: `test/vitest/particle-trails-gpu.spec.tsx` mounts the component with injected resources and asserts each instanced attribute exists with the configured length.)*
+2. **WHEN** a ship's thrust command meets or exceeds the configured minimum throttle during a render frame, **THE SYSTEM SHALL** write the ship's thruster spawn data into the GPU instanced attribute ring buffer using deterministic jitter so the geometry `instanceCount` increases and spawn arrays record the emission timestamp. *(Acceptance: the same Vitest spec advances a frame with a thrusting fighter and verifies the ring buffer slot stores the expected spawn time while `instanceCount` increments.)*
+3. **WHEN** the render loop advances, **THE SYSTEM SHALL** update the shader time uniform on each frame so GPU-driven fading derives from the current clock value without CPU-side particle iteration. *(Acceptance: the Vitest spec drives successive frames and confirms the material `uTime` uniform tracks the clock time monotonically.)*
+
 ## 2025-10-05 — Ship LOD Visibility Regression
 
 1. **WHEN** a ship crosses the configured near/far threshold because either its transform or the active camera position changed, **THE SYSTEM SHALL** recompute the LOD partition within the next render frame so full hull meshes mount for near ships. *(Acceptance: `test/components/lod/ShipLODManager.spec.ts` verifies the new partition refresh helper promotes ships to the near cohort after a simulated camera move.)*

--- a/memory/tasks/TASK246-thruster-trails-gpu.md
+++ b/memory/tasks/TASK246-thruster-trails-gpu.md
@@ -1,0 +1,44 @@
+# [TASK246] - Thruster trail GPU buffer migration
+
+**Status:** In Progress
+**Added:** 2025-10-06
+**Updated:** 2025-10-06
+
+## Original Request
+
+Move thruster trails to GPU-managed buffers. The current particle trail system preloads all GLTFs, clones vectors for every spawn, and iterates a large particle pool on the CPU each frame, which will bottleneck large fleet scenarios. Replacing the pool with instanced buffer attributes (e.g., InstancedBufferGeometry with shader-driven fading) or a compute/transform feedback approach would shift the workload to the GPU and cut allocations, improving scalability.
+
+## Thought Process
+
+- CPU-based pool writes every particle transform each frame and clones vectors, so scaling to thousands of trails is wasteful.
+- GPU instancing only needs spawn metadata; shader time uniform can animate positions and fading, removing CPU hot loop.
+- Deterministic jitter remains important for reproducibility; leverage `SeededRng` and spawn remainder accumulators for smooth emission.
+- Tests must confirm geometry/material composition and ensure shader time uniform updates without CPU iteration.
+
+## Implementation Plan
+
+- Author EARS requirements (done) and DESIGN003 detailing GPU resource factory, ring buffer, shader, and testing strategy.
+- Refactor `ParticleTrails` to consume GPU resources, expose optional resource injection for tests, and implement deterministic spawn logic.
+- Add Vitest coverage validating resource shape, spawn writes, and uniform updates; mock `useFrame`/`useGLTF` similarly to StarDisk tests.
+- Run `npx tsc --noEmit` and `npm test`, document results, and update memory bank progress plus reflections.
+
+## Progress Tracking
+
+**Overall Status:** In Progress - 80%
+
+### Subtasks
+
+| ID  | Description                                                      | Status     | Updated     | Notes |
+| --- | ---------------------------------------------------------------- | ---------- | ----------- | ----- |
+| 1.1 | Publish requirements and DESIGN003, register TASK246             | Completed  | 2025-10-06  | Requirements + design added to memory bank |
+| 1.2 | Implement GPU resource factory and refactor `ParticleTrails`     | Completed  | 2025-10-06  | GPU instancing, shader, and deterministic spawning implemented |
+| 1.3 | Add Vitest coverage for GPU trails and deterministic spawning    | Completed  | 2025-10-06  | Added `particle-trails-gpu.spec.tsx` with spawn/uniform assertions |
+| 1.4 | Run validation, document reflections, and prep PR summary        | In Progress| 2025-10-06  | Type-check + tests running; documentation/summary pending |
+
+## Progress Log
+
+### 2025-10-06
+
+- Logged TASK246, captured requirements, and produced DESIGN003 outlining GPU instancing approach, shader logic, and testing plan.
+- Replaced CPU particle pool with GPU instanced buffers, deterministic spawner, and shader-driven fading in `ParticleTrails.tsx`; exported resource factory for tests.
+- Added `particle-trails-gpu.spec.tsx` and updated `thruster-glow.spec.ts` to assert GPU pipeline integration; ran `npx tsc --noEmit` and full `npm test` suite.

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -6,6 +6,7 @@ This index tracks active tasks and their memory files. Use the `/memory/tasks` f
 
 ## In Progress
 
+- [TASK246](TASK246-thruster-trails-gpu.md) — Move thruster trails to GPU-managed instanced buffers for scalable rendering. (In Progress — design published, implementation pending) (2025-10-06)
 - [TASK245](TASK245-ship-hull-visibility.md) — Restore ship hull visibility by refreshing LOD partitioning after instancing refactor. (In Progress — requirements/design in flight) (2025-10-05)
 
 - [TASK240](TASK240-rings-bloomOnly.md) — Add `rings.bloomOnly` config flag and create follow-up wiring/tests tasks. (In Progress — wiring & tests remaining) (2025-10-03)

--- a/src/components/ParticleTrails.tsx
+++ b/src/components/ParticleTrails.tsx
@@ -1,62 +1,221 @@
 import React, { useRef, useMemo, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { 
-  InstancedMesh, 
-  SphereGeometry, 
-  MeshBasicMaterial, 
-  Vector3, 
+import {
+  SphereGeometry,
+  Vector3,
   Color,
-  Object3D,
   Box3,
+  Mesh,
+  InstancedBufferGeometry,
+  InstancedBufferAttribute,
+  ShaderMaterial,
+  DynamicDrawUsage,
+  AdditiveBlending,
 } from 'three';
-import type { ShipEntity } from '../types/index.js';
-import { THRUSTER_GLOW_CONFIG, PARTICLE_TRAILS_CONFIG } from '../config/renderer.js';
 import { useGLTF } from '@react-three/drei';
 import type { GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { SHIP_MODEL_PATHS } from '../assets/ships.js';
+import type { ShipEntity } from '../types/index.js';
 import type { ShipHull } from '../types/index.js';
+import { THRUSTER_GLOW_CONFIG, PARTICLE_TRAILS_CONFIG } from '../config/renderer.js';
+import type { ParticleTrailsConfig } from '../config/renderer.js';
+import { SeededRng } from '../utils/rng.js';
 
 interface ParticleTrailProps {
   ships: ShipEntity[];
+  /** Optional GPU resources for testing */
+  resources?: ParticleTrailResources;
 }
 
-interface Particle {
-  position: Vector3;
-  velocity: Vector3;
-  life: number;
-  maxLife: number;
-  scale: number;
-  shipId: number;
+const TRAIL_RNG_SEED = 0x54524149; // 'TRAI'
+
+export interface ParticleTrailResources {
+  geometry: InstancedBufferGeometry;
+  material: ShaderMaterial;
+  attributes: {
+    spawnPosition: InstancedBufferAttribute;
+    velocity: InstancedBufferAttribute;
+    spawnTime: InstancedBufferAttribute;
+    lifetime: InstancedBufferAttribute;
+    scale: InstancedBufferAttribute;
+  };
+  arrays: {
+    spawnPosition: Float32Array;
+    velocity: Float32Array;
+    spawnTime: Float32Array;
+    lifetime: Float32Array;
+    scale: Float32Array;
+  };
+}
+
+function createTrailMaterial(
+  config: Pick<ParticleTrailsConfig, 'color' | 'opacity' | 'additiveBlending' | 'depthTest' | 'depthWrite'>,
+): ShaderMaterial {
+  const color = new Color(config.color || THRUSTER_GLOW_CONFIG.defaultEmissiveColor);
+
+  const material = new ShaderMaterial({
+    uniforms: {
+      uTime: { value: 0 },
+      uColor: { value: color },
+      uOpacity: { value: config.opacity },
+    },
+    transparent: true,
+    depthTest: config.depthTest,
+    depthWrite: config.depthWrite,
+    vertexShader: /* glsl */ `
+      attribute vec3 instanceSpawnPosition;
+      attribute vec3 instanceVelocity;
+      attribute float instanceSpawnTime;
+      attribute float instanceLifetime;
+      attribute float instanceScale;
+
+      uniform float uTime;
+
+      varying float vFade;
+
+      void main() {
+        float age = max(uTime - instanceSpawnTime, 0.0);
+        float lifeRatio = clamp(1.0 - age / max(instanceLifetime, 1e-6), 0.0, 1.0);
+        float scale = instanceScale * lifeRatio;
+        vec3 worldPosition = instanceSpawnPosition + instanceVelocity * age + position * scale;
+        vFade = lifeRatio;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(worldPosition, 1.0);
+      }
+    `,
+    fragmentShader: /* glsl */ `
+      uniform vec3 uColor;
+      uniform float uOpacity;
+
+      varying float vFade;
+
+      void main() {
+        float alpha = uOpacity * vFade;
+        if (alpha <= 0.001) {
+          discard;
+        }
+        gl_FragColor = vec4(uColor, alpha);
+      }
+    `,
+  });
+
+  if (config.additiveBlending) {
+    material.blending = AdditiveBlending;
+  }
+
+  return material;
+}
+
+export function createParticleTrailResources(
+  maxParticles: number,
+  config: Pick<ParticleTrailsConfig, 'size' | 'color' | 'opacity' | 'additiveBlending' | 'depthTest' | 'depthWrite'>,
+): ParticleTrailResources {
+  const baseGeometry = new SphereGeometry(config.size, 6, 4);
+  const geometry = new InstancedBufferGeometry();
+  const positionAttribute = baseGeometry.getAttribute('position');
+  geometry.setAttribute('position', positionAttribute.clone());
+  const normalAttribute = baseGeometry.getAttribute('normal');
+  if (normalAttribute) {
+    geometry.setAttribute('normal', normalAttribute.clone());
+  }
+  const uvAttribute = baseGeometry.getAttribute('uv');
+  if (uvAttribute) {
+    geometry.setAttribute('uv', uvAttribute.clone());
+  }
+  const index = baseGeometry.getIndex();
+  if (index) {
+    geometry.setIndex(index.clone());
+  }
+  baseGeometry.dispose();
+  geometry.instanceCount = 0;
+
+  const spawnPositionArray = new Float32Array(maxParticles * 3);
+  const velocityArray = new Float32Array(maxParticles * 3);
+  const spawnTimeArray = new Float32Array(maxParticles);
+  const lifetimeArray = new Float32Array(maxParticles);
+  const scaleArray = new Float32Array(maxParticles);
+
+  const spawnPosition = new InstancedBufferAttribute(spawnPositionArray, 3);
+  spawnPosition.setUsage(DynamicDrawUsage);
+  const velocity = new InstancedBufferAttribute(velocityArray, 3);
+  velocity.setUsage(DynamicDrawUsage);
+  const spawnTime = new InstancedBufferAttribute(spawnTimeArray, 1);
+  spawnTime.setUsage(DynamicDrawUsage);
+  const lifetime = new InstancedBufferAttribute(lifetimeArray, 1);
+  lifetime.setUsage(DynamicDrawUsage);
+  const scale = new InstancedBufferAttribute(scaleArray, 1);
+  scale.setUsage(DynamicDrawUsage);
+
+  geometry.setAttribute('instanceSpawnPosition', spawnPosition);
+  geometry.setAttribute('instanceVelocity', velocity);
+  geometry.setAttribute('instanceSpawnTime', spawnTime);
+  geometry.setAttribute('instanceLifetime', lifetime);
+  geometry.setAttribute('instanceScale', scale);
+  geometry.computeBoundingSphere();
+
+  const material = createTrailMaterial(config);
+
+  return {
+    geometry,
+    material,
+    attributes: {
+      spawnPosition,
+      velocity,
+      spawnTime,
+      lifetime,
+      scale,
+    },
+    arrays: {
+      spawnPosition: spawnPositionArray,
+      velocity: velocityArray,
+      spawnTime: spawnTimeArray,
+      lifetime: lifetimeArray,
+      scale: scaleArray,
+    },
+  };
 }
 
 /**
  * Simple particle trail system for ship thrusters.
  * Spawns small particles from ship thruster anchors that fade out over time.
  */
-export function ParticleTrails({ ships }: ParticleTrailProps): React.ReactElement {
-  // Early out if globally disabled via config
+export function ParticleTrails({ ships, resources }: ParticleTrailProps): React.ReactElement {
   if (!PARTICLE_TRAILS_CONFIG.enabled) return <></>;
-  const meshRef = useRef<InstancedMesh>(null);
-  // Build an initial particle pool synchronously so the first useFrame never sees an empty array.
-  const initialParticles = useMemo<Particle[]>(
-    () =>
-      Array.from({ length: PARTICLE_TRAILS_CONFIG.maxParticles }, () => ({
-        position: new Vector3(),
-        velocity: new Vector3(),
-        life: 0,
-        maxLife: PARTICLE_TRAILS_CONFIG.lifetime,
-        scale: 0,
-        shipId: 0,
-      })),
-    []
-  );
-  const particlesRef = useRef<Particle[]>(initialParticles);
-  const nextParticleIndex = useRef(0);
-  const dummy = useMemo(() => new Object3D(), []);
-  const tmpVec = useMemo(() => new Vector3(), []);
 
-  // Preload GLTFs for all hulls and compute local anchors from real model bounds.
-  // These hooks are unconditional to satisfy the Rules of Hooks.
+  const meshRef = useRef<Mesh<InstancedBufferGeometry, ShaderMaterial>>(null);
+  const nextParticleIndex = useRef(0);
+  const filledCount = useRef(0);
+  const rngRef = useRef(new SeededRng(TRAIL_RNG_SEED));
+  const spawnRemainders = useRef<Map<number, number[]>>(new Map());
+  const anchorCache = useRef<Map<number, Vector3[]>>(new Map());
+  const backward = useMemo(() => new Vector3(), []);
+
+  const ownsResources = resources == null;
+  const trailResources = useMemo(() => {
+    if (resources) return resources;
+    return createParticleTrailResources(PARTICLE_TRAILS_CONFIG.maxParticles, {
+      size: PARTICLE_TRAILS_CONFIG.size,
+      color: PARTICLE_TRAILS_CONFIG.color || THRUSTER_GLOW_CONFIG.defaultEmissiveColor,
+      opacity: PARTICLE_TRAILS_CONFIG.opacity,
+      additiveBlending: PARTICLE_TRAILS_CONFIG.additiveBlending,
+      depthTest: PARTICLE_TRAILS_CONFIG.depthTest,
+      depthWrite: PARTICLE_TRAILS_CONFIG.depthWrite,
+    });
+  }, [resources]);
+
+  useEffect(() => {
+    if (!ownsResources) return;
+    return () => {
+      trailResources.geometry.dispose();
+      trailResources.material.dispose();
+    };
+  }, [ownsResources, trailResources]);
+
+  useEffect(() => {
+    if (meshRef.current) {
+      meshRef.current.visible = false;
+    }
+  }, []);
+
   const gltfFighter = useGLTF(SHIP_MODEL_PATHS.fighter) as GLTF;
   const gltfCorvette = useGLTF(SHIP_MODEL_PATHS.corvette) as GLTF;
   const gltfFrigate = useGLTF(SHIP_MODEL_PATHS.frigate) as GLTF;
@@ -66,7 +225,6 @@ export function ParticleTrails({ ships }: ParticleTrailProps): React.ReactElemen
   const anchorLocalsByHull = useMemo(() => {
     const makeAnchors = (gltf: GLTF | null, hull: ShipHull): Vector3[] => {
       if (!gltf?.scene) return [];
-      // Compute bounding box from the GLTF scene (local space)
       gltf.scene.updateMatrixWorld(true);
       const box = new Box3().setFromObject(gltf.scene);
       const size = box.getSize(new Vector3());
@@ -74,7 +232,8 @@ export function ParticleTrails({ ships }: ParticleTrailProps): React.ReactElemen
       const tailZ = box.min.z - THRUSTER_GLOW_CONFIG.tailOffset * size.z;
       const anchors: Vector3[] = [];
       for (let i = 0; i < count; i++) {
-        let x = 0, y = 0;
+        let x = 0;
+        let y = 0;
         if (count === 2) {
           x = (i === 0 ? -1 : 1) * 0.3 * size.x;
         } else if (count === 4) {
@@ -97,145 +256,159 @@ export function ParticleTrails({ ships }: ParticleTrailProps): React.ReactElemen
       ['carrier', makeAnchors(gltfCarrier, 'carrier')],
     ]);
   }, [gltfFighter, gltfCorvette, gltfFrigate, gltfDestroyer, gltfCarrier]);
-  
-  const geometry = useMemo(() => new SphereGeometry(PARTICLE_TRAILS_CONFIG.size, 6, 4), []);
-  const material = useMemo(() => {
-    const m = new MeshBasicMaterial({
-      color: new Color(PARTICLE_TRAILS_CONFIG.color || THRUSTER_GLOW_CONFIG.defaultEmissiveColor),
-      transparent: true,
-      opacity: PARTICLE_TRAILS_CONFIG.opacity,
-      depthTest: PARTICLE_TRAILS_CONFIG.depthTest,
-      depthWrite: PARTICLE_TRAILS_CONFIG.depthWrite,
-    });
-    if (PARTICLE_TRAILS_CONFIG.additiveBlending) {
-      // Lazy import enum to avoid direct dependency; numeric value is fine too, but use property if available
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (m as any).blending = 2; // AdditiveBlending
-    }
-    return m;
-  }, []);
-
-  // Ensure pool stays in sync if config changes (unlikely at runtime but safe).
-  useEffect(() => {
-    if (particlesRef.current.length !== PARTICLE_TRAILS_CONFIG.maxParticles) {
-      particlesRef.current = Array.from({ length: PARTICLE_TRAILS_CONFIG.maxParticles }, () => ({
-        position: new Vector3(),
-        velocity: new Vector3(),
-        life: 0,
-        maxLife: PARTICLE_TRAILS_CONFIG.lifetime,
-        scale: 0,
-        shipId: 0,
-      }));
-      nextParticleIndex.current = 0;
-    }
-  }, []);
 
   const computeThrusterAnchorsWorld = (ship: ShipEntity): Vector3[] => {
     const locals = anchorLocalsByHull.get(ship.ship.hull);
+    const cache = anchorCache.current;
+    const desiredCount = locals && locals.length > 0 ? locals.length : THRUSTER_GLOW_CONFIG.anchorsByHull[ship.ship.hull] || 1;
+    let anchors = cache.get(ship.id);
+    if (!anchors || anchors.length !== desiredCount) {
+      anchors = Array.from({ length: desiredCount }, () => new Vector3());
+      cache.set(ship.id, anchors);
+    }
+
     if (!locals || locals.length === 0) {
-      // Fallback to heuristic anchors if GLTF not yet ready
-      const count = THRUSTER_GLOW_CONFIG.anchorsByHull[ship.ship.hull] || 1;
-      const anchors: Vector3[] = [];
       const shipSize = { x: 2, y: 1, z: 3 };
       const tailZ = -shipSize.z * PARTICLE_TRAILS_CONFIG.tailZFactor;
-      for (let i = 0; i < count; i++) {
-        let x = 0, y = 0;
-        if (count === 2) x = (i === 0 ? -1 : 1) * 0.3 * shipSize.x;
-        else if (count === 4) { x = (i % 2 === 0 ? -1 : 1) * 0.25 * shipSize.x; y = (i < 2 ? -1 : 1) * 0.15 * shipSize.y; }
-        else if (count === 6) { x = (i % 2 === 0 ? -1 : 1) * 0.35 * shipSize.x; y = (Math.floor(i / 2) - 1) * 0.2 * shipSize.y; }
-        anchors.push(new Vector3(x, y, tailZ)
+      for (let i = 0; i < desiredCount; i++) {
+        let x = 0;
+        let y = 0;
+        if (desiredCount === 2) {
+          x = (i === 0 ? -1 : 1) * 0.3 * shipSize.x;
+        } else if (desiredCount === 4) {
+          x = (i % 2 === 0 ? -1 : 1) * 0.25 * shipSize.x;
+          y = (i < 2 ? -1 : 1) * 0.15 * shipSize.y;
+        } else if (desiredCount === 6) {
+          x = (i % 2 === 0 ? -1 : 1) * 0.35 * shipSize.x;
+          y = (Math.floor(i / 2) - 1) * 0.2 * shipSize.y;
+        }
+
+        anchors[i]
+          .set(x, y, tailZ)
           .multiplyScalar(ship.transform.scale)
           .applyQuaternion(ship.transform.rotation)
-          .add(ship.transform.position));
+          .add(ship.transform.position);
       }
       return anchors;
     }
-    // Transform local anchors to world using ship transform and scale
-    const out: Vector3[] = new Array(locals.length);
+
     for (let i = 0; i < locals.length; i++) {
-      out[i] = tmpVec.clone()
+      anchors[i]
         .copy(locals[i])
         .multiplyScalar(ship.transform.scale)
         .applyQuaternion(ship.transform.rotation)
         .add(ship.transform.position);
     }
-    return out;
+
+    return anchors;
   };
 
   useFrame((state, delta) => {
-    if (!meshRef.current) return;
+    const mesh = meshRef.current;
+    if (!mesh) return;
 
-    const particles = particlesRef.current;
-    if (!particles || particles.length === 0) return;
-    let activeCount = 0;
+    const time = state.clock.getElapsedTime();
+    trailResources.material.uniforms.uTime.value = time;
 
-    // Update existing particles
-    for (let i = 0; i < particles.length; i++) {
-      const particle = particles[i];
-      
-      if (particle.life <= 0) continue;
-      
-      particle.life -= delta;
-      particle.position.add(particle.velocity.clone().multiplyScalar(delta));
-      
-      if (particle.life > 0) {
-        const lifeRatio = particle.life / particle.maxLife;
-        const scale = particle.scale * lifeRatio;
-        
-        dummy.position.copy(particle.position);
-        dummy.scale.setScalar(scale);
-        dummy.updateMatrix();
-        
-        meshRef.current.setMatrixAt(activeCount, dummy.matrix);
-        activeCount++;
-      }
-    }
+    const spawnRatePerAnchor = PARTICLE_TRAILS_CONFIG.spawnRatePerAnchor;
+    const minThrottle = PARTICLE_TRAILS_CONFIG.minThrottle;
+    const backwardMin = PARTICLE_TRAILS_CONFIG.backwardSpeed.min;
+    const backwardMax = PARTICLE_TRAILS_CONFIG.backwardSpeed.max;
+    const lateralJitter = PARTICLE_TRAILS_CONFIG.lateralJitter;
+    const longitudinalJitter = PARTICLE_TRAILS_CONFIG.longitudinalJitter;
+    const scaleJitter = PARTICLE_TRAILS_CONFIG.scaleJitter;
+    const lifetimeBase = PARTICLE_TRAILS_CONFIG.lifetime;
+    const maxParticles = PARTICLE_TRAILS_CONFIG.maxParticles;
 
-    // Spawn new particles from thrusting ships
+    const activeShipIds = new Set<number>();
+    let spawnedThisFrame = false;
+
     for (const ship of ships) {
+      activeShipIds.add(ship.id);
       const throttle = ship.ai?.command?.thrust ?? 0;
-      if (throttle < PARTICLE_TRAILS_CONFIG.minThrottle) continue; // Only spawn when thrusting
-      
-  const anchors = computeThrusterAnchorsWorld(ship);
-  const spawnRate = throttle * PARTICLE_TRAILS_CONFIG.spawnRatePerAnchor; // Particles/s per anchor
-  const shouldSpawn = Math.random() < spawnRate * delta;
-      
-      if (shouldSpawn) {
-        for (const anchor of anchors) {
-          const idx = nextParticleIndex.current % particles.length;
-          const particle = particles[idx];
-          nextParticleIndex.current = (nextParticleIndex.current + 1) % PARTICLE_TRAILS_CONFIG.maxParticles;
-          
-          if (!particle) continue;
-          particle.position.copy(anchor);
-          
-          // Random velocity backwards from ship with some spread
-          const backward = new Vector3(0, 0, -1).applyQuaternion(ship.transform.rotation);
-          const speed = PARTICLE_TRAILS_CONFIG.backwardSpeed.min + Math.random() * (PARTICLE_TRAILS_CONFIG.backwardSpeed.max - PARTICLE_TRAILS_CONFIG.backwardSpeed.min);
-          particle.velocity.copy(backward).multiplyScalar(speed)
-            .add(new Vector3(
-              (Math.random() - 0.5) * 2 * PARTICLE_TRAILS_CONFIG.lateralJitter,
-              (Math.random() - 0.5) * 2 * PARTICLE_TRAILS_CONFIG.lateralJitter,
-              (Math.random() - 0.5) * 2 * PARTICLE_TRAILS_CONFIG.longitudinalJitter
-            ));
+      if (throttle < minThrottle) continue;
 
-          particle.life = PARTICLE_TRAILS_CONFIG.lifetime * (1 - PARTICLE_TRAILS_CONFIG.scaleJitter + Math.random() * 2 * PARTICLE_TRAILS_CONFIG.scaleJitter);
-          particle.maxLife = particle.life;
-          particle.scale = 1 - PARTICLE_TRAILS_CONFIG.scaleJitter + Math.random() * 2 * PARTICLE_TRAILS_CONFIG.scaleJitter;
-          particle.shipId = ship.id;
+      const anchors = computeThrusterAnchorsWorld(ship);
+      if (anchors.length === 0) continue;
+
+      const remainderForShip = (() => {
+        const existing = spawnRemainders.current.get(ship.id);
+        if (existing && existing.length === anchors.length) {
+          return existing;
+        }
+        const arr = new Array<number>(anchors.length).fill(0);
+        spawnRemainders.current.set(ship.id, arr);
+        return arr;
+      })();
+
+      for (let i = 0; i < anchors.length; i++) {
+        const anchor = anchors[i];
+        const rate = throttle * spawnRatePerAnchor;
+        const desired = rate * delta + remainderForShip[i];
+        const spawnCount = Math.floor(desired);
+        remainderForShip[i] = desired - spawnCount;
+        if (spawnCount <= 0) continue;
+        spawnedThisFrame = true;
+
+        for (let spawnIndex = 0; spawnIndex < spawnCount; spawnIndex++) {
+          const idx = nextParticleIndex.current;
+          const base3 = idx * 3;
+
+          trailResources.arrays.spawnPosition[base3] = anchor.x;
+          trailResources.arrays.spawnPosition[base3 + 1] = anchor.y;
+          trailResources.arrays.spawnPosition[base3 + 2] = anchor.z;
+
+          backward.set(0, 0, -1).applyQuaternion(ship.transform.rotation);
+          const speed = backwardMin + rngRef.current.next() * (backwardMax - backwardMin);
+          const jitterX = (rngRef.current.next() - 0.5) * 2 * lateralJitter;
+          const jitterY = (rngRef.current.next() - 0.5) * 2 * lateralJitter;
+          const jitterZ = (rngRef.current.next() - 0.5) * 2 * longitudinalJitter;
+
+          trailResources.arrays.velocity[base3] = backward.x * speed + jitterX;
+          trailResources.arrays.velocity[base3 + 1] = backward.y * speed + jitterY;
+          trailResources.arrays.velocity[base3 + 2] = backward.z * speed + jitterZ;
+
+          const lifetimeJitter = 1 - scaleJitter + rngRef.current.next() * 2 * scaleJitter;
+          trailResources.arrays.lifetime[idx] = lifetimeBase * lifetimeJitter;
+          trailResources.arrays.spawnTime[idx] = time;
+          trailResources.arrays.scale[idx] = 1 - scaleJitter + rngRef.current.next() * 2 * scaleJitter;
+
+          nextParticleIndex.current = (nextParticleIndex.current + 1) % maxParticles;
+          if (filledCount.current < maxParticles) {
+            filledCount.current++;
+          }
         }
       }
     }
 
-    // Update the instanced mesh
-    meshRef.current.count = activeCount;
-    meshRef.current.instanceMatrix.needsUpdate = true;
+    for (const [shipId] of spawnRemainders.current) {
+      if (!activeShipIds.has(shipId)) {
+        spawnRemainders.current.delete(shipId);
+      }
+    }
+    for (const [shipId] of anchorCache.current) {
+      if (!activeShipIds.has(shipId)) {
+        anchorCache.current.delete(shipId);
+      }
+    }
+
+    if (spawnedThisFrame) {
+      trailResources.attributes.spawnPosition.needsUpdate = true;
+      trailResources.attributes.velocity.needsUpdate = true;
+      trailResources.attributes.spawnTime.needsUpdate = true;
+      trailResources.attributes.lifetime.needsUpdate = true;
+      trailResources.attributes.scale.needsUpdate = true;
+    }
+
+    trailResources.geometry.instanceCount = filledCount.current;
+    mesh.visible = filledCount.current > 0;
   });
 
   return (
-    <instancedMesh
+    <mesh
       ref={meshRef}
-      args={[geometry, material, PARTICLE_TRAILS_CONFIG.maxParticles]}
+      geometry={trailResources.geometry}
+      material={trailResources.material}
       frustumCulled={false}
     />
   );

--- a/test/vitest/particle-trails-gpu.spec.tsx
+++ b/test/vitest/particle-trails-gpu.spec.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { Vector3, Quaternion } from 'three';
+import type { ShipEntity } from '../../src/types/index.js';
+import { ParticleTrails, createParticleTrailResources } from '../../src/components/ParticleTrails.js';
+import { PARTICLE_TRAILS_CONFIG } from '../../src/config/renderer.js';
+
+const frameCallbacks: Array<(state: { clock: { getElapsedTime: () => number } }, delta: number) => void> = [];
+
+vi.mock('@react-three/fiber', () => ({
+  useFrame: (callback: (state: { clock: { getElapsedTime: () => number } }, delta: number) => void) => {
+    frameCallbacks.push(callback);
+  },
+}));
+
+vi.mock('@react-three/drei', () => ({
+  useGLTF: () => ({ scene: null }),
+}));
+
+afterEach(() => {
+  cleanup();
+  frameCallbacks.length = 0;
+  vi.clearAllMocks();
+});
+
+function createTestShip(thrust: number): ShipEntity {
+  const ship = {
+    id: 1,
+    transform: {
+      position: new Vector3(),
+      rotation: new Quaternion(),
+      scale: 1,
+    },
+    rigidBody: {} as unknown,
+    collider: {} as unknown,
+    ship: {
+      team: 'blue',
+      hull: 'fighter',
+      hp: 1,
+      maxHp: 1,
+      shield: 0,
+      maxShield: 0,
+      cooldown: 0,
+      fireRate: 0,
+      damage: 0,
+      projectileSpeed: 0,
+      range: 0,
+      speed: 0,
+      xp: 0,
+      level: 1,
+      xpToNext: 1,
+      damageType: 'kinetic',
+      levelBonuses: {} as unknown,
+      subsystems: {} as unknown,
+      armor: 0,
+      velocity: new Vector3(),
+      angularVelocity: new Vector3(),
+      motion: {
+        mass: 1,
+        maxSpeed: 1,
+        linearAcceleration: 1,
+        linearDamping: 1,
+        maxTurnRate: 1,
+        angularAcceleration: 1,
+        angularDamping: 1,
+      },
+    },
+    ai: { command: { thrust } },
+  };
+
+  return ship as unknown as ShipEntity;
+}
+
+function runLatestFrame(time: number, delta: number): void {
+  const callback = frameCallbacks[frameCallbacks.length - 1];
+  expect(typeof callback).toBe('function');
+  callback?.({ clock: { getElapsedTime: () => time } }, delta);
+}
+
+describe('ParticleTrails GPU buffers', () => {
+  it('creates instanced attributes sized to configuration', () => {
+    const resources = createParticleTrailResources(32, {
+      size: PARTICLE_TRAILS_CONFIG.size,
+      color: PARTICLE_TRAILS_CONFIG.color,
+      opacity: PARTICLE_TRAILS_CONFIG.opacity,
+      additiveBlending: PARTICLE_TRAILS_CONFIG.additiveBlending,
+      depthTest: PARTICLE_TRAILS_CONFIG.depthTest,
+      depthWrite: PARTICLE_TRAILS_CONFIG.depthWrite,
+    });
+
+    expect(resources.geometry.instanceCount).toBe(0);
+    expect(resources.arrays.spawnPosition).toHaveLength(32 * 3);
+    expect(resources.arrays.velocity).toHaveLength(32 * 3);
+    expect(resources.arrays.spawnTime).toHaveLength(32);
+    expect(resources.arrays.lifetime).toHaveLength(32);
+    expect(resources.arrays.scale).toHaveLength(32);
+    expect(resources.attributes.spawnPosition.itemSize).toBe(3);
+    expect(resources.attributes.spawnTime.itemSize).toBe(1);
+  });
+
+  it('writes spawn data into GPU buffers when ships thrust', () => {
+    const resources = createParticleTrailResources(16, {
+      size: PARTICLE_TRAILS_CONFIG.size,
+      color: PARTICLE_TRAILS_CONFIG.color,
+      opacity: PARTICLE_TRAILS_CONFIG.opacity,
+      additiveBlending: PARTICLE_TRAILS_CONFIG.additiveBlending,
+      depthTest: PARTICLE_TRAILS_CONFIG.depthTest,
+      depthWrite: PARTICLE_TRAILS_CONFIG.depthWrite,
+    });
+
+    render(<ParticleTrails ships={[createTestShip(1)]} resources={resources} />);
+
+    runLatestFrame(0.5, 0.1);
+
+    expect(resources.geometry.instanceCount).toBeGreaterThanOrEqual(1);
+    expect(resources.arrays.spawnTime[0]).toBeCloseTo(0.5, 6);
+    expect(resources.arrays.velocity[0]).not.toBe(0);
+    expect(Math.abs(resources.arrays.spawnPosition[2])).toBeGreaterThan(0);
+  });
+
+  it('updates shader time uniform every frame', () => {
+    const resources = createParticleTrailResources(4, {
+      size: PARTICLE_TRAILS_CONFIG.size,
+      color: PARTICLE_TRAILS_CONFIG.color,
+      opacity: PARTICLE_TRAILS_CONFIG.opacity,
+      additiveBlending: PARTICLE_TRAILS_CONFIG.additiveBlending,
+      depthTest: PARTICLE_TRAILS_CONFIG.depthTest,
+      depthWrite: PARTICLE_TRAILS_CONFIG.depthWrite,
+    });
+
+    render(<ParticleTrails ships={[createTestShip(0)]} resources={resources} />);
+
+    runLatestFrame(1.0, 0.016);
+    const first = resources.material.uniforms.uTime.value as number;
+    expect(first).toBeCloseTo(1.0, 6);
+
+    runLatestFrame(1.25, 0.016);
+    const second = resources.material.uniforms.uTime.value as number;
+    expect(second).toBeGreaterThan(first);
+  });
+});

--- a/test/vitest/thruster-glow.spec.ts
+++ b/test/vitest/thruster-glow.spec.ts
@@ -68,8 +68,10 @@ describe('Thruster glow enhancement', () => {
     
     // Check for particle system functionality
     expect(txt).toContain('ParticleTrails');
-    expect(txt).toContain('InstancedMesh');
-    expect(txt).toContain('computeThrusterAnchors');
+    expect(txt).toContain('createParticleTrailResources');
+    expect(txt).toContain('InstancedBufferGeometry');
+    expect(txt).toContain('ShaderMaterial');
+    expect(txt).toContain('computeThrusterAnchorsWorld');
     expect(txt).toContain('throttle');
     
     // Check it's integrated in Battlefield


### PR DESCRIPTION
## Summary
- replace the ParticleTrails CPU pool with GPU instanced buffers, shader-driven fading, and deterministic spawn bookkeeping so engine exhaust scales on the GPU【F:src/components/ParticleTrails.tsx†L1-L414】
- expose reusable particle trail resources with optional injection for tests and refresh thruster glow expectations for the GPU pipeline【F:src/components/ParticleTrails.tsx†L32-L208】【F:test/vitest/thruster-glow.spec.ts†L1-L78】
- add GPU particle trail Vitest coverage plus requirements, design, and task tracking updates for TASK246【F:test/vitest/particle-trails-gpu.spec.tsx†L1-L142】【F:memory/requirements.md†L1-L5】【F:memory/designs/DESIGN003-thruster-trails-gpu.md†L1-L151】【F:memory/tasks/TASK246-thruster-trails-gpu.md†L1-L38】

## Testing
- `npx tsc --noEmit`【81352b†L1-L2】
- `npm test`【a41cdd†L1-L13】

------
https://chatgpt.com/codex/tasks/task_e_68e39bf8f5ec832a98443ec5f889b668