### PR TITLE
Fix beam visuals to reach targets

### DIFF
--- a/src/game/systems/projectiles.ts
+++ b/src/game/systems/projectiles.ts
@@ -336,6 +336,7 @@ export function fireProjectile(
     (opts?.override?.damage ?? origin.ship.damage) *
     getEffectiveStats(origin.ship).damageMultiplier;
   const range = opts?.override?.range ?? origin.ship.range;
+  const resolvedRange = Number.isFinite(range ?? NaN) ? Math.max(range as number, 0) : 0;
   const beamConfig = category === 'beam' ? getProjectileBeamConfig(bulletKey) : undefined;
   const lifetime =
     category === 'beam'
@@ -378,6 +379,11 @@ export function fireProjectile(
       );
     }
 
+    const maxLength = Math.max(beamLength, actualLength, resolvedRange);
+    if (actualLength > maxLength) {
+      actualLength = maxLength;
+    }
+
     const invRotation = TEMP_INV_ROT.copy(origin.transform.rotation).invert();
     const localOrigin = startPosition
       .clone()
@@ -410,7 +416,7 @@ export function fireProjectile(
           maxTtl: beamTtl,
           width: beamWidth,
           length: actualLength,
-          maxLength: beamLength,
+          maxLength,
           fade: beamConfig.fade,
           bulletType: bulletKey,
           sourceId: origin.id,
@@ -434,7 +440,7 @@ export function fireProjectile(
       ttl: beamConfig.ttl,
       width: beamConfig.width,
       length: beamConfig.length,
-      maxLength: beamConfig.length,
+      maxLength: Math.max(beamConfig.length, resolvedRange),
       fade: beamConfig.fade,
       worldOffset: beamWorldOffset.clone(),
     };

--- a/test/vitest/beam-visuals.spec.ts
+++ b/test/vitest/beam-visuals.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { Vector3 } from 'three';
+import { createGameState, disposeGameState } from '../../src/game/state.js';
+import { spawnShip } from '../../src/game/ships.js';
+import { fireProjectile } from '../../src/game/systems/projectiles.js';
+import { flushPostPhysicsMutations } from '../../src/game/simulationQueue.js';
+import type { BeamVisualEntity, GameState, ShipEntity } from '../../src/types/index.js';
+
+async function setupState(): Promise<{
+  state: GameState;
+  shooter: ShipEntity;
+  target: ShipEntity;
+}> {
+  const state = await createGameState();
+  const shooter = spawnShip(state, {
+    hull: 'fighter',
+    team: 'blue',
+    position: new Vector3(0, 0, 0),
+    heading: 0,
+  });
+  const target = spawnShip(state, {
+    hull: 'fighter',
+    team: 'red',
+    position: new Vector3(0, 0, 200),
+    heading: Math.PI,
+  });
+  return { state, shooter, target };
+}
+
+describe('beam visuals', () => {
+  it('extend visuals to the actual engagement distance', async () => {
+    const { state, shooter, target } = await setupState();
+    try {
+      const direction = target.transform.position
+        .clone()
+        .sub(shooter.transform.position)
+        .normalize();
+
+      fireProjectile(state, shooter, direction, {
+        targetId: target.id,
+        projectileCategory: 'beam',
+      });
+
+      flushPostPhysicsMutations(state);
+
+      const visuals = state.queries.beamVisuals.entities as BeamVisualEntity[];
+      expect(visuals).toHaveLength(1);
+
+      const beam = visuals[0];
+
+      const muzzleOffset = shooter.transform.scale * 1.6;
+      const expectedLength =
+        target.transform.position.clone().sub(shooter.transform.position).length() - muzzleOffset;
+
+      expect(beam.beamVisual.length).toBeGreaterThan(60);
+      expect(beam.beamVisual.length).toBeCloseTo(expectedLength, 3);
+      expect(beam.beamVisual.maxLength).toBeGreaterThanOrEqual(shooter.ship.range);
+    } finally {
+      disposeGameState(state);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- ensure beam projectile visuals use the greater of their configured length, actual hit distance, or weapon range
- add a regression test confirming beam beams stretch across long engagements

## Testing
- npx prettier --check src/game/systems/projectiles.ts test/vitest/beam-visuals.spec.ts
- npm run lint
- npx tsc --noEmit
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68efa7992918832ab30258f353afe0b2