### PR TITLE
refactor: remove legacy AI fallback path

### DIFF
--- a/docs/tech-debt-report.md
+++ b/docs/tech-debt-report.md
@@ -16,6 +16,7 @@ post_date: '2025-10-26'
 ---
 
 <!-- markdownlint-disable-next-line MD041 -->
+
 ## Overview
 
 This report documents five high-value tech debt or legacy compatibility paths in the SpaceAutoBattler codebase. Each item includes a severity rating (0–100%), estimated effort, rationale, and suggested next steps. Ratings reflect expected maintenance risk or cost if the debt remains.
@@ -30,13 +31,13 @@ This report documents five high-value tech debt or legacy compatibility paths in
 
 ## Candidate Summary
 
-| Item | Rating (%) | Effort | Snapshot |
-| --- | ---: | --- | --- |
-| Legacy AI fallback (`runLegacyShipBehavior`) | 85 | L (≥3d) | Old steering path remains shipped alongside AI v2 and is still exercised in tests. |
-| JSX compatibility shims (`jsx-shim.d.ts`, `jsx-compat.d.ts`) | 70 | M (1–2d) | Temporary React 19 typing workarounds disable intrinsic element safety. |
-| Miniplex legacy event adapters (`useArchetypeEntities`) | 60 | M (1–2d) | Hook maintains dual subscription APIs despite standardising on Miniplex v2. |
-| Renderer smoothing legacy fallback (`legacyFrameDt`) | 55 | M (1–2d) | Interpolation still maps new time-constant stats into deprecated per-frame lerp values. |
-| Unused Pixi dependency (`pixi.js`) | 45 | S (≤0.5d) | Heavy dependency remains in `package.json` but is only mocked in tests. |
+| Item                                                         | Rating (%) | Effort    | Snapshot                                                                                |
+| ------------------------------------------------------------ | ---------: | --------- | --------------------------------------------------------------------------------------- |
+| Legacy AI fallback (`runLegacyShipBehavior`)                 |         85 | L (≥3d)   | Old steering path remains shipped alongside AI v2 and is still exercised in tests.      |
+| JSX compatibility shims (`jsx-shim.d.ts`, `jsx-compat.d.ts`) |         70 | M (1–2d)  | Temporary React 19 typing workarounds disable intrinsic element safety.                 |
+| Miniplex legacy event adapters (`useArchetypeEntities`)      |         60 | M (1–2d)  | Hook maintains dual subscription APIs despite standardising on Miniplex v2.             |
+| Renderer smoothing legacy fallback (`legacyFrameDt`)         |         55 | M (1–2d)  | Interpolation still maps new time-constant stats into deprecated per-frame lerp values. |
+| Unused Pixi dependency (`pixi.js`)                           |         45 | S (≤0.5d) | Heavy dependency remains in `package.json` but is only mocked in tests.                 |
 
 ## Findings
 
@@ -52,6 +53,7 @@ This report documents five high-value tech debt or legacy compatibility paths in
   - Remove the `runLegacyShipBehavior` branch from `prepareShips` and `executeAICommand`, delete the function, and rewrite regression specs to target AI v2 toggles instead of legacy logic.
   - Add a guard in configuration to throw or log when the UI attempts to disable AI v2 after removal.
 - **Dependencies & risks:** Requires migrating or deleting several Vitest suites (`ai-regression`, `ai-metrics`) that currently rely on the fallback. Coordinated QA sign-off needed before removal.
+- **Update (2025-10-26):** AI v2 is now enforced; the legacy fallback was removed, UI toggles ignore disable requests, and Vitest suites target the v2 command path exclusively.
 
 ### JSX compatibility shims (`jsx-shim.d.ts`, `jsx-compat.d.ts`)
 

--- a/memory/designs/DESIGN005-legacy-ai-fallback-removal.md
+++ b/memory/designs/DESIGN005-legacy-ai-fallback-removal.md
@@ -1,0 +1,53 @@
+# DESIGN005 — Remove Legacy AI Fallback Path
+
+## Summary
+
+Retire the `runLegacyShipBehavior` steering branch so all ships execute the AI v2 command pipeline. Harden configuration and UI glue so disabling AI v2 is no longer possible, while keeping harnesses deterministic and metrics intact.
+
+## Requirements
+
+1. **WHEN** `prepareShips` runs each tick, **THE SYSTEM SHALL** drive every ship with an AI component through `executeAICommand`, regardless of UI toggle state. _(Acceptance: vitest exercises `prepareShips` after forcing the UI toggle off and asserts the ship still advances using its AI command.)_
+2. **WHEN** a caller attempts to disable AI v2 via the UI store or configuration flags, **THE SYSTEM SHALL** keep AI enabled and emit a single warning explaining the ignore. _(Acceptance: vitest clicks the HUD "AI V2" toggle and asserts `console.warn` plus the store flag staying `true`; environment override coverage via unit shim.)_
+3. **WHEN** `executeAICommand` encounters a ship missing its AI component, **THE SYSTEM SHALL** log an error, keep the ship stationary for that tick, and return `null` without throwing. _(Acceptance: vitest constructs a ship without `ai`, calls `executeAICommand`, and verifies translation is frozen alongside the logged error.)_
+4. **WHEN** ships fire using AI v2 commands, **THE SYSTEM SHALL** continue recording first-shot telemetry and range metrics exactly once per firing event. _(Acceptance: existing `ai-metrics.spec.ts` `records shot telemetry via executeAICommand` remains green without legacy helpers.)_
+
+## Architecture & Interfaces
+
+- **`src/game/systems/shipControl.ts`**
+  - Remove `runLegacyShipBehavior` export and associated helper logic.
+  - Introduce a module-scoped guard (`warnedAiDisable`) to re-enable `state.ai.enabled` whenever it becomes `false`, logging a single warning.
+  - Update `executeAICommand` to handle missing `ship.ai` by logging a structured error and re-queuing the ship's current transform through `deferSetNextKinematicTranslation`/`Rotation`.
+- **`src/game/systems.ts`**
+  - Drop legacy export from `__aiTestHooks` and main bundle imports.
+- **`src/game/config.ts`**
+  - Force `AI_CONFIG.v2Enabled` to `true`, capturing environment attempts to disable it with a console warning.
+- **UI Glue (`src/game/uiStore.ts`, `src/components/hudToggleConfig.ts`, `src/game/context.tsx`)**
+  - Guard `toggleAiV2`/`setAiV2Enabled` so attempts to set `false` restore `true` and warn once.
+  - Ensure `GameProvider` mirrors the locked-on flag back into `GameState.ai.enabled` (defensive) without relying on consumer toggles.
+
+## Data Flow
+
+1. UI toggles attempt to flip `aiV2Enabled` → store rejects false writes, logs warning, remains `true`.
+2. GameProvider effect mirrors the store flag → no change (remains `true`), ensuring simulation `GameState.ai.enabled` stays active.
+3. Simulation tick (`prepareShips`) sees `state.ai.enabled` true → executes `executeAICommand` for each ship.
+4. `executeAICommand` moves ships, fires projectiles, and records metrics. Missing AI components short-circuit with a logged error but keep physics stable by re-scheduling their current transform.
+
+## Error Handling Matrix
+
+| Condition                        | Detection                                | Response                                                                 |
+| -------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------ |
+| UI store toggles AI V2 off       | `toggleAiV2` sees requested `false`      | Emit `console.warn` once, keep `aiV2Enabled = true`                      |
+| Environment variable disables AI | Config loader sees `AI_V2_DEFAULT=false` | Emit `console.warn` once, force runtime default to `true`                |
+| Ship lacks `ai` component        | `executeAICommand` receives `undefined`  | Log `console.error`, keep ship stationary by mirroring current transform |
+
+## Testing Strategy
+
+- Extend `test/vitest/ai-regression.spec.ts` to validate the disable guard and stationary behavior when AI is missing.
+- Update `test/vitest/ui-settings-panels.spec.tsx` to expect the AI toggle warning and sticky `true` value.
+- Remove legacy-specific assertions from `test/vitest/ai-metrics.spec.ts` while retaining telemetry coverage for the v2 path.
+- Adjust mocked exports in `test/vitest/update-game-panic.spec.ts` and smoke import lists to match the new API surface.
+- Run `npm run lint`, `npx tsc --noEmit`, and `npm test` to satisfy repository policy.
+
+## Open Questions
+
+- Do any scenario harness fixtures intentionally remove `ship.ai`? Current plan treats it as an error but keeps simulation deterministic. Future work could promote this into validation that enforces component integrity earlier in the spawn pipeline.

--- a/memory/requirements.md
+++ b/memory/requirements.md
@@ -129,7 +129,7 @@
 ## 2025-09-28 — AI metrics resilience
 
 1. **WHEN** `aggregateKpis` processes recorded first-shot timestamps, **THE SYSTEM SHALL** compute percentile outputs using the floor of `(n - 1) * p` so `p50` reflects the earliest timestamp at or above the target fraction and `p90` remains bounded by the next sampled time. _(Acceptance: `test/vitest/ai-metrics.spec.ts` expects `p50 = 18` and `p90 = 32` for the curated dataset.)_
-2. **WHEN** AI command execution runs inside lightweight harnesses without a full Rapier runtime, **THE SYSTEM SHALL** surface shim implementations for `RigidBodyDesc`, `ColliderDesc`, and physics world hooks so `fireProjectile` executes without throwing while still emitting projectile entities. _(Acceptance: `test/vitest/ai-metrics.spec.ts` covers `executeAICommand` and `runLegacyShipBehavior` in the shimmed state.)_
+2. **WHEN** AI command execution runs inside lightweight harnesses without a full Rapier runtime, **THE SYSTEM SHALL** surface shim implementations for `RigidBodyDesc`, `ColliderDesc`, and physics world hooks so `fireProjectile` executes without throwing while still emitting projectile entities. _(Acceptance: `test/vitest/ai-metrics.spec.ts` covers `executeAICommand` in the shimmed state now that the legacy fallback has been removed.)_
 3. **WHEN** `runAIScenario` completes a deterministic simulation, **THE SYSTEM SHALL** append a metrics snapshot to the exported log, including KPI summaries, first-shot times, histograms, and intent timeline data. _(Acceptance: scenario fixtures in `test/vitest/ai-scenario-harness.spec.ts` assert the serialized metrics payload.)_
 
 ## 2025-09-28 — Renderer Performance Audit Report

--- a/memory/tasks/TASK251-remove-legacy-ai-fallback.md
+++ b/memory/tasks/TASK251-remove-legacy-ai-fallback.md
@@ -1,0 +1,43 @@
+# TASK251 - Remove legacy AI fallback path
+
+**Status:** Completed
+**Added:** 2025-10-26
+**Updated:** 2025-10-26
+
+## Original Request
+
+Retire the `runLegacyShipBehavior` pathway called out in the tech-debt report so the simulation always uses AI v2. Publish a supporting design and execution plan in the Memory Bank and implement the removal end-to-end.
+
+## Thought Process
+
+- The fallback currently powers UI toggles, metrics harness tests, and panic mocks; removing it demands coordinated updates.
+- Disabling AI v2 should become impossible, so the UI store, context, and configuration must all harden against `false` values.
+- Tests need to pivot from legacy parity to verifying the guardrails and AI v2 telemetry behaviour.
+
+## Implementation Plan
+
+- [x] Record requirements and DESIGN005 detailing architecture changes, guard strategy, and validation scope.
+- [x] Update configuration/UI glue so `aiV2Enabled` cannot become `false` (store guards, HUD toggle expectations, context mirror).
+- [x] Remove `runLegacyShipBehavior` from `shipControl`, `systems`, and downstream consumers; add logging when AI state is missing.
+- [x] Refresh Vitest suites (`ai-regression`, `ai-metrics`, `ui-settings-panels`, `update-game-panic`, helpers) to reflect the v2-only path.
+- [x] Run linting, type-checking, and unit tests; update Memory Bank status before hand-off.
+
+## Progress Tracking
+
+**Overall Status:** Completed — 100%
+
+### Subtasks
+
+| ID  | Description                                                               | Status    | Updated    | Notes                                                   |
+| --- | ------------------------------------------------------------------------- | --------- | ---------- | ------------------------------------------------------- |
+| 1.1 | Land DESIGN005 capturing requirements, data flow, and guard behaviour     | Completed | 2025-10-26 | Authored DESIGN005 with requirements + testing strategy |
+| 1.2 | Enforce AI v2 enablement across config, UI store, and context             | Completed | 2025-10-26 | Guarded toggles, context mirror, and config defaults    |
+| 1.3 | Delete legacy ship behaviour and harden `executeAICommand` error handling | Completed | 2025-10-26 | Removed fallback and added stationary safeguard         |
+| 1.4 | Update Vitest coverage and mocks for the new API surface                  | Completed | 2025-10-26 | Updated specs and mocks for v2-only execution           |
+| 1.5 | Execute validation commands and document completion                       | Completed | 2025-10-26 | Ran lint, type-check, and unit tests                    |
+
+## Progress Log
+
+- 2025-10-26: Logged TASK251 and drafted DESIGN005 describing how to remove the fallback and guard AI enablement.
+- 2025-10-26: Hardened AI enablement across config, store, and context; removed `runLegacyShipBehavior` and added missing-AI safeguards.
+- 2025-10-26: Updated Vitest suites, refreshed the tech-debt report entry, and ran repository validation commands.

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -18,6 +18,7 @@ This index tracks active tasks and their memory files. Use the `/memory/tasks` f
 
 - [TASK247](TASK247-version2-vision.md) — Authored Version 2.0 vision document outlining pillars, feature concepts, and validation plans. (2025-10-13)
 - [TASK250](TASK250-tech-debt-report.md) — Documented legacy cleanup opportunities with ratings/effort and validated build/tests. (2025-10-26)
+- [TASK251](TASK251-remove-legacy-ai-fallback.md) — Removed the legacy AI fallback, enforced AI V2 enablement, and updated tests. (2025-10-26)
 - [TASK242](TASK242-lint-compliance.md) - Restore lint compliance across config, hooks, and effect updaters. (2025-10-03)
 
 - [TASK241](TASK241-motion-pd-tuning.md) — Reduce AI bobbing with hull-specific motion tuning and documentation. (2025-10-03)

--- a/src/game/config.ts
+++ b/src/game/config.ts
@@ -62,7 +62,17 @@ function readStringParam(name: string, defaultValue: string): string {
   return query || defaultValue;
 }
 
-const DEFAULT_AI_V2 = readBooleanEnv('AI_V2_DEFAULT', true);
+const REQUESTED_AI_V2_DEFAULT = readBooleanEnv('AI_V2_DEFAULT', true);
+const DEFAULT_AI_V2 = true;
+if (!REQUESTED_AI_V2_DEFAULT && typeof globalThis !== 'undefined') {
+  try {
+    globalThis.console?.warn?.(
+      'AI v2 fallback has been removed; ignoring AI_V2_DEFAULT=false and forcing v2 on.',
+    );
+  } catch {
+    // ignore logging failures
+  }
+}
 const TICK_RATE_BASE = 12;
 
 // Tick rate experiment flags

--- a/src/game/context.tsx
+++ b/src/game/context.tsx
@@ -5,6 +5,17 @@ import { createGameState, disposeGameState, spawnInitialFleets } from './state.j
 import { updateGame } from './systems.js';
 import { mirrorHudHealthBarsFlag, useUiStore } from './uiStore.js';
 
+let warnedAiDisableContext = false;
+function warnAiDisableInContext(): void {
+  if (warnedAiDisableContext) return;
+  warnedAiDisableContext = true;
+  try {
+    globalThis.console?.warn?.('AI v2 disable attempts are ignored in the simulation context.');
+  } catch {
+    // ignore logging failures
+  }
+}
+
 interface GameContextValue {
   state: GameState | null;
 }
@@ -39,7 +50,7 @@ export function GameProvider({ children, fallback = null }: GameProviderProps): 
             (window as unknown as { __SAB?: any }).__SAB = {
               getCounts: () => ({
                 ships: created.queries.ships.entities.length,
-                projectiles: created.queries.projectiles.entities.length
+                projectiles: created.queries.projectiles.entities.length,
               }),
               sampleShipMotion: () => {
                 try {
@@ -55,25 +66,33 @@ export function GameProvider({ children, fallback = null }: GameProviderProps): 
                         team: ship?.team ?? null,
                         hull: ship?.hull ?? null,
                         position: transform
-                          ? { x: transform.position.x, y: transform.position.y, z: transform.position.z }
+                          ? {
+                              x: transform.position.x,
+                              y: transform.position.y,
+                              z: transform.position.z,
+                            }
                           : { x: 0, y: 0, z: 0 },
                         rotation: transform
                           ? {
                               x: transform.rotation.x,
                               y: transform.rotation.y,
                               z: transform.rotation.z,
-                              w: transform.rotation.w
+                              w: transform.rotation.w,
                             }
                           : { x: 0, y: 0, z: 0, w: 1 },
                         velocity: ship
                           ? { x: ship.velocity.x, y: ship.velocity.y, z: ship.velocity.z }
                           : { x: 0, y: 0, z: 0 },
                         angularVelocity: ship
-                          ? { x: ship.angularVelocity.x, y: ship.angularVelocity.y, z: ship.angularVelocity.z }
+                          ? {
+                              x: ship.angularVelocity.x,
+                              y: ship.angularVelocity.y,
+                              z: ship.angularVelocity.z,
+                            }
                           : { x: 0, y: 0, z: 0 },
-                        lateralAcceleration: ship?.lateralAcceleration ?? 0
+                        lateralAcceleration: ship?.lateralAcceleration ?? 0,
                       };
-                    })
+                    }),
                   };
                 } catch {
                   return { tick: created.simulation.lastTickIndex, time: created.time, ships: [] };
@@ -93,7 +112,10 @@ export function GameProvider({ children, fallback = null }: GameProviderProps): 
                   const key = '__sabAutoTick__';
                   const w = window as any;
                   if (w[key]) return; // already running
-                  w[key] = setInterval(() => updateGame(created, dt), Math.max(1, Math.round(dt * 1000)));
+                  w[key] = setInterval(
+                    () => updateGame(created, dt),
+                    Math.max(1, Math.round(dt * 1000)),
+                  );
                 } catch {
                   /* ignore */
                 }
@@ -109,7 +131,7 @@ export function GameProvider({ children, fallback = null }: GameProviderProps): 
                 } catch {
                   /* ignore */
                 }
-              }
+              },
             };
           }
         }
@@ -143,7 +165,18 @@ export function GameProvider({ children, fallback = null }: GameProviderProps): 
 
   useEffect(() => {
     if (!state?.ai) return;
-    state.ai.enabled = aiV2Enabled;
+    if (!aiV2Enabled) {
+      warnAiDisableInContext();
+      try {
+        const store = useUiStore.getState();
+        if (!store.aiV2Enabled) {
+          store.setAiV2Enabled(true);
+        }
+      } catch {
+        // ignore store sync failures
+      }
+    }
+    state.ai.enabled = true;
   }, [state, aiV2Enabled]);
 
   useEffect(() => {
@@ -152,9 +185,7 @@ export function GameProvider({ children, fallback = null }: GameProviderProps): 
   }, [state, hudHealthBarsEnabled]);
 
   return (
-    <GameContext.Provider value={{ state }}>
-      {state ? children : fallback}
-    </GameContext.Provider>
+    <GameContext.Provider value={{ state }}>{state ? children : fallback}</GameContext.Provider>
   );
 }
 
@@ -178,4 +209,3 @@ export function useOptionalGameState(): GameState | null {
   }
   return context.state;
 }
-

--- a/src/game/systems.ts
+++ b/src/game/systems.ts
@@ -21,7 +21,7 @@ import {
   writeCommand,
   computeInterceptHeadingVector,
 } from './systems/decision/intents.js';
-import { prepareShips, executeAICommand, runLegacyShipBehavior } from './systems/shipControl.js';
+import { prepareShips, executeAICommand } from './systems/shipControl.js';
 import { fireProjectile, advanceProjectiles } from './systems/projectiles.js';
 import { findNearestEnemy, updateTurrets } from './systems/turrets.js';
 import { resolveProjectiles } from './systems/damage.js';
@@ -111,7 +111,6 @@ export const __aiTestHooks = {
   computeLod,
   writeCommand,
   prepareShips,
-  runLegacyShipBehavior,
   computeInterceptHeadingVector,
   executeAICommand,
 };

--- a/src/game/systems/shipControl.ts
+++ b/src/game/systems/shipControl.ts
@@ -11,15 +11,65 @@ import {
   deferSetNextKinematicRotation,
 } from '../physics/safeKinematics.js';
 
-const FORWARD = new Vector3(0, 0, 1);
 const TEMP_DIR = new Vector3();
 const TEMP_POS = new Vector3();
 const TEMP_REL_POS = new Vector3();
 const TEMP_QUAT = new Quaternion();
+const missingAiShips = new Set<number>();
+let warnedAiDisableInShips = false;
+
+function ensureAiEnabled(state: GameState): void {
+  if (state.ai) state.ai.enabled = true;
+  if (warnedAiDisableInShips) return;
+  warnedAiDisableInShips = true;
+  try {
+    globalThis.console?.warn?.('AI v2 fallback removed: forcing AI enabled for all ships.');
+  } catch {
+    // ignore logging failures in headless tests
+  }
+}
+
+function keepShipStationary(state: GameState, ship: ShipEntity): void {
+  const position = ship.transform.position;
+  deferSetNextKinematicTranslation(
+    state,
+    ship.rigidBody as unknown as KinematicBody,
+    position.x,
+    position.y,
+    position.z,
+  );
+  const rotation = ship.transform.rotation;
+  deferSetNextKinematicRotation(
+    state,
+    ship.rigidBody as unknown as KinematicBody,
+    rotation.x,
+    rotation.y,
+    rotation.z,
+    rotation.w,
+  );
+}
+
+function handleMissingAi(state: GameState, ship: ShipEntity): ShipEntity | null {
+  if (!missingAiShips.has(ship.id)) {
+    missingAiShips.add(ship.id);
+    try {
+      globalThis.console?.error?.(
+        `Ship ${ship.id} is missing an AI component; keeping it stationary.`,
+      );
+    } catch {
+      // ignore logging failures
+    }
+  }
+  keepShipStationary(state, ship);
+  return findNearestEnemy(state, ship);
+}
 
 export function prepareShips(state: GameState, delta: number): void {
   const ships = state.queries.ships.entities as ShipEntity[];
-  const useAIV2 = !!state.ai?.enabled;
+
+  if (state.ai && !state.ai.enabled) {
+    ensureAiEnabled(state);
+  }
 
   for (const ship of ships) {
     ship.ship.cooldown = Math.max(0, ship.ship.cooldown - delta);
@@ -36,13 +86,7 @@ export function prepareShips(state: GameState, delta: number): void {
       ship.ship.shield = Math.min(ship.ship.maxShield, ship.ship.shield + regen * delta);
     }
 
-    let preferredTarget: ShipEntity | null = null;
-
-    if (useAIV2 && ship.ai) {
-      preferredTarget = executeAICommand(state, ship, delta);
-    } else {
-      preferredTarget = runLegacyShipBehavior(state, ship, delta);
-    }
+    const preferredTarget = executeAICommand(state, ship, delta);
 
     if (state.queries.turrets.entities.length === 0 && ship.turrets && preferredTarget) {
       runEmbeddedTurrets(state, ship, preferredTarget);
@@ -61,7 +105,7 @@ export function executeAICommand(
   delta: number,
 ): ShipEntity | null {
   const ai = ship.ai;
-  if (!ai) return runLegacyShipBehavior(state, ship, delta);
+  if (!ai) return handleMissingAi(state, ship);
   const command = ai.command;
   command.ttl = Math.max(0, command.ttl - delta);
 
@@ -169,104 +213,6 @@ export function executeAICommand(
   }
 
   return target;
-}
-
-export function runLegacyShipBehavior(
-  state: GameState,
-  ship: ShipEntity,
-  delta: number,
-): ShipEntity | null {
-  const target = findNearestEnemy(state, ship);
-
-  if (!target) {
-    const p = ship.transform.position;
-    deferSetNextKinematicTranslation(
-      state,
-      ship.rigidBody as unknown as KinematicBody,
-      p.x,
-      p.y,
-      p.z,
-    );
-    return null;
-  }
-
-  const direction = TEMP_DIR.subVectors(target.transform.position, ship.transform.position);
-  const distance = direction.length();
-  if (distance > 0.0001) {
-    direction.normalize();
-  } else {
-    direction.set(0, 0, 1);
-  }
-
-  orientTowards(state, ship, direction);
-
-  if (distance > ship.ship.range * 0.6) {
-    const moveDistance = Math.min(
-      ship.ship.speed * delta,
-      Math.max(distance - ship.ship.range * 0.55, 0),
-    );
-    const nextPosition = TEMP_POS.copy(ship.transform.position).addScaledVector(
-      direction,
-      moveDistance,
-    );
-    clampToWorld(nextPosition);
-    deferSetNextKinematicTranslation(
-      state,
-      ship.rigidBody as unknown as KinematicBody,
-      nextPosition.x,
-      nextPosition.y,
-      nextPosition.z,
-    );
-  } else {
-    const p = ship.transform.position;
-    deferSetNextKinematicTranslation(
-      state,
-      ship.rigidBody as unknown as KinematicBody,
-      p.x,
-      p.y,
-      p.z,
-    );
-  }
-
-  if (distance <= ship.ship.range && ship.ship.cooldown <= 0) {
-    (ship.muzzleFlashes ??= []).push({
-      local: new Vector3(0, 0, ship.transform.scale * 1.6),
-      t0: state.time,
-      amp: 1,
-      bulletType: ship.ship.bulletType,
-    });
-    const metrics = state.ai?.metrics;
-    if (metrics && target) {
-      recordShotMetrics(metrics, {
-        shipId: ship.id,
-        hull: ship.ship.hull,
-        time: state.time,
-        distance,
-        deltaY: target.transform.position.y - ship.transform.position.y,
-      });
-    }
-    fireProjectile(state, ship, direction);
-    ship.ship.cooldown = ship.ship.fireRate;
-  }
-
-  return target;
-}
-
-export function orientTowards(state: GameState, ship: ShipEntity, direction: Vector3): void {
-  const rotation = new Quaternion().setFromUnitVectors(FORWARD, direction);
-  const bank = Math.max(Math.min(direction.x * 0.6, 0.6), -0.6);
-  const banking = new Quaternion().setFromAxisAngle(FORWARD, -bank);
-  rotation.multiply(banking);
-
-  ship.transform.rotation.copy(rotation);
-  deferSetNextKinematicRotation(
-    state,
-    ship.rigidBody as unknown as KinematicBody,
-    rotation.x,
-    rotation.y,
-    rotation.z,
-    rotation.w,
-  );
 }
 
 export function getShipById(state: GameState, id: number | undefined): ShipEntity | null {

--- a/src/game/uiStore.ts
+++ b/src/game/uiStore.ts
@@ -2,6 +2,17 @@ import { create } from 'zustand';
 import type { GameState } from '../types/index.js';
 import { AI_CONFIG } from './config.js';
 
+let warnedAiDisableToggle = false;
+function warnAiDisable(): void {
+  if (warnedAiDisableToggle) return;
+  warnedAiDisableToggle = true;
+  try {
+    globalThis.console?.warn?.('AI v2 cannot be disabled; ignoring toggle request.');
+  } catch {
+    // ignore logging issues in non-browser runtimes
+  }
+}
+
 export type UiState = {
   paused: boolean;
   timeScale: number; // 0.25x .. 4x typical
@@ -68,8 +79,22 @@ export const useUiStore = create<UiState>((set) => ({
   setPaused: (p: boolean) => set({ paused: p }),
   setTimeScale: (s: number) => set({ timeScale: Math.max(0, s) }),
   aiV2Enabled: AI_CONFIG.v2Enabled,
-  toggleAiV2: () => set((s) => ({ aiV2Enabled: !s.aiV2Enabled })),
-  setAiV2Enabled: (v: boolean) => set({ aiV2Enabled: v }),
+  toggleAiV2: () =>
+    set((s) => {
+      if (s.aiV2Enabled) {
+        warnAiDisable();
+        return { aiV2Enabled: true };
+      }
+      return { aiV2Enabled: true };
+    }),
+  setAiV2Enabled: (v: boolean) =>
+    set(() => {
+      if (!v) {
+        warnAiDisable();
+        return { aiV2Enabled: true };
+      }
+      return { aiV2Enabled: true };
+    }),
   aiDebugEnabled: false,
   toggleAiDebug: () => set((s) => ({ aiDebugEnabled: !s.aiDebugEnabled })),
   setAiDebugEnabled: (v: boolean) => set({ aiDebugEnabled: v }),

--- a/test/vitest/ai-metrics.spec.ts
+++ b/test/vitest/ai-metrics.spec.ts
@@ -18,7 +18,7 @@ import {
 } from '../../src/game/aiScenarioHarness.js';
 import type { AIState, GameState, ShipEntity } from '../../src/types/index.js';
 
-const { executeAICommand, runLegacyShipBehavior } = __aiTestHooks;
+const { executeAICommand } = __aiTestHooks;
 
 describe('AI metrics aggregation', () => {
   it('computes KPI summaries from recorded events', () => {
@@ -138,25 +138,6 @@ describe('AI metrics aggregation', () => {
     expect(metrics.firstShotTimes[0]).toBeCloseTo(state.time, 5);
     expect(metrics.shotDistanceHist.fighter.total).toBe(1);
     expect(metrics.shotDeltaYHist.fighter.total).toBe(1);
-  });
-
-  it('records shot telemetry through legacy behavior', () => {
-    const state = createStubState();
-    state.ai.enabled = false;
-    const ship = createStubShip(5, 'blue', new Vector3(0, 0, 0));
-    const target = createStubShip(6, 'red', new Vector3(100, -120, 0));
-    ship.ship.cooldown = 0;
-
-    const ships = state.queries.ships.entities as ShipEntity[];
-    ships.push(ship, target);
-
-    const result = runLegacyShipBehavior(state, ship, 0.1);
-    expect(result).toBe(target);
-
-    const metrics = state.ai.metrics;
-    expect(metrics.firstShotTimes).toHaveLength(1);
-    expect(metrics.firstShotByShip[ship.id]).toBeCloseTo(state.time, 5);
-    expect(metrics.shotDeltaYHist.fighter.total).toBeGreaterThan(0);
   });
 });
 

--- a/test/vitest/ai-regression.spec.ts
+++ b/test/vitest/ai-regression.spec.ts
@@ -1,12 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Quaternion, Vector3 } from 'three';
 import { applyProgressionDefaults } from './helpers/progression.js';
 import { createDefaultMotionStats } from '../../src/game/ships.js';
 import { __aiTestHooks } from '../../src/game/systems.js';
+import {
+  flushDeferredMutations,
+  flushPostPhysicsMutations,
+} from '../../src/game/simulationQueue.js';
 import { createDefaultMetrics } from '../../src/game/metrics.js';
 import type { GameState, ShipEntity } from '../../src/types/index.js';
 
-const { prepareShips, runLegacyShipBehavior } = __aiTestHooks;
+const { prepareShips, executeAICommand } = __aiTestHooks;
 
 function createRigidBodyRecorder() {
   let last = { x: 0, y: 0, z: 0 };
@@ -135,34 +139,56 @@ function createShip(id: number, team: 'blue' | 'red', position: Vector3) {
   return { ship, recorder };
 }
 
-describe('AI flag-off regression', () => {
-  it('matches legacy steering when AI V2 is disabled', () => {
-    const aiState = createState();
-    const legacyState = createState();
-    legacyState.ai.enabled = false;
+describe('AI v2 enforcement', () => {
+  it('forces AI enabled and still executes commands when the state flag is false', () => {
+    const state = createState();
+    state.ai.enabled = false;
 
-    const { ship: aiBlue, recorder: aiRecorder } = createShip(1, 'blue', new Vector3(0, 0, 0));
-    const { ship: aiRed } = createShip(2, 'red', new Vector3(120, 0, 0));
-    const { ship: legacyBlue, recorder: legacyRecorder } = createShip(
-      3,
-      'blue',
-      new Vector3(0, 0, 0),
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { ship: blue, recorder } = createShip(1, 'blue', new Vector3(0, 0, 0));
+    blue.ai!.command.thrust = 1;
+    blue.ai!.command.ttl = 1;
+    blue.ai!.command.heading.set(0, 0, 1);
+
+    const { ship: red } = createShip(2, 'red', new Vector3(150, 0, 0));
+    red.ai!.command.heading.set(0, 0, -1);
+
+    const ships = state.queries.ships.entities as unknown as ShipEntity[];
+    ships.splice(0, ships.length, blue, red);
+
+    prepareShips(state, 0.1);
+
+    flushDeferredMutations(state);
+    flushPostPhysicsMutations(state);
+
+    expect(state.ai.enabled).toBe(true);
+    expect(recorder.read()).toEqual({ x: 0, y: 0, z: 3 });
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});
+
+describe('Missing AI safeguards', () => {
+  it('logs an error and keeps the ship stationary when AI is missing', () => {
+    const state = createState();
+    const { ship, recorder } = createShip(5, 'blue', new Vector3(12, 0, -4));
+    delete (ship as { ai?: unknown }).ai;
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = executeAICommand(state, ship, 0.1);
+
+    flushDeferredMutations(state);
+    flushPostPhysicsMutations(state);
+
+    expect(result).toBeNull();
+    expect(recorder.read()).toEqual({ x: 12, y: 0, z: -4 });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Ship 5 is missing an AI component'),
     );
-    const { ship: legacyRed } = createShip(4, 'red', new Vector3(120, 0, 0));
 
-    delete (legacyBlue as { ai?: unknown }).ai;
-
-    const aiShips = aiState.queries.ships.entities as unknown as ShipEntity[];
-    aiShips.splice(0, aiShips.length, aiBlue, aiRed);
-    const legacyShips = legacyState.queries.ships.entities as unknown as ShipEntity[];
-    legacyShips.splice(0, legacyShips.length, legacyBlue, legacyRed);
-
-    prepareShips(aiState, 0.1);
-    const aiTranslation = aiRecorder.read();
-
-    runLegacyShipBehavior(legacyState, legacyBlue, 0.1);
-    const legacyTranslation = legacyRecorder.read();
-
-    expect(aiTranslation).toEqual(legacyTranslation);
+    errorSpy.mockRestore();
   });
 });

--- a/test/vitest/ui-settings-panels.spec.tsx
+++ b/test/vitest/ui-settings-panels.spec.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { SettingsDrawer } from '../../src/components/HudToggleDrawer.js';
@@ -50,7 +50,12 @@ describe('SettingsDrawer', () => {
     expect(useUiStore.getState().hudHealthBarsEnabled).toBe(true);
 
     const aiSwitch = screen.getByRole('switch', { name: 'AI V2' });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(aiSwitch.getAttribute('aria-checked')).toBe('true');
     fireEvent.click(aiSwitch);
-    expect(useUiStore.getState().aiV2Enabled).toBe(false);
+    expect(useUiStore.getState().aiV2Enabled).toBe(true);
+    expect(aiSwitch.getAttribute('aria-checked')).toBe('true');
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });

--- a/test/vitest/update-game-panic.spec.ts
+++ b/test/vitest/update-game-panic.spec.ts
@@ -28,7 +28,6 @@ vi.mock('../../src/game/systems/decision/intents.js', () => ({
 vi.mock('../../src/game/systems/shipControl.js', () => ({
   prepareShips: vi.fn(),
   executeAICommand: vi.fn(),
-  runLegacyShipBehavior: vi.fn(),
 }));
 vi.mock('../../src/game/systems/projectiles.js', () => ({
   fireProjectile: vi.fn(),


### PR DESCRIPTION
## Summary
- enforce AI v2 as the only execution path by deleting the legacy fallback and hardening config, store, and context guards
- refresh regression, metrics, and HUD toggle tests to validate the new guardrails while documenting the change in the tech-debt report and memory bank

## Testing
- npm run lint
- npm run typecheck
- npm test
- npx prettier --check docs/tech-debt-report.md memory/designs/DESIGN005-legacy-ai-fallback-removal.md memory/requirements.md memory/tasks/TASK251-remove-legacy-ai-fallback.md memory/tasks/_index.md src/game/config.ts src/game/context.tsx src/game/systems.ts src/game/systems/shipControl.ts src/game/uiStore.ts test/vitest/ai-metrics.spec.ts test/vitest/ai-regression.spec.ts test/vitest/ui-settings-panels.spec.tsx test/vitest/update-game-panic.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68fdec6cdbc0832a9c9bcde771e5bbf3