### PR TITLE
refactor: drop legacy ecs and renderer fallbacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "lodash": "^4.17.21",
         "lru-cache": "^11.2.2",
         "miniplex": "^2.0.0",
-        "pixi.js": "^8.14.0",
         "playwright": "^1.55.1",
         "postprocessing": "^6.37.8",
         "pyright": "^1.1.405",
@@ -2524,7 +2523,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2546,7 +2545,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2556,7 +2555,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2567,14 +2566,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2771,12 +2770,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@pixi/colord": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
-      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
-      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3394,12 +3387,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/css-font-loading-module": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
-      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
-      "license": "MIT"
-    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3421,12 +3408,6 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
       "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/earcut": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
-      "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
       "license": "MIT"
     },
     "node_modules/@types/eslint": {
@@ -3556,7 +3537,7 @@
       "version": "24.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.12.0"
@@ -3623,7 +3604,6 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4437,15 +4417,6 @@
         }
       }
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -4488,7 +4459,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -5176,7 +5147,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/bun-types": {
@@ -6044,7 +6015,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -6457,12 +6427,6 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/earcut": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
-      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
-      "license": "ISC"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -7877,22 +7841,13 @@
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
       "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/gifuct-js": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/gifuct-js/-/gifuct-js-2.1.2.tgz",
-      "integrity": "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==",
-      "license": "MIT",
-      "dependencies": {
-        "js-binary-schema-parser": "^2.0.3"
       }
     },
     "node_modules/github-slugger": {
@@ -9154,12 +9109,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
-    "node_modules/ismobilejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
-      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
-      "license": "MIT"
-    },
     "node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -9295,17 +9244,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.0.tgz",
       "integrity": "sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
-    },
-    "node_modules/js-binary-schema-parser": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/js-binary-schema-parser/-/js-binary-schema-parser-2.0.3.tgz",
-      "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==",
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -11368,12 +11311,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse-svg-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
-      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
-      "license": "MIT"
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -11515,35 +11452,6 @@
       "bin": {
         "pixelmatch": "bin/pixelmatch"
       }
-    },
-    "node_modules/pixi.js": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.14.0.tgz",
-      "integrity": "sha512-ituDiEBb1Oqx56RYwTtC6MjPUhPfF/i15fpUv5oEqmzC/ce3SaSumulJcOjKG7+y0J0Ekl9Rl4XTxaUw+MVFZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@pixi/colord": "^2.9.6",
-        "@types/css-font-loading-module": "^0.0.12",
-        "@types/earcut": "^3.0.0",
-        "@webgpu/types": "^0.1.40",
-        "@xmldom/xmldom": "^0.8.10",
-        "earcut": "^3.0.2",
-        "eventemitter3": "^5.0.1",
-        "gifuct-js": "^2.1.2",
-        "ismobilejs": "^1.1.1",
-        "parse-svg-path": "^0.1.2",
-        "tiny-lru": "^11.4.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
-      }
-    },
-    "node_modules/pixi.js/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -12453,7 +12361,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -13194,7 +13102,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -13213,7 +13121,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -13611,7 +13519,7 @@
       "version": "5.44.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
       "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -13665,7 +13573,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -13805,15 +13713,6 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tiny-lru": {
-      "version": "11.4.5",
-      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.4.5.tgz",
-      "integrity": "sha512-hkcz3FjNJfKXjV4mjQ1OrXSLAehg8Hw+cEZclOVT+5c/cWQWImQ9wolzTjth+dmmDe++p3bme3fTxz6Q4Etsqw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -14122,7 +14021,7 @@
       "version": "4.20.6",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.25.0",
@@ -14142,7 +14041,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14356,7 +14254,7 @@
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
       "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -15579,7 +15477,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "lodash": "^4.17.21",
     "lru-cache": "^11.2.2",
     "miniplex": "^2.0.0",
-    "pixi.js": "^8.14.0",
     "playwright": "^1.55.1",
     "postprocessing": "^6.37.8",
     "pyright": "^1.1.405",

--- a/scripts/generate-smoke-tests.mjs
+++ b/scripts/generate-smoke-tests.mjs
@@ -52,14 +52,13 @@ function ensureOutDir() {
 }
 
 function generate() {
-  const files = walk(srcDir).filter(f => !f.endsWith('.d.ts'));
+  const files = walk(srcDir).filter((f) => !f.endsWith('.d.ts'));
   ensureOutDir();
 
   // Heavily mocked modules to avoid pulling large/native deps during import.
   const heavyMocks = [
     'three',
     'postprocessing',
-    'pixi.js',
     'puppeteer',
     'playwright',
     '@dimforge/rapier3d-compat',
@@ -67,30 +66,32 @@ function generate() {
     'idb-keyval',
   ];
 
-  const imports = files.map(f => toImportPath(f));
+  const imports = files.map((f) => toImportPath(f));
 
-  const content = "import { describe, it, expect, vi } from 'vitest';\n\n" +
-    "// Auto-generated smoke test. Tries to import many project modules to increase\n" +
+  const content =
+    "import { describe, it, expect, vi } from 'vitest';\n\n" +
+    '// Auto-generated smoke test. Tries to import many project modules to increase\n' +
     "// coverage. We mock heavy external libs above so imports don't fail.\n\n" +
-    "// Mock heavy external deps at the top level\n" +
-    heavyMocks.map(m => `vi.mock('${m}', () => ({}));`).join('\n') + '\n\n' +
+    '// Mock heavy external deps at the top level\n' +
+    heavyMocks.map((m) => `vi.mock('${m}', () => ({}));`).join('\n') +
+    '\n\n' +
     `const modules = ${JSON.stringify(imports, null, 2)};\n\n` +
     "describe('smoke imports', () => {\n" +
-    "  for (const m of modules) {\n" +
+    '  for (const m of modules) {\n' +
     "    it('imports ' + m, async () => {\n" +
-    "      // dynamic import so mocking can be applied first\n" +
-    "      let ok = true;\n" +
-    "      try {\n" +
-    "        const mod = await import(m);\n" +
-    "        expect(mod).toBeTruthy();\n" +
-    "      } catch (err) {\n" +
-    "        ok = false;\n" +
+    '      // dynamic import so mocking can be applied first\n' +
+    '      let ok = true;\n' +
+    '      try {\n' +
+    '        const mod = await import(m);\n' +
+    '        expect(mod).toBeTruthy();\n' +
+    '      } catch (err) {\n' +
+    '        ok = false;\n' +
     "        console.warn('smoke import failed', m, err && err.message ? err.message : err);\n" +
-    "      }\n" +
-    "      expect(ok).toBe(true);\n" +
-    "    });\n" +
-    "  }\n" +
-    "});\n";
+    '      }\n' +
+    '      expect(ok).toBe(true);\n' +
+    '    });\n' +
+    '  }\n' +
+    '});\n';
 
   fs.writeFileSync(outFile, content, 'utf8');
   console.log('Wrote', outFile, `(${imports.length} modules)`);

--- a/src/config/renderer.ts
+++ b/src/config/renderer.ts
@@ -1,12 +1,12 @@
 import type { MotionStats, ShipHull } from '../types/index.js';
 
 export interface RendererMotionConfig {
-  /** Linear interpolation factor applied every render frame (0..1). */
-  positionLerp: number;
-  /** Spherical interpolation factor for rotation (0..1). */
-  rotationSlerp: number;
-  /** Low-pass filter factor for banking (0..1). */
-  bankLerp: number;
+  /** Position smoothing time-constant used as a fallback when hull config omits one. */
+  positionK: number;
+  /** Rotation smoothing time-constant used as a fallback when hull config omits one. */
+  rotationK: number;
+  /** Banking smoothing time-constant used as a fallback when hull config omits one. */
+  bankK: number;
   /** Maximum bank angle allowed for visuals (degrees). */
   maxBankDeg: number;
   /** Conversion factor from yaw rate (rad/s) to bank degrees. */
@@ -18,9 +18,9 @@ export interface RendererMotionConfig {
 }
 
 export const RENDERER_MOTION_DEFAULTS: RendererMotionConfig = {
-  positionLerp: 0.18,
-  rotationSlerp: 0.25,
-  bankLerp: 0.15,
+  positionK: 12.0,
+  rotationK: 30.0,
+  bankK: 18.0,
   maxBankDeg: 32,
   bankFactor: 18,
   teleportDistance: 30,
@@ -31,50 +31,17 @@ export const RENDERER_MOTION_DEFAULTS: RendererMotionConfig = {
 export const RENDERER_VISUAL_CONFIG = {
   // Master switch: when false, per-ship visual smoothing is disabled.
   enableShipVisualSmoothing: true,
-  // Canonical frame time to approximate legacy per-frame mapping (used only for migration/compat).
-  legacyFrameDt: 1 / 60,
 };
-
-function kToFrameLerp(
-  k: number | undefined,
-  frameDt = RENDERER_VISUAL_CONFIG.legacyFrameDt,
-): number {
-  if (!k || k <= 0) return 0;
-  return 1 - Math.exp(-k * frameDt);
-}
 
 export function resolveRendererMotionConfig(motion?: MotionStats): RendererMotionConfig {
   const visual = motion?.visual;
-  const smoothing = motion?.smoothing;
-
-  if (visual) {
-    // Map time-constant semantics to legacy per-frame factors for current runtime compatibility
-    const posK = visual.position?.k ?? 12.0;
-    const rotK = visual.rotation?.k ?? 30.0;
-    const bankK = visual.bank?.k ?? 18.0;
-
-    return {
-      positionLerp: kToFrameLerp(posK),
-      rotationSlerp: kToFrameLerp(rotK),
-      bankLerp: kToFrameLerp(bankK),
-      maxBankDeg: visual.bank?.maxDeg ?? motion?.maxBankDeg ?? RENDERER_MOTION_DEFAULTS.maxBankDeg,
-      bankFactor: motion?.visualBankFactor ?? RENDERER_MOTION_DEFAULTS.bankFactor,
-      teleportDistance:
-        visual.teleportDistance ??
-        smoothing?.teleportDistance ??
-        RENDERER_MOTION_DEFAULTS.teleportDistance,
-      thrusterIntensity: RENDERER_MOTION_DEFAULTS.thrusterIntensity,
-    };
-  }
-
-  // Legacy behavior: use smoothing block directly
   return {
-    positionLerp: smoothing?.positionLerp ?? RENDERER_MOTION_DEFAULTS.positionLerp,
-    rotationSlerp: smoothing?.rotationSlerp ?? RENDERER_MOTION_DEFAULTS.rotationSlerp,
-    bankLerp: smoothing?.bankLerp ?? RENDERER_MOTION_DEFAULTS.bankLerp,
-    maxBankDeg: motion?.maxBankDeg ?? RENDERER_MOTION_DEFAULTS.maxBankDeg,
+    positionK: visual?.position?.k ?? RENDERER_MOTION_DEFAULTS.positionK,
+    rotationK: visual?.rotation?.k ?? RENDERER_MOTION_DEFAULTS.rotationK,
+    bankK: visual?.bank?.k ?? RENDERER_MOTION_DEFAULTS.bankK,
+    maxBankDeg: visual?.bank?.maxDeg ?? motion?.maxBankDeg ?? RENDERER_MOTION_DEFAULTS.maxBankDeg,
     bankFactor: motion?.visualBankFactor ?? RENDERER_MOTION_DEFAULTS.bankFactor,
-    teleportDistance: smoothing?.teleportDistance ?? RENDERER_MOTION_DEFAULTS.teleportDistance,
+    teleportDistance: visual?.teleportDistance ?? RENDERER_MOTION_DEFAULTS.teleportDistance,
     thrusterIntensity: RENDERER_MOTION_DEFAULTS.thrusterIntensity,
   };
 }

--- a/src/data/shipStats.ts
+++ b/src/data/shipStats.ts
@@ -64,8 +64,7 @@ export const SHIP_STATS: Record<ShipHull, ShipStats> = {
       maxLateralAcceleration: 12,
       visualBankFactor: 20,
       maxBankDeg: 35,
-      // New visual config (time-constant k semantics). These map to legacy per-frame
-      // factors for backward compatibility until the renderer is updated.
+      // Visual smoothing uses time-constant semantics consumed directly by the renderer.
       visual: {
         enabled: true,
         position: { k: 12.0 },

--- a/src/game/validation.ts
+++ b/src/game/validation.ts
@@ -47,20 +47,8 @@ export function validateMotionStats(stats: MotionStats): void {
   if (stats.visualBankFactor != null) {
     assertRange('motion.visualBankFactor', stats.visualBankFactor, { min: 0 });
   }
-  if (stats.smoothing?.positionLerp != null) {
-    assertRange('motion.smoothing.positionLerp', stats.smoothing.positionLerp, { min: 0, max: 1 });
-  }
-  if (stats.smoothing?.rotationSlerp != null) {
-    assertRange('motion.smoothing.rotationSlerp', stats.smoothing.rotationSlerp, {
-      min: 0,
-      max: 1,
-    });
-  }
-  if (stats.smoothing?.bankLerp != null) {
-    assertRange('motion.smoothing.bankLerp', stats.smoothing.bankLerp, { min: 0, max: 1 });
-  }
-  if (stats.smoothing?.teleportDistance != null) {
-    assertRange('motion.smoothing.teleportDistance', stats.smoothing.teleportDistance, { min: 0 });
+  if (stats.smoothing) {
+    throw new Error('motion.smoothing is no longer supported. Use motion.visual instead.');
   }
 
   // New visual config validations (time-constant semantics)

--- a/src/hooks/useArchetypeEntities.ts
+++ b/src/hooks/useArchetypeEntities.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useState } from 'react';
 import type { Archetype } from '../types/index.js';
 import type { GameEntity } from '../types/index.js';
@@ -20,64 +19,19 @@ export function useArchetypeEntities<T extends GameEntity>(
       return;
     }
 
-    const handleChange = () => {
+    const updateEntities = () => {
       setEntities([...archetype.entities] as T[]);
     };
 
     // Initialize and subscribe to entity changes
-    handleChange();
+    updateEntities();
 
-    // Support both legacy/mock API (onEntityAdded.add/remove) and the newer
-    // miniplex v2 API (onEntityAdded.subscribe which may return an
-    // unsubscribe function, or a subscription object with `unsubscribe`).
-    let cleanupAdded: (() => void) | null = null;
-    let cleanupRemoved: (() => void) | null = null;
-
-    const tryRegister = (eventObj: any, cb: () => void): (() => void) | null => {
-      if (!eventObj) return null;
-
-      // Legacy add/remove pair
-      if (typeof eventObj.add === 'function') {
-        eventObj.add(cb);
-        return () => {
-          if (typeof eventObj.remove === 'function') eventObj.remove(cb);
-        };
-      }
-
-      // Newer subscribe style. Subscribe may return an unsubscribe fn or an
-      // object with an `unsubscribe` method. It may also return nothing, in
-      // which case try to call eventObj.unsubscribe(cb) on cleanup.
-      if (typeof eventObj.subscribe === 'function') {
-        const ret = eventObj.subscribe(cb);
-        if (typeof ret === 'function') return ret as () => void;
-        if (ret && typeof (ret as any).unsubscribe === 'function') {
-          return () => (ret as any).unsubscribe();
-        }
-        if (typeof eventObj.unsubscribe === 'function') {
-          return () => eventObj.unsubscribe(cb);
-        }
-
-        // No reliable cleanup returned; best-effort no-op
-        return null;
-      }
-
-      return null;
-    };
-
-    cleanupAdded = tryRegister(archetype.onEntityAdded as any, handleChange);
-    cleanupRemoved = tryRegister(archetype.onEntityRemoved as any, handleChange);
+    const unsubscribeAdded = archetype.onEntityAdded.subscribe(updateEntities);
+    const unsubscribeRemoved = archetype.onEntityRemoved.subscribe(updateEntities);
 
     return () => {
-      if (cleanupAdded) cleanupAdded();
-      else if (archetype && typeof (archetype.onEntityAdded as any).remove === 'function') {
-        // Fallback to legacy removal if present but we didn't record cleanup
-        (archetype.onEntityAdded as any).remove(handleChange);
-      }
-
-      if (cleanupRemoved) cleanupRemoved();
-      else if (archetype && typeof (archetype.onEntityRemoved as any).remove === 'function') {
-        (archetype.onEntityRemoved as any).remove(handleChange);
-      }
+      unsubscribeAdded();
+      unsubscribeRemoved();
     };
   }, [archetype]);
 

--- a/src/hooks/useShipInterpolation.ts
+++ b/src/hooks/useShipInterpolation.ts
@@ -28,9 +28,9 @@ export interface InterpolationState {
 }
 
 export interface SmoothingConfig {
-  positionLerp: number;
-  rotationSlerp: number;
-  bankLerp: number;
+  positionK: number;
+  rotationK: number;
+  bankK: number;
   teleportThresholdSq: number;
   bankFactor: number;
   maxBankDeg: number;
@@ -58,9 +58,9 @@ export function useShipInterpolation(
   const smoothing = useMemo(() => {
     const cfg = resolveRendererMotionConfig(entity.ship.motion);
     return {
-      positionLerp: MathUtils.clamp(cfg.positionLerp, 0, 1),
-      rotationSlerp: MathUtils.clamp(cfg.rotationSlerp, 0, 1),
-      bankLerp: MathUtils.clamp(cfg.bankLerp, 0, 1),
+      positionK: Math.max(0, cfg.positionK),
+      rotationK: Math.max(0, cfg.rotationK),
+      bankK: Math.max(0, cfg.bankK),
       teleportThresholdSq: Math.max(1, cfg.teleportDistance * cfg.teleportDistance),
       bankFactor: cfg.bankFactor,
       maxBankDeg: cfg.maxBankDeg,
@@ -238,13 +238,6 @@ export function updateInterpolation(
   state.targetVisualPosition.copy(state.interpPosition);
   state.visualLocalOffset.set(0, 0, 0);
 
-  const frameDt = Math.max(RENDERER_VISUAL_CONFIG.legacyFrameDt, 1e-6);
-  const legacyToAlpha = (f: number) => {
-    if (f <= 0 || dt <= 0) return 0;
-    const clamped = MathUtils.clamp(f, 0, 1);
-    return 1 - Math.pow(1 - clamped, Math.max(dt, 1e-6) / frameDt);
-  };
-
   if (smoothingEnabled && visualCfg?.bob && visualCfg.bob.enabled !== false) {
     const baseAmp = Math.max(0, visualCfg.bob.baseAmp ?? 0);
     const freq = Math.max(0, visualCfg.bob.freq ?? 0);
@@ -286,10 +279,7 @@ export function updateInterpolation(
     bankValueRef.current = 0;
     bankVelocityRef.current = 0;
   } else {
-    const posAlpha =
-      visualCfg?.position?.k != null && visualCfg.position.k > 0
-        ? kToAlpha(visualCfg.position.k, dt)
-        : legacyToAlpha(smoothing.positionLerp);
+    const posAlpha = kToAlpha(visualCfg?.position?.k ?? smoothing.positionK, dt);
 
     if (posAlpha <= 0) {
       state.visualPosition.copy(state.targetVisualPosition);
@@ -299,10 +289,7 @@ export function updateInterpolation(
       state.visualPosition.lerp(state.targetVisualPosition, MathUtils.clamp(posAlpha, 0, 1));
     }
 
-    const rotAlpha =
-      visualCfg?.rotation?.k != null && visualCfg.rotation.k > 0
-        ? kToAlpha(visualCfg.rotation.k, dt)
-        : legacyToAlpha(smoothing.rotationSlerp);
+    const rotAlpha = kToAlpha(visualCfg?.rotation?.k ?? smoothing.rotationK, dt);
 
     if (rotAlpha <= 0) {
       state.visualRotation.copy(state.interpRotation);
@@ -341,10 +328,7 @@ export function updateInterpolation(
       bankValueRef.current = xNew;
       bankVelocityRef.current = vNew;
     } else {
-      const bankAlpha =
-        visualCfg?.bank?.k != null && visualCfg.bank.k > 0
-          ? kToAlpha(visualCfg.bank.k, dt)
-          : legacyToAlpha(smoothing.bankLerp);
+      const bankAlpha = kToAlpha(visualCfg?.bank?.k ?? smoothing.bankK, dt);
       if (bankAlpha <= 0) {
         bankValueRef.current = targetBankRad;
       } else if (bankAlpha >= 1) {

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -10,31 +10,7 @@ export type { RapierModule, RapierWorld, Collider, EventQueue, RigidBody };
 
 export type EntityId = number;
 
-/**
- * Minimal representation of the parts of a Miniplex query that the codebase
- * depends on. This avoids pulling in a non-existent `Archetype` export and
- * keeps typing tight for our usage patterns (entities + lifecycle events).
- */
-type MiniplexQueryReturn<T> = {
-  entities: T[];
-};
-
-type LegacyArchetypeShape<T> = MiniplexQueryReturn<T> & {
-  onEntityAdded?: {
-    add?: (cb: () => void) => void;
-    remove?: (cb: () => void) => void;
-    subscribe?: (cb: (entity?: T) => void) => void | (() => void) | { unsubscribe: () => void };
-  };
-  onEntityRemoved?: {
-    add?: (cb: () => void) => void;
-    remove?: (cb: () => void) => void;
-    subscribe?: (cb: (entity?: T) => void) => void | (() => void) | { unsubscribe: () => void };
-  };
-  [key: string]: unknown;
-};
-
-export type Archetype<T, _C extends readonly string[] = readonly string[]> =
-  | (ReturnType<ECSWorld<object>['with']> & MiniplexQueryReturn<T>)
-  | LegacyArchetypeShape<T>;
-
-export type { MiniplexQueryReturn };
+export type Archetype<
+  T extends object,
+  _C extends readonly string[] = readonly string[],
+> = ReturnType<ECSWorld<T>['with']>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,7 +7,6 @@ export type {
   RigidBody,
   EntityId,
   Archetype,
-  MiniplexQueryReturn,
 } from './core.js';
 
 // Gameplay types

--- a/test/vitest/hooks-useArchetypeEntities.spec.tsx
+++ b/test/vitest/hooks-useArchetypeEntities.spec.tsx
@@ -2,11 +2,30 @@ import { describe, expect, it, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useArchetypeEntities } from '../../src/hooks/useArchetypeEntities.js';
 
+class MockEvent {
+  listeners = new Set();
+  unsubscribeCallbacks = [];
+
+  subscribe = vi.fn((listener) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+      this.unsubscribeCallbacks.push(listener);
+    };
+  });
+
+  emit() {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
 // Mock an archetype that follows the Miniplex pattern
 class MockArchetype {
   entities = [];
-  onEntityAdded = { add: vi.fn(), remove: vi.fn() };
-  onEntityRemoved = { add: vi.fn(), remove: vi.fn() };
+  onEntityAdded = new MockEvent();
+  onEntityRemoved = new MockEvent();
 
   constructor(initialEntities = []) {
     this.entities = [...initialEntities];
@@ -14,20 +33,14 @@ class MockArchetype {
 
   addEntity(entity) {
     this.entities.push(entity);
-    // Simulate calling all listeners
-    this.onEntityAdded.add.mock.calls.forEach(([listener]) => {
-      listener();
-    });
+    this.onEntityAdded.emit();
   }
 
   removeEntity(entity) {
     const index = this.entities.indexOf(entity);
     if (index > -1) {
       this.entities.splice(index, 1);
-      // Simulate calling all listeners
-      this.onEntityRemoved.add.mock.calls.forEach(([listener]) => {
-        listener();
-      });
+      this.onEntityRemoved.emit();
     }
   }
 }
@@ -35,7 +48,7 @@ class MockArchetype {
 describe('useArchetypeEntities', () => {
   it('returns empty array when archetype is null', () => {
     const { result } = renderHook(() => useArchetypeEntities(null));
-    
+
     expect(result.current).toEqual([]);
   });
 
@@ -45,7 +58,7 @@ describe('useArchetypeEntities', () => {
     const archetype = new MockArchetype([entity1, entity2]);
 
     const { result } = renderHook(() => useArchetypeEntities(archetype));
-    
+
     expect(result.current).toEqual([entity1, entity2]);
   });
 
@@ -53,9 +66,9 @@ describe('useArchetypeEntities', () => {
     const archetype = new MockArchetype([]);
 
     renderHook(() => useArchetypeEntities(archetype));
-    
-    expect(archetype.onEntityAdded.add).toHaveBeenCalledWith(expect.any(Function));
-    expect(archetype.onEntityRemoved.add).toHaveBeenCalledWith(expect.any(Function));
+
+    expect(archetype.onEntityAdded.subscribe).toHaveBeenCalledWith(expect.any(Function));
+    expect(archetype.onEntityRemoved.subscribe).toHaveBeenCalledWith(expect.any(Function));
   });
 
   it('updates entities when archetype changes', () => {
@@ -64,10 +77,9 @@ describe('useArchetypeEntities', () => {
     const archetype1 = new MockArchetype([entity1]);
     const archetype2 = new MockArchetype([entity2]);
 
-    const { result, rerender } = renderHook(
-      ({ archetype }) => useArchetypeEntities(archetype),
-      { initialProps: { archetype: archetype1 } }
-    );
+    const { result, rerender } = renderHook(({ archetype }) => useArchetypeEntities(archetype), {
+      initialProps: { archetype: archetype1 },
+    });
 
     expect(result.current).toEqual([entity1]);
 
@@ -81,10 +93,9 @@ describe('useArchetypeEntities', () => {
     const entity1 = { id: 1 };
     const archetype = new MockArchetype([entity1]);
 
-    const { result, rerender } = renderHook(
-      ({ archetype }) => useArchetypeEntities(archetype),
-      { initialProps: { archetype } }
-    );
+    const { result, rerender } = renderHook(({ archetype }) => useArchetypeEntities(archetype), {
+      initialProps: { archetype },
+    });
 
     expect(result.current).toEqual([entity1]);
 
@@ -98,32 +109,30 @@ describe('useArchetypeEntities', () => {
     const archetype1 = new MockArchetype([]);
     const archetype2 = new MockArchetype([]);
 
-    const { rerender } = renderHook(
-      ({ archetype }) => useArchetypeEntities(archetype),
-      { initialProps: { archetype: archetype1 } }
-    );
+    const { rerender } = renderHook(({ archetype }) => useArchetypeEntities(archetype), {
+      initialProps: { archetype: archetype1 },
+    });
 
     // Change archetype
     rerender({ archetype: archetype2 });
 
-    expect(archetype1.onEntityAdded.remove).toHaveBeenCalledWith(expect.any(Function));
-    expect(archetype1.onEntityRemoved.remove).toHaveBeenCalledWith(expect.any(Function));
+    expect(archetype1.onEntityAdded.unsubscribeCallbacks).toHaveLength(1);
+    expect(archetype1.onEntityRemoved.unsubscribeCallbacks).toHaveLength(1);
   });
 
   it('updates when entities are added to archetype', () => {
     const archetype = new MockArchetype([]);
 
     const { result } = renderHook(() => useArchetypeEntities(archetype));
-    
+
     expect(result.current).toEqual([]);
 
     const newEntity = { id: 1 };
-    
+
     act(() => {
       // Simulate the archetype change by directly calling the listener
       archetype.entities.push(newEntity);
-      const listener = archetype.onEntityAdded.add.mock.calls[0][0];
-      listener();
+      archetype.onEntityAdded.emit();
     });
 
     expect(result.current).toEqual([newEntity]);
@@ -135,14 +144,13 @@ describe('useArchetypeEntities', () => {
     const archetype = new MockArchetype([entity1, entity2]);
 
     const { result } = renderHook(() => useArchetypeEntities(archetype));
-    
+
     expect(result.current).toEqual([entity1, entity2]);
 
     act(() => {
       // Simulate the archetype change by directly calling the listener
       archetype.entities.splice(0, 1); // Remove first entity
-      const listener = archetype.onEntityRemoved.add.mock.calls[0][0];
-      listener();
+      archetype.onEntityRemoved.emit();
     });
 
     expect(result.current).toEqual([entity2]);
@@ -152,10 +160,10 @@ describe('useArchetypeEntities', () => {
     const archetype = new MockArchetype([]);
 
     const { unmount } = renderHook(() => useArchetypeEntities(archetype));
-    
+
     unmount();
 
-    expect(archetype.onEntityAdded.remove).toHaveBeenCalledWith(expect.any(Function));
-    expect(archetype.onEntityRemoved.remove).toHaveBeenCalledWith(expect.any(Function));
+    expect(archetype.onEntityAdded.unsubscribeCallbacks).toHaveLength(1);
+    expect(archetype.onEntityRemoved.unsubscribeCallbacks).toHaveLength(1);
   });
 });

--- a/test/vitest/ship-interpolation.spec.ts
+++ b/test/vitest/ship-interpolation.spec.ts
@@ -56,9 +56,9 @@ function createTestEntity(): ShipEntity {
 
 function createSmoothingConfig(): SmoothingConfig {
   return {
-    positionLerp: 0.18,
-    rotationSlerp: 0.25,
-    bankLerp: 0.15,
+    positionK: 12,
+    rotationK: 30,
+    bankK: 18,
     teleportThresholdSq: 900,
     bankFactor: 18,
     maxBankDeg: 32,

--- a/test/vitest/smoke/import_all.spec.ts
+++ b/test/vitest/smoke/import_all.spec.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, vi } from 'vitest';
 
 // Mock heavy external deps at the top level
 vi.mock('postprocessing', () => ({}));
-vi.mock('pixi.js', () => ({}));
 vi.mock('puppeteer', () => ({}));
 vi.mock('playwright', () => ({}));
 vi.mock('@dimforge/rapier3d-compat', () => ({}));

--- a/test/vitest/validation.spec.ts
+++ b/test/vitest/validation.spec.ts
@@ -15,10 +15,11 @@ describe('validateMotionStats', () => {
     maxLateralAcceleration: 15,
     maxBankDeg: 45,
     visualBankFactor: 1.2,
-    smoothing: {
-      positionLerp: 0.3,
-      rotationSlerp: 0.4,
-      bankLerp: 0.5,
+    visual: {
+      enabled: true,
+      position: { k: 12 },
+      rotation: { k: 24 },
+      bank: { k: 18, maxDeg: 45, useCriticallyDamped: true },
       teleportDistance: 100,
     },
   };
@@ -131,87 +132,11 @@ describe('validateMotionStats', () => {
     expect(() => validateMotionStats(stats)).not.toThrow();
   });
 
-  it('throws for positionLerp below 0', () => {
-    const stats = { ...validStats, smoothing: { ...validStats.smoothing!, positionLerp: -0.1 } };
+  it('throws when legacy smoothing config is provided', () => {
+    const stats = { ...validStats, smoothing: { positionLerp: 0.5 } };
     expect(() => validateMotionStats(stats)).toThrow(
-      'motion.smoothing.positionLerp must be ≥ 0. Received -0.1',
+      'motion.smoothing is no longer supported. Use motion.visual instead.',
     );
-  });
-
-  it('throws for positionLerp above 1', () => {
-    const stats = { ...validStats, smoothing: { ...validStats.smoothing!, positionLerp: 1.5 } };
-    expect(() => validateMotionStats(stats)).toThrow(
-      'motion.smoothing.positionLerp must be ≤ 1. Received 1.5',
-    );
-  });
-
-  it('accepts undefined positionLerp', () => {
-    const stats = {
-      ...validStats,
-      smoothing: { ...validStats.smoothing!, positionLerp: undefined },
-    };
-    expect(() => validateMotionStats(stats)).not.toThrow();
-  });
-
-  it('throws for rotationSlerp below 0', () => {
-    const stats = { ...validStats, smoothing: { ...validStats.smoothing!, rotationSlerp: -0.2 } };
-    expect(() => validateMotionStats(stats)).toThrow(
-      'motion.smoothing.rotationSlerp must be ≥ 0. Received -0.2',
-    );
-  });
-
-  it('throws for rotationSlerp above 1', () => {
-    const stats = { ...validStats, smoothing: { ...validStats.smoothing!, rotationSlerp: 2.0 } };
-    expect(() => validateMotionStats(stats)).toThrow(
-      'motion.smoothing.rotationSlerp must be ≤ 1. Received 2',
-    );
-  });
-
-  it('accepts undefined rotationSlerp', () => {
-    const stats = {
-      ...validStats,
-      smoothing: { ...validStats.smoothing!, rotationSlerp: undefined },
-    };
-    expect(() => validateMotionStats(stats)).not.toThrow();
-  });
-
-  it('throws for bankLerp below 0', () => {
-    const stats = { ...validStats, smoothing: { ...validStats.smoothing!, bankLerp: -0.3 } };
-    expect(() => validateMotionStats(stats)).toThrow(
-      'motion.smoothing.bankLerp must be ≥ 0. Received -0.3',
-    );
-  });
-
-  it('throws for bankLerp above 1', () => {
-    const stats = { ...validStats, smoothing: { ...validStats.smoothing!, bankLerp: 1.1 } };
-    expect(() => validateMotionStats(stats)).toThrow(
-      'motion.smoothing.bankLerp must be ≤ 1. Received 1.1',
-    );
-  });
-
-  it('accepts undefined bankLerp', () => {
-    const stats = { ...validStats, smoothing: { ...validStats.smoothing!, bankLerp: undefined } };
-    expect(() => validateMotionStats(stats)).not.toThrow();
-  });
-
-  it('throws for negative teleportDistance', () => {
-    const stats = { ...validStats, smoothing: { ...validStats.smoothing!, teleportDistance: -50 } };
-    expect(() => validateMotionStats(stats)).toThrow(
-      'motion.smoothing.teleportDistance must be ≥ 0. Received -50',
-    );
-  });
-
-  it('accepts undefined teleportDistance', () => {
-    const stats = {
-      ...validStats,
-      smoothing: { ...validStats.smoothing!, teleportDistance: undefined },
-    };
-    expect(() => validateMotionStats(stats)).not.toThrow();
-  });
-
-  it('accepts undefined smoothing object', () => {
-    const stats = { ...validStats, smoothing: undefined };
-    expect(() => validateMotionStats(stats)).not.toThrow();
   });
 
   it('validates all edge cases at once', () => {
@@ -227,10 +152,10 @@ describe('validateMotionStats', () => {
       maxLateralAcceleration: 0,
       maxBankDeg: 0,
       visualBankFactor: 0,
-      smoothing: {
-        positionLerp: 0,
-        rotationSlerp: 0,
-        bankLerp: 0,
+      visual: {
+        position: { k: 0 },
+        rotation: { k: 0 },
+        bank: { k: 0, maxDeg: 0 },
         teleportDistance: 0,
       },
     };
@@ -250,10 +175,10 @@ describe('validateMotionStats', () => {
       maxLateralAcceleration: Number.MAX_SAFE_INTEGER,
       maxBankDeg: 90,
       visualBankFactor: Number.MAX_SAFE_INTEGER,
-      smoothing: {
-        positionLerp: 1,
-        rotationSlerp: 1,
-        bankLerp: 1,
+      visual: {
+        position: { k: Number.MAX_SAFE_INTEGER },
+        rotation: { k: Number.MAX_SAFE_INTEGER },
+        bank: { k: Number.MAX_SAFE_INTEGER, maxDeg: 90 },
         teleportDistance: Number.MAX_SAFE_INTEGER,
       },
     };


### PR DESCRIPTION
## Summary
- update the archetype hook and type definitions to rely on Miniplex v2 subscribe APIs
- remove legacy renderer smoothing conversions and drive interpolation directly from visual time constants
- block deprecated motion.smoothing configs, refresh related tests, and drop the unused pixi.js dependency

## Testing
- npx prettier --write package.json scripts/generate-smoke-tests.mjs src/config/renderer.ts src/data/shipStats.ts src/game/validation.ts src/hooks/useArchetypeEntities.ts src/hooks/useShipInterpolation.ts src/types/core.ts src/types/index.ts test/vitest/smoke/import_all.spec.ts test/vitest/validation.spec.ts
- npx tsc --noEmit
- npm run lint
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68fe3d21bb88832aa9876e46c034d9e0