### PR TITLE
feat: centralize projectile info helpers

### DIFF
--- a/memory/designs/DESIGN100-centralize-projectile-info.md
+++ b/memory/designs/DESIGN100-centralize-projectile-info.md
@@ -1,6 +1,6 @@
 # DESIGN100 — Centralize Projectile Info & Beam Helpers
 
-**Status:** Proposed
+**Status:** Implemented
 **Created:** 2025-10-27
 **Authors:** GitHub Copilot (assistant)
 

--- a/memory/tasks/TASK253-centralize-projectile-info.md
+++ b/memory/tasks/TASK253-centralize-projectile-info.md
@@ -1,6 +1,6 @@
 # TASK253 - Centralize Projectile Info & Beam Helpers
 
-**Status:** Not Started
+**Status:** Completed
 **Added:** 2025-10-27
 **Owner:** TBD
 
@@ -24,17 +24,22 @@ This task implements the design described in `memory/designs/DESIGN100-centraliz
 
 | ID  | Description | Status | Updated | Notes |
 | --- | ----------- | ------ | ------- | ----- |
-| 1.1 | Create `src/utils/projectileInfo.ts` | Not Started | - | Core helper module |
-| 1.2 | Add unit tests | Not Started | - | `test/utils/projectileInfo.spec.ts` |
-| 1.3 | Update `projectiles.ts` | Not Started | - | Use resolver & computeBeamTransform |
-| 1.4 | Update `ProjectilesInstancedLayer.tsx` | Not Started | - | Use computeBeamTransform for beam matrix |
-| 1.5 | Update `damage.ts` | Not Started | - | Use resolveProjectileCategory |
-| 1.6 | Run checks & tests | Not Started | - | Fix issues found |
+| 1.1 | Create `src/utils/projectileInfo.ts` | Complete | 2025-10-27 | Core helper module |
+| 1.2 | Add unit tests | Complete | 2025-10-27 | `test/utils/projectileInfo.spec.ts` |
+| 1.3 | Update `projectiles.ts` | Complete | 2025-10-27 | Use resolver & computeBeamTransform |
+| 1.4 | Update `ProjectilesInstancedLayer.tsx` | Complete | 2025-10-27 | Use computeBeamTransform for beam matrix |
+| 1.5 | Update `damage.ts` | Complete | 2025-10-27 | Use resolveProjectileCategory |
+| 1.6 | Run checks & tests | Complete | 2025-10-27 | Fix issues found |
 
 ## Progress Log
 
 ### 2025-10-27
 - Task created and design added to memory.
+
+### 2025-10-27 (Implementation)
+- Implemented `src/utils/projectileInfo.ts` with shared projectile resolvers.
+- Updated simulation and renderer layers to consume the helpers.
+- Added Vitest coverage for info resolution and beam transforms; checks pass locally.
 
 ## Acceptance Criteria
 - `npx tsc --noEmit` passes

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -16,6 +16,7 @@ This index tracks active tasks and their memory files. Use the `/memory/tasks` f
 
 ## Completed
 
+- [TASK253](TASK253-centralize-projectile-info.md) — Centralized projectile info helpers and refactored beam handling. (2025-10-27)
 - [TASK252](TASK252-ai-harness-modernization.md) — Modernized AI test harness documentation and created deprecation/patterns guides. (2025-10-26)
 - [TASK247](TASK247-version2-vision.md) — Authored Version 2.0 vision document outlining pillars, feature concepts, and validation plans. (2025-10-13)
 - [TASK250](TASK250-tech-debt-report.md) — Documented legacy cleanup opportunities with ratings/effort and validated build/tests. (2025-10-26)

--- a/src/components/layers/ProjectilesInstancedLayer.tsx
+++ b/src/components/layers/ProjectilesInstancedLayer.tsx
@@ -1,11 +1,15 @@
 import { useFrame } from '@react-three/fiber';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { InstancedMesh } from 'three';
-import { Color, DynamicDrawUsage, InstancedBufferAttribute, Matrix4, Vector3 } from 'three';
+import { Color, Matrix4, Vector3 } from 'three';
 import type { Archetype, GameEntity, ProjectileEntity } from '../../types/index.js';
 import { useArchetypeEntities } from '../../hooks/useArchetypeEntities.js';
-import { getProjectileConfig } from '../../config/projectiles.js';
 import { getProjectileGeometry } from '../../utils/projectileGeometries.js';
+import {
+  computeBeamTransform,
+  resolveProjectileInfo,
+  type ResolvedProjectileInfo,
+} from '../../utils/projectileInfo.js';
 import {
   createInstancedMaterial,
   type InstancedMaterialInfo,
@@ -31,6 +35,7 @@ interface ProjectileGroupState {
   geometry: ReturnType<typeof getProjectileGeometry>;
   baseColor: Color;
   maxIndex: number;
+  info: ResolvedProjectileInfo;
 }
 
 const DEFAULT_CAPACITY = 512;
@@ -39,13 +44,6 @@ const DEFAULT_CAPACITY = 512;
 const TEMP_MATRIX = new Matrix4();
 const TEMP_SCALE = new Vector3();
 const TEMP_POSITION = new Vector3();
-
-interface ProjectileGeometryMetadata {
-  category?: string;
-  baseRadius?: number;
-  baseWidth?: number;
-  baseLength?: number;
-}
 
 function ProjectileGroupMesh({ group }: { group: ProjectileGroupState }): React.ReactElement {
   const { meshRef, materialInfo, geometry, capacity, baseColor } = group;
@@ -98,6 +96,7 @@ export function ProjectilesInstancedLayer({
       if (existing) return existing;
       const resolvedCapacity = Math.max(1, capacityByType?.[key] ?? defaultCapacity);
       const geometry = getProjectileGeometry(key);
+      const info = resolveProjectileInfo(key);
       const materialInfo = createInstancedMaterial(key);
       const meshRef: React.MutableRefObject<InstancedMesh | null> = { current: null };
       const baseColor = new Color(1, 1, 1);
@@ -115,6 +114,7 @@ export function ProjectilesInstancedLayer({
         geometry,
         baseColor,
         maxIndex: -1,
+        info,
       };
       groupsRef.current.set(key, group);
       forceRender((n) => n + 1);
@@ -165,45 +165,28 @@ export function ProjectilesInstancedLayer({
       if (!mesh) continue;
 
       totalAllocated += 1;
-      const cfg = getProjectileConfig(projectile.projectile.bulletType);
-      const visualMultiplier = cfg.visualMultiplier ?? 1;
-      const baseScale = projectile.transform.scale * visualMultiplier;
-      const metadata = (group.geometry.userData.projectile ?? {}) as ProjectileGeometryMetadata;
-      const category =
-        projectile.projectile.category ?? metadata.category ?? cfg.category ?? 'bullet';
+      const info = group.info;
+      const category = projectile.projectile.category ?? info.category;
 
       if (category === 'beam' && projectile.projectile.beam) {
-        const beam = projectile.projectile.beam;
-        const baseLength = metadata.baseLength && metadata.baseLength > 0 ? metadata.baseLength : 1;
-        const widthConfig = beam.width ?? cfg.beam?.width ?? metadata.baseWidth ?? baseScale;
-        const baseWidth =
-          metadata.baseWidth && metadata.baseWidth > 0 ? metadata.baseWidth : baseScale;
-        let beamLength =
-          beam.maxLength ?? projectile.projectile.speed * projectile.projectile.maxTtl;
-
-        if (beam.hitPoint) {
-          TEMP_POSITION.copy(beam.hitPoint).sub(projectile.transform.position);
-          beamLength = TEMP_POSITION.length();
-        }
-
-        beamLength = Math.max(0.1, beamLength);
-        const lengthScale = beamLength / baseLength;
-        const widthScale = baseWidth > 0 ? widthConfig / baseWidth : baseScale;
-        TEMP_SCALE.set(widthScale, widthScale, lengthScale);
-        TEMP_POSITION.copy(projectile.transform.position).addScaledVector(
-          projectile.direction,
-          beamLength / 2,
-        );
-        TEMP_MATRIX.compose(TEMP_POSITION, projectile.transform.rotation, TEMP_SCALE);
+        const result = computeBeamTransform({
+          projectile,
+          info,
+          matrix: TEMP_MATRIX,
+          scratchScale: TEMP_SCALE,
+          scratchPosition: TEMP_POSITION,
+        });
+        group.manager.setMatrixAt(index, result.matrix);
       } else {
+        const baseScale = projectile.transform.scale * info.visualMultiplier;
         TEMP_SCALE.setScalar(baseScale);
         TEMP_MATRIX.compose(
           projectile.transform.position,
           projectile.transform.rotation,
           TEMP_SCALE,
         );
+        group.manager.setMatrixAt(index, TEMP_MATRIX);
       }
-      group.manager.setMatrixAt(index, TEMP_MATRIX);
     }
 
     for (const group of groupsRef.current.values()) {

--- a/src/game/systems/damage.ts
+++ b/src/game/systems/damage.ts
@@ -5,7 +5,7 @@ import type {
   ShipEntity,
   ShieldRipple,
 } from '../../types/index.js';
-import { getProjectileConfig, getProjectileCategory } from '../../config/projectiles.js';
+import { resolveProjectileCategory, resolveProjectileInfo } from '../../utils/projectileInfo.js';
 import {
   applySubsystemDamage,
   awardDamageXp,
@@ -77,7 +77,7 @@ export function applyProjectileDamage(
       : ships.find((s) => s.ship.team === projectile.projectile.team);
     if (attackerShip) {
       const projectileCategory =
-        projectile.projectile.category ?? getProjectileCategory(projectile.projectile.bulletType);
+        projectile.projectile.category ?? resolveProjectileCategory(projectile.projectile.bulletType);
       awardDamageXp(
         attackerShip.ship,
         totalDamageDealt,
@@ -193,7 +193,7 @@ export function resolveProjectiles(state: GameState, delta: number): void {
 
   for (const projectile of projectiles) {
     const category: ProjectileCategory =
-      projectile.projectile.category ?? getProjectileCategory(projectile.projectile.bulletType);
+      projectile.projectile.category ?? resolveProjectileCategory(projectile.projectile.bulletType);
 
     if (category === 'beam') {
       handleBeamProjectile(state, projectile, ships, toRemove, delta);
@@ -206,8 +206,9 @@ export function resolveProjectiles(state: GameState, delta: number): void {
       continue;
     }
 
-    const projCfg = getProjectileConfig(projectile.projectile.bulletType);
-    const projRadius = projCfg.colliderRadius ?? Math.max(0.08, projectile.transform.scale * 1.2);
+    const info = resolveProjectileInfo(projectile.projectile.bulletType);
+    const projRadius =
+      info.config.colliderRadius ?? Math.max(0.08, projectile.transform.scale * 1.2);
 
     for (const ship of ships) {
       if (ship.ship.team === projectile.projectile.team) continue;

--- a/src/game/systems/projectiles.ts
+++ b/src/game/systems/projectiles.ts
@@ -2,12 +2,11 @@ import { Quaternion, Vector3 } from 'three';
 import type { GameState, ShipEntity, ProjectileEntity } from '../../types/index.js';
 import type { ProjectileCategory, ProjectileHomingConfig } from '../../types/combat.js';
 import {
-  getProjectileConfig,
-  getProjectileCategory,
-  type ProjectileConfigItem,
-  type ProjectileBeamConfig,
-  DEFAULT_PROJECTILE_CONFIG,
-} from '../../config/projectiles.js';
+  resolveProjectileCategory,
+  resolveProjectileInfo,
+  type ResolvedProjectileInfo,
+} from '../../utils/projectileInfo.js';
+import { type ProjectileBeamConfig } from '../../config/projectiles.js';
 import { clampToWorld, AI_CONFIG } from '../config.js';
 import { getEffectiveStats } from '../progression.js';
 import { enqueuePostPhysicsMutation } from '../simulationQueue.js';
@@ -78,7 +77,7 @@ function steerProjectileTowardTarget(
 
 function populateProjectileBehaviour(
   projectile: ProjectileEntity,
-  config: ProjectileConfigItem,
+  info: ResolvedProjectileInfo,
   category: ProjectileCategory,
   override: FireProjectileOverride | undefined,
   state: GameState,
@@ -86,9 +85,9 @@ function populateProjectileBehaviour(
 ): void {
   projectile.projectile.category = category;
   projectile.projectile.spawnTime = state.time;
-  projectile.projectile.armingTime = override?.armingTime ?? config.armingTime;
-  projectile.projectile.aoeRadius = override?.aoeRadius ?? config.aoeRadius;
-  const homing = override?.homing ?? config.homing;
+  projectile.projectile.armingTime = override?.armingTime ?? info.config.armingTime;
+  projectile.projectile.aoeRadius = override?.aoeRadius ?? info.config.aoeRadius;
+  const homing = override?.homing ?? info.config.homing;
   if (homing) {
     projectile.projectile.homing = homing;
     projectile.projectile.targetId = override?.targetId ?? targetId;
@@ -96,7 +95,7 @@ function populateProjectileBehaviour(
     projectile.projectile.targetId = targetId;
   }
   if (category === 'beam') {
-    const beamConfig = override?.beam ?? config.beam;
+    const beamConfig = override?.beam ?? info.beamConfig;
     if (beamConfig) {
       const runtime = projectile.projectile.beam ?? {
         ttl: beamConfig.ttl,
@@ -120,7 +119,7 @@ export function advanceProjectiles(state: GameState, delta: number): void {
   const projectiles = state.queries.projectiles.entities as ProjectileEntity[];
   for (const projectile of projectiles) {
     const category =
-      projectile.projectile.category ?? getProjectileCategory(projectile.projectile.bulletType);
+      projectile.projectile.category ?? resolveProjectileCategory(projectile.projectile.bulletType);
     if (category === 'beam') {
       continue;
     }
@@ -222,19 +221,19 @@ export function fireProjectile(
     : origin.transform.position.clone().addScaledVector(direction, muzzleOffset);
   const rotation = new Quaternion().setFromUnitVectors(FORWARD, direction);
 
-  const bulletKey = opts?.override?.bulletType ?? origin.ship.bulletType ?? '';
-  const cfg = getProjectileConfig(bulletKey);
-  const category = opts?.override?.projectileCategory ?? cfg.category ?? 'bullet';
-  const visualScale = cfg.visualScale ?? DEFAULT_PROJECTILE_CONFIG.visualScale;
-  const colliderRadius = cfg.colliderRadius ?? Math.max(0.08, visualScale * 1.2);
+  const bulletKey = opts?.override?.bulletType ?? origin.ship.bulletType;
+  const info = resolveProjectileInfo(bulletKey);
+  const category = opts?.override?.projectileCategory ?? info.category;
+  const visualScale = info.visualScale;
+  const colliderRadius = info.colliderRadius;
 
   let speed = opts?.override?.projectileSpeed ?? origin.ship.projectileSpeed;
-  speed = resolveProjectileSpeed(origin, speed, bulletKey, opts?.override);
+  speed = resolveProjectileSpeed(origin, speed, info.key, opts?.override);
   const damage =
     (opts?.override?.damage ?? origin.ship.damage) *
     getEffectiveStats(origin.ship).damageMultiplier;
   const range = opts?.override?.range ?? origin.ship.range;
-  const lifetime = speed > 0 ? Math.min(range / speed, 30) : (cfg.beam?.ttl ?? 0.4);
+  const lifetime = speed > 0 ? Math.min(range / speed, 30) : (info.beamConfig?.ttl ?? 0.4);
 
   const spawnDirection = direction.clone();
   const rotationComponents = { x: rotation.x, y: rotation.y, z: rotation.z, w: rotation.w };
@@ -249,8 +248,8 @@ export function fireProjectile(
   const projectileData = {
     team: origin.ship.team,
     damage,
-    ttl: category === 'beam' ? (cfg.beam?.ttl ?? lifetime) : lifetime,
-    speed: category === 'beam' ? range / Math.max(cfg.beam?.ttl ?? lifetime, 0.001) : speed,
+    ttl: category === 'beam' ? (info.beamConfig?.ttl ?? lifetime) : lifetime,
+    speed: category === 'beam' ? range / Math.max(info.beamConfig?.ttl ?? lifetime, 0.001) : speed,
     bulletType: opts?.override?.bulletType ?? origin.ship.bulletType,
     damageType,
     sourceId: origin.id,
@@ -299,13 +298,13 @@ export function fireProjectile(
       projectile.projectile.beam = {
         ttl: projectileData.ttl,
         maxLength: beamInfo.distance,
-        width: cfg.beam?.width,
+        width: info.beamConfig?.width,
         hitPoint: beamInfo.hitPoint.clone(),
         applied: false,
       };
     }
 
-    populateProjectileBehaviour(projectile, cfg, category, opts?.override, state, targetId);
+    populateProjectileBehaviour(projectile, info, category, opts?.override, state, targetId);
 
     if (collider?.handle != null) {
       state.colliderLookup.set(collider.handle, projectile);

--- a/src/utils/projectileGeometries.ts
+++ b/src/utils/projectileGeometries.ts
@@ -9,7 +9,7 @@ import {
 
 const geometryCache = new Map<string, BufferGeometry>();
 
-interface ProjectileGeometryMetadata {
+export interface ProjectileGeometryMetadata {
   category: string;
   baseRadius?: number;
   baseWidth?: number;

--- a/src/utils/projectileInfo.ts
+++ b/src/utils/projectileInfo.ts
@@ -1,0 +1,190 @@
+import { Matrix4, Vector3 } from 'three';
+import type { ProjectileEntity } from '../types/index.js';
+import type { ProjectileCategory } from '../types/combat.js';
+import {
+  DEFAULT_PROJECTILE_CONFIG,
+  PROJECTILE_CONFIG,
+  getProjectileConfig,
+  type ProjectileBeamConfig,
+  type ProjectileConfigItem,
+} from '../config/projectiles.js';
+import {
+  getProjectileGeometry,
+  type ProjectileGeometryMetadata,
+} from './projectileGeometries.js';
+
+const FALLBACK_PROJECTILE_KEY = 'bullet:laser';
+const TEMP_HIT_VECTOR = new Vector3();
+
+export interface ResolvedProjectileGeometryMetadata {
+  category?: ProjectileCategory;
+  baseRadius?: number;
+  baseWidth?: number;
+  baseLength?: number;
+}
+
+export interface ResolvedProjectileInfo {
+  key: string;
+  config: ProjectileConfigItem;
+  category: ProjectileCategory;
+  visualScale: number;
+  visualMultiplier: number;
+  colliderRadius: number;
+  metadata: ResolvedProjectileGeometryMetadata;
+  beamConfig?: ProjectileBeamConfig;
+}
+
+interface ResolveProjectileInfoOptions {
+  metadata?: Partial<ResolvedProjectileGeometryMetadata> | null;
+}
+
+export interface ComputeBeamTransformParams {
+  projectile: ProjectileEntity;
+  info: ResolvedProjectileInfo;
+  matrix?: Matrix4;
+  scratchScale?: Vector3;
+  scratchPosition?: Vector3;
+  scratchDirection?: Vector3;
+}
+
+export interface BeamTransformResult {
+  matrix: Matrix4;
+  widthScale: number;
+  lengthScale: number;
+}
+
+function normalizeProjectileKey(key?: string | null): string {
+  const candidate = key ?? FALLBACK_PROJECTILE_KEY;
+  if (Object.prototype.hasOwnProperty.call(PROJECTILE_CONFIG, candidate)) {
+    return candidate;
+  }
+  return FALLBACK_PROJECTILE_KEY;
+}
+
+function resolveGeometryMetadata(
+  key: string,
+  opts?: Partial<ResolvedProjectileGeometryMetadata> | null,
+): ResolvedProjectileGeometryMetadata {
+  const geometry = getProjectileGeometry(key);
+  const raw = (geometry.userData.projectile ?? {}) as ProjectileGeometryMetadata | undefined;
+  return {
+    category: (opts?.category ?? raw?.category) as ProjectileCategory | undefined,
+    baseRadius: opts?.baseRadius ?? raw?.baseRadius,
+    baseWidth: opts?.baseWidth ?? raw?.baseWidth,
+    baseLength: opts?.baseLength ?? raw?.baseLength,
+  };
+}
+
+export function resolveProjectileInfo(
+  key?: string | null,
+  opts?: ResolveProjectileInfoOptions,
+): ResolvedProjectileInfo {
+  const normalizedKey = normalizeProjectileKey(key);
+  const config = getProjectileConfig(normalizedKey);
+  const geometryMetadata = resolveGeometryMetadata(normalizedKey, opts?.metadata);
+
+  const baseRadius =
+    geometryMetadata.baseRadius ??
+    config.baseGeometryRadius ??
+    DEFAULT_PROJECTILE_CONFIG.baseGeometryRadius ??
+    0.5;
+  const computedCategory =
+    geometryMetadata.category ?? config.category ?? 'bullet';
+  const baseWidth =
+    geometryMetadata.baseWidth ??
+    (baseRadius != null ? baseRadius * 2 : undefined);
+  const beamLengthFallback = Math.max(
+    1,
+    (config.visualScale ?? DEFAULT_PROJECTILE_CONFIG.visualScale ?? 1) * 12,
+  );
+  const baseLength =
+    geometryMetadata.baseLength ??
+    (computedCategory === 'beam'
+      ? beamLengthFallback
+      : baseWidth ?? baseRadius * 2);
+
+  const visualScale = config.visualScale ?? DEFAULT_PROJECTILE_CONFIG.visualScale ?? 0.2;
+  const visualMultiplier = config.visualMultiplier ?? 1;
+  const colliderRadius =
+    config.colliderRadius ?? Math.max(0.08, visualScale * 1.2);
+
+  const metadata: ResolvedProjectileGeometryMetadata = {
+    category: computedCategory,
+    baseRadius,
+    baseWidth,
+    baseLength: baseLength && baseLength > 0 ? baseLength : 1,
+  };
+
+  return {
+    key: normalizedKey,
+    config,
+    category: computedCategory,
+    visualScale,
+    visualMultiplier,
+    colliderRadius,
+    metadata,
+    beamConfig: config.beam,
+  };
+}
+
+export function resolveProjectileCategory(key?: string | null): ProjectileCategory {
+  return resolveProjectileInfo(key).category;
+}
+
+export function computeBeamTransform({
+  projectile,
+  info,
+  matrix,
+  scratchScale,
+  scratchPosition,
+  scratchDirection,
+}: ComputeBeamTransformParams): BeamTransformResult {
+  const beam = projectile.projectile.beam;
+  if (!beam) {
+    throw new Error('computeBeamTransform requires a beam projectile.');
+  }
+
+  const workingMatrix = matrix ?? new Matrix4();
+  const scale = scratchScale ?? new Vector3();
+  const position = scratchPosition ?? new Vector3();
+  const directionScratch = scratchDirection ?? TEMP_HIT_VECTOR;
+
+  const baseScale = projectile.transform.scale * info.visualMultiplier;
+  const baseWidth = info.metadata.baseWidth && info.metadata.baseWidth > 0
+    ? info.metadata.baseWidth
+    : baseScale;
+  const configuredWidth =
+    beam.width ?? info.beamConfig?.width ?? baseWidth ?? baseScale;
+  const widthScale = baseWidth && baseWidth > 0 ? configuredWidth / baseWidth : baseScale;
+
+  let beamLength = beam.maxLength ?? projectile.projectile.speed * projectile.projectile.maxTtl;
+  if (beam.hitPoint) {
+    directionScratch
+      .copy(beam.hitPoint)
+      .sub(projectile.transform.position);
+    beamLength = directionScratch.length();
+  }
+  if (!Number.isFinite(beamLength) || beamLength <= 0) {
+    beamLength = projectile.projectile.speed * Math.max(projectile.projectile.maxTtl, 0);
+  }
+  beamLength = Math.max(0.1, beamLength);
+
+  const baseLength = info.metadata.baseLength && info.metadata.baseLength > 0
+    ? info.metadata.baseLength
+    : 1;
+  const lengthScale = baseLength > 0 ? beamLength / baseLength : beamLength;
+
+  scale.set(widthScale, widthScale, lengthScale);
+  position
+    .copy(projectile.transform.position)
+    .addScaledVector(projectile.direction, beamLength / 2);
+  workingMatrix.compose(position, projectile.transform.rotation, scale);
+
+  return {
+    matrix: workingMatrix,
+    widthScale,
+    lengthScale,
+  };
+}
+
+export type { ProjectileGeometryMetadata } from './projectileGeometries.js';

--- a/test/utils/projectileInfo.spec.ts
+++ b/test/utils/projectileInfo.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { Matrix4, Quaternion, Vector3 } from 'three';
+import type { DamageType, ProjectileEntity, Team } from '../../src/types/index.js';
+import {
+  computeBeamTransform,
+  resolveProjectileInfo,
+  resolveProjectileCategory,
+  type ResolvedProjectileInfo,
+} from '../../src/utils/projectileInfo.js';
+
+function createBeamProjectile(info: ResolvedProjectileInfo): ProjectileEntity {
+  const position = new Vector3(0, 0, 0);
+  const rotation = new Quaternion();
+  const direction = new Vector3(0, 0, 1);
+  const ttl = info.beamConfig?.ttl ?? 0.4;
+  return {
+    id: 1,
+    rigidBody: {} as any,
+    collider: {} as any,
+    transform: {
+      position,
+      rotation,
+      scale: info.visualScale,
+    },
+    projectile: {
+      team: 'blue' as Team,
+      damage: 10,
+      ttl,
+      maxTtl: ttl,
+      speed: 200,
+      bulletType: info.key,
+      damageType: 'kinetic' as DamageType,
+      sourceId: 42,
+      beam: {
+        ttl,
+        maxLength: 50,
+        width: info.beamConfig?.width,
+        hitPoint: undefined,
+        applied: false,
+      },
+    },
+    direction,
+  } as unknown as ProjectileEntity;
+}
+
+describe('resolveProjectileInfo', () => {
+  it('returns detailed configuration for known projectile keys', () => {
+    const laser = resolveProjectileInfo('bullet:laser');
+    expect(laser.key).toBe('bullet:laser');
+    expect(laser.category).toBe('bullet');
+    expect(laser.visualScale).toBeCloseTo(0.5);
+    expect(laser.colliderRadius).toBeCloseTo(0.6, 5);
+
+    const missile = resolveProjectileInfo('missile:light');
+    expect(missile.category).toBe('missile');
+    expect(missile.colliderRadius).toBeCloseTo(0.45, 5);
+
+    const beam = resolveProjectileInfo('beam:laser');
+    expect(beam.category).toBe('beam');
+    expect(beam.beamConfig?.ttl).toBeCloseTo(0.4);
+    expect(beam.metadata.baseLength).toBeGreaterThan(0);
+  });
+
+  it('falls back to the laser configuration for unknown keys', () => {
+    const info = resolveProjectileInfo('unknown:type');
+    expect(info.key).toBe('bullet:laser');
+    expect(info.category).toBe('bullet');
+  });
+
+  it('resolves projectile category consistently', () => {
+    expect(resolveProjectileCategory('torpedo:standard')).toBe('torpedo');
+    expect(resolveProjectileCategory('nonexistent')).toBe('bullet');
+  });
+});
+
+describe('computeBeamTransform', () => {
+  it('computes matrix and scale factors for beam projectiles', () => {
+    const info = resolveProjectileInfo('beam:laser');
+    const projectile = createBeamProjectile(info);
+    const tempMatrix = new Matrix4();
+    const tempScale = new Vector3();
+    const tempPosition = new Vector3();
+
+    const result = computeBeamTransform({
+      projectile,
+      info,
+      matrix: tempMatrix,
+      scratchScale: tempScale,
+      scratchPosition: tempPosition,
+    });
+
+    const extractedPosition = new Vector3();
+    const extractedRotation = new Quaternion();
+    const extractedScale = new Vector3();
+    result.matrix.decompose(extractedPosition, extractedRotation, extractedScale);
+
+    expect(extractedPosition.z).toBeCloseTo(25); // half of maxLength (50)
+    expect(result.lengthScale).toBeCloseTo(50 / (info.metadata.baseLength ?? 1));
+    expect(result.widthScale).toBeGreaterThan(0);
+    expect(extractedScale.z).toBeCloseTo(result.lengthScale);
+    expect(extractedRotation.equals(projectile.transform.rotation)).toBe(true);
+  });
+
+  it('uses beam hit point when provided to determine length', () => {
+    const info = resolveProjectileInfo('beam:laser');
+    const projectile = createBeamProjectile(info);
+    projectile.projectile.beam = {
+      ttl: info.beamConfig?.ttl ?? 0.4,
+      maxLength: 200,
+      width: info.beamConfig?.width,
+      hitPoint: new Vector3(0, 0, 30),
+      applied: false,
+    };
+
+    const result = computeBeamTransform({ projectile, info });
+    expect(result.lengthScale).toBeCloseTo(30 / (info.metadata.baseLength ?? 1));
+  });
+});


### PR DESCRIPTION
## Summary
- add `src/utils/projectileInfo.ts` to resolve projectile metadata and beam transforms per DESIGN100
- refactor projectile simulation, renderer, and damage handling to consume the shared helpers
- cover the new utilities with vitest specs and update task/design records

## Testing
- npx tsc --noEmit
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ffa84c04a0832a9fc5ef21bfe6cbc2