### PR TITLE
Add shared physics, range policy, and steering utilities

### DIFF
--- a/memory/tasks/TASK101-physics-factory.md
+++ b/memory/tasks/TASK101-physics-factory.md
@@ -1,13 +1,15 @@
 # TASK101 - Implement Physics Factory helpers and migrate ship/projectile spawn
 
-**Status:** Not Started
+**Status:** Completed
 **Added:** 2025-10-27
 **Updated:** 2025-10-27
 
 ## Original Request
+
 Create a helper module that centralizes Rapier `RigidBody` and `Collider` creation and safe registration of collider handles into `state.colliderLookup`. Migrate `spawnShip` and `fireProjectile` to use the helper as a proof-of-concept.
 
 ## Thought Process
+
 - The code currently repeats body/collider creation logic in `spawnShip`, `fireProjectile`, and turret creation.
 - Implement a small, focused helper module in `src/game/utils/physicsFactory.ts` with the following responsibilities:
   - build & create RigidBodyDesc with provided translation/rotation
@@ -26,15 +28,19 @@ Create a helper module that centralizes Rapier `RigidBody` and `Collider` creati
 - Step 6: Iterate on additional call sites (turrets) if everything passes.
 
 ### Subtasks
-| ID | Description | Status | Updated | Notes |
-| --- | --- | --- | --- | --- |
-| 101.1 | Create `physicsFactory.ts` with helper functions | Not Started |  |  |
-| 101.2 | Add unit tests for factory behaviors | Not Started |  |  |
-| 101.3 | Migrate `spawnShip` to use factory | Not Started |  |  |
-| 101.4 | Migrate `fireProjectile` to use factory | Not Started |  |  |
-| 101.5 | Run tests and fix issues | Not Started |  |  |
+
+| ID    | Description                                      | Status    | Updated    | Notes                                                                    |
+| ----- | ------------------------------------------------ | --------- | ---------- | ------------------------------------------------------------------------ |
+| 101.1 | Create `physicsFactory.ts` with helper functions | Completed | 2025-10-27 | Implemented centralized creation helpers for rigid bodies and colliders. |
+| 101.2 | Add unit tests for factory behaviors             | Completed | 2025-10-27 | Added deterministic coverage in `physics-factory.spec.ts`.               |
+| 101.3 | Migrate `spawnShip` to use factory               | Completed | 2025-10-27 | Ship and turret spawns now consume the shared helper.                    |
+| 101.4 | Migrate `fireProjectile` to use factory          | Completed | 2025-10-27 | Projectile creation path updated to call helper utilities.               |
+| 101.5 | Run tests and fix issues                         | Completed | 2025-10-27 | Lint, type check, and full Vitest suite passing.                         |
 
 ## Progress Log
 
 ### 2025-10-27
+
 - Task created.
+- Implemented physics factory helpers with collider registration utilities and added dedicated unit tests.
+- Updated ship, turret, and projectile spawning flows to rely on the shared helpers; full test suite verified.

--- a/memory/tasks/TASK102-range-policy.md
+++ b/memory/tasks/TASK102-range-policy.md
@@ -1,12 +1,14 @@
 # TASK102 - Implement Range Policy helpers and migrate range logic
 
-**Status:** Not Started
+**Status:** Completed
 **Added:** 2025-10-27
 
 ## Original Request
+
 Centralize AI range/speed/profile policy logic into `src/game/utils/rangePolicy.ts` and migrate usages in `spawnShip`, `projectiles`, and profile adjustment code.
 
 ## Thought Process
+
 - There are multiple conditional checks of `AI_CONFIG.rangePolicy` and ad-hoc per-hull/per-style adjustments in several modules. A stable helper module will make changes easier and reduce risk of inconsistent behavior.
 
 ## Implementation Plan
@@ -19,16 +21,20 @@ Centralize AI range/speed/profile policy logic into `src/game/utils/rangePolicy.
 - Step 6: Run typecheck and tests, fix behavioral mismatches.
 
 ### Subtasks
-| ID | Description | Status | Updated | Notes |
-| --- | --- | --- | --- | --- |
-| 102.1 | Implement `rangePolicy.ts` | Not Started |  |  |
-| 102.2 | Unit tests for parity | Not Started |  |  |
-| 102.3 | Migrate `spawnShip` usage | Not Started |  |  |
-| 102.4 | Migrate `projectiles` usage | Not Started |  |  |
-| 102.5 | Migrate `profile-adjustment` usage | Not Started |  |  |
-| 102.6 | Run CI / tests | Not Started |  |  |
+
+| ID    | Description                        | Status    | Updated    | Notes                                                                         |
+| ----- | ---------------------------------- | --------- | ---------- | ----------------------------------------------------------------------------- |
+| 102.1 | Implement `rangePolicy.ts`         | Completed | 2025-10-27 | Added centralized range policy helpers with optional config overrides.        |
+| 102.2 | Unit tests for parity              | Completed | 2025-10-27 | Created coverage in `range-policy.spec.ts` validating deterministic behavior. |
+| 102.3 | Migrate `spawnShip` usage          | Completed | 2025-10-27 | Ship range variance now delegates to the shared helper.                       |
+| 102.4 | Migrate `projectiles` usage        | Completed | 2025-10-27 | Projectile speed adjustments call `adjustProjectileSpeedForHullAndBullet`.    |
+| 102.5 | Migrate `profile-adjustment` usage | Completed | 2025-10-27 | Decision profile range adjustments rely on the helper API.                    |
+| 102.6 | Run CI / tests                     | Completed | 2025-10-27 | Lint, typecheck, and full Vitest suite executed after migrations.             |
 
 ## Progress Log
 
 ### 2025-10-27
+
 - Task created.
+- Implemented range policy module with parity tests and replaced ship, projectile, and profile adjustment call sites.
+- Updated scripts and documentation exports to consume the new helpers; verified end-to-end via CI commands.

--- a/memory/tasks/TASK103-steering-utils.md
+++ b/memory/tasks/TASK103-steering-utils.md
@@ -1,12 +1,14 @@
 # TASK103 - Implement Steering & Transform Utilities
 
-**Status:** Not Started
+**Status:** Completed
 **Added:** 2025-10-27
 
 ## Original Request
+
 Create a `src/utils/steering.ts` (or `transformUtils.ts`) module that centralizes vector/quaternion math for steering, orientation and lead computation. Migrate `steerProjectileTowardTarget` and related orientation code to use the helpers.
 
 ## Thought Process
+
 - Homing/steering code is repeated in projectiles and motion systems. Renderer code also computes quaternions from direction vectors. Consolidation will reduce bugs and clarify numeric guards.
 
 ## Implementation Plan
@@ -18,15 +20,19 @@ Create a `src/utils/steering.ts` (or `transformUtils.ts`) module that centralize
 - Step 5: Run tests and fix issues.
 
 ### Subtasks
-| ID | Description | Status | Updated | Notes |
-| --- | --- | --- | --- | --- |
-| 103.1 | Implement `steering.ts` helpers | Not Started |  |  |
-| 103.2 | Unit tests for helpers | Not Started |  |  |
-| 103.3 | Migrate projectile homing | Not Started |  |  |
-| 103.4 | Migrate motion & renderer code | Not Started |  |  |
-| 103.5 | Run tests and integrate | Not Started |  |  |
+
+| ID    | Description                     | Status    | Updated    | Notes                                                                            |
+| ----- | ------------------------------- | --------- | ---------- | -------------------------------------------------------------------------------- |
+| 103.1 | Implement `steering.ts` helpers | Completed | 2025-10-27 | Added shared steering/math utilities with safe normalization.                    |
+| 103.2 | Unit tests for helpers          | Completed | 2025-10-27 | Authored coverage in `steering-utils.spec.ts` for key behaviors.                 |
+| 103.3 | Migrate projectile homing       | Completed | 2025-10-27 | Homing logic now consumes the reusable steering helpers.                         |
+| 103.4 | Migrate motion & renderer code  | Completed | 2025-10-27 | Motion system and star disk orientation rely on `orientQuaternionFromDirection`. |
+| 103.5 | Run tests and integrate         | Completed | 2025-10-27 | Formatting, lint, typecheck, and full test suite verified.                       |
 
 ## Progress Log
 
 ### 2025-10-27
+
 - Task created.
+- Implemented steering utilities with deterministic vector helpers, added unit tests, and refactored projectile, motion, and renderer paths.
+- Verified integrations across systems with formatting, linting, typechecks, and comprehensive test execution.

--- a/scripts/test-range-variance.ts
+++ b/scripts/test-range-variance.ts
@@ -5,21 +5,11 @@
 
 import { AI_CONFIG } from '../src/game/config.js';
 import { SHIP_STATS } from '../src/game/ships.js';
-import { SeededRng } from '../src/utils/rng.js';
+import {
+  adjustProjectileSpeedForHullAndBullet,
+  applyRangeVariance,
+} from '../src/game/utils/rangePolicy.js';
 import type { ShipHull } from '../src/types/index.js';
-
-// Replicate the range variance logic
-function applyRangeVariance(baseRange: number, traitSeed: number, weaponIndex = 0): number {
-  if (AI_CONFIG.rangePolicy !== 'v0.1.1-exp') return baseRange;
-
-  const rangeSeed = Math.abs((traitSeed ^ (weaponIndex * 7919)) >>> 0) || 1;
-  const rng = new SeededRng(rangeSeed);
-
-  const variance = 0.05;
-  const modifier = 1 + (rng.next() * 2 - 1) * variance;
-
-  return Math.round(baseRange * modifier);
-}
 
 function calculateRangeStats(ranges: number[]): {
   min: number;
@@ -90,28 +80,22 @@ console.log('🚀 Projectile Speed Variance');
 console.log('=============================\n');
 
 // Demonstrate projectile speed adjustments
-const speedAdjustments = {
-  fighter: 1.02,
-  corvette: 0.98,
-  frigate: 0.96,
-  destroyer: 1.05,
-  carrier: 1.05,
-};
-
 for (const hull of hulls) {
   const baseSpeed = SHIP_STATS[hull].projectileSpeed;
-  const adjustment = speedAdjustments[hull];
-  const newSpeed = Math.round(baseSpeed * adjustment);
   const bulletType = SHIP_STATS[hull].bulletType;
-
-  let typeAdjustment = 1.0;
-  if (bulletType.includes('laser')) typeAdjustment *= 0.97;
-  if (bulletType.includes('heavy') || bulletType.includes('ion')) typeAdjustment *= 1.03;
-
-  const finalSpeed = Math.round(newSpeed * typeAdjustment);
+  const adjustedSpeed = adjustProjectileSpeedForHullAndBullet(
+    hull,
+    baseSpeed,
+    bulletType,
+    false,
+    AI_CONFIG,
+  );
+  const finalSpeed = Math.round(adjustedSpeed);
 
   console.log(
-    `${hull.padEnd(10)} | Base: ${baseSpeed.toString().padStart(2)} | Hull: ${newSpeed.toString().padStart(2)} | Type: ${finalSpeed.toString().padStart(2)} | ${bulletType}`,
+    `${hull.padEnd(10)} | Base: ${baseSpeed.toString().padStart(2)} | Adjusted: ${finalSpeed
+      .toString()
+      .padStart(2)} | ${bulletType}`,
   );
 }
 

--- a/src/game/ships.ts
+++ b/src/game/ships.ts
@@ -10,46 +10,22 @@ import { SHIP_STATS } from '../data/shipStats.js';
 import { createInitialAIState } from './aiState.js';
 import { registerTurret } from './turretRegistry.js';
 import { CARRIER_LAUNCH_CONFIG } from '../config/carriers.js';
-import { AI_CONFIG } from './config.js';
-import { SeededRng } from '../utils/rng.js';
 import { calculateXpForLevel } from '../config/progression.js';
 import { generateCaptain, createSubsystems, createLevelBonusState } from './progression.js';
-
-/**
- * Apply range variance based on range policy and ship's trait seed.
- * Provides ±5% variance to weapon ranges when rangePolicy is 'v0.1.1-exp'.
- */
-function applyRangeVariance(baseRange: number, traitSeed: number, weaponIndex = 0): number {
-  if (AI_CONFIG.rangePolicy !== 'v0.1.1-exp') return baseRange;
-
-  // Create a deterministic seed combining traitSeed and weapon index for consistency
-  const rangeSeed = Math.abs((traitSeed ^ (weaponIndex * 7919)) >>> 0) || 1;
-  const rng = new SeededRng(rangeSeed);
-
-  // Apply ±5% variance
-  const variance = 0.05;
-  const modifier = 1 + (rng.next() * 2 - 1) * variance;
-
-  return Math.round(baseRange * modifier);
-}
+import { createKinematicBodyWithCollider, registerColliderHandle } from './utils/physicsFactory.js';
+import { applyRangeVariance } from './utils/rangePolicy.js';
 
 export function spawnShip(state: GameState, blueprint: ShipBlueprint): ShipEntity {
   const stats = SHIP_STATS[blueprint.hull];
   const rotation = new Quaternion().setFromAxisAngle(new Vector3(0, 1, 0), blueprint.heading);
   const position = blueprint.position.clone();
 
-  const bodyDesc = state.rapier.RigidBodyDesc.kinematicPositionBased()
-    .setTranslation(position.x, position.y, position.z)
-    .setRotation({ x: rotation.x, y: rotation.y, z: rotation.z, w: rotation.w });
-  if (stats.motion.visual?.enableCcd) {
-    bodyDesc.setCcdEnabled(true);
-  }
-  const body = state.physicsWorld.createRigidBody(bodyDesc);
-
-  const colliderDesc = state.rapier.ColliderDesc.capsule(0.8, 0.6)
-    .setActiveEvents(state.rapier.ActiveEvents.COLLISION_EVENTS)
-    .setActiveCollisionTypes(state.rapier.ActiveCollisionTypes.ALL);
-  const collider = state.physicsWorld.createCollider(colliderDesc, body);
+  const { body, collider } = createKinematicBodyWithCollider(state, {
+    position,
+    rotation,
+    collider: { type: 'capsule', halfHeight: 0.8, radius: 0.6 },
+    ccd: stats.motion.visual?.enableCcd ?? false,
+  });
 
   const aiState = createInitialAIState(state, blueprint.hull);
 
@@ -119,19 +95,16 @@ export function spawnShip(state: GameState, blueprint: ShipBlueprint): ShipEntit
   }
 
   const registered = state.world.add(entity) as ShipEntity;
-  state.colliderLookup.set(collider.handle, registered);
+  registerColliderHandle(state, collider, registered);
 
   const turretSpecs = stats.turrets ?? [];
   turretSpecs.forEach((spec, idx) => {
-    const tBodyDesc = state.rapier.RigidBodyDesc.kinematicPositionBased()
-      .setTranslation(position.x, position.y, position.z)
-      .setRotation({ x: rotation.x, y: rotation.y, z: rotation.z, w: rotation.w });
-    const tBody = state.physicsWorld.createRigidBody(tBodyDesc);
-    const tColliderDesc = state.rapier.ColliderDesc.ball(0.05)
-      .setActiveEvents(state.rapier.ActiveEvents.COLLISION_EVENTS)
-      .setActiveCollisionTypes(state.rapier.ActiveCollisionTypes.ALL)
-      .setSensor(true as unknown as boolean);
-    const tCollider = state.physicsWorld.createCollider(tColliderDesc, tBody);
+    const { body: tBody, collider: tCollider } = createKinematicBodyWithCollider(state, {
+      position,
+      rotation,
+      collider: { type: 'ball', radius: 0.05 },
+      sensor: true,
+    });
 
     const turretEntity = state.world.add({
       id: state.nextEntityId++,
@@ -161,7 +134,7 @@ export function spawnShip(state: GameState, blueprint: ShipBlueprint): ShipEntit
         priority: spec.priority ?? 'any',
       },
     }) as TurretEntity;
-    state.colliderLookup.set(tCollider.handle, turretEntity);
+    registerColliderHandle(state, tCollider, turretEntity);
     try {
       registerTurret(state, registered.id, turretEntity);
     } catch {

--- a/src/game/systems/combat.ts
+++ b/src/game/systems/combat.ts
@@ -5,7 +5,8 @@
 // - damage.ts: projectile resolution, damage application, XP
 // - sync.ts: transform synchronization
 
-export { fireProjectile, advanceProjectiles, FORWARD, TEMP_DIR, TEMP_POS } from './projectiles.js';
+export { fireProjectile, advanceProjectiles, TEMP_POS } from './projectiles.js';
+export { FORWARD } from '../../utils/steering.js';
 
 export { findNearestEnemy, runEmbeddedTurrets, updateTurrets } from './turrets.js';
 

--- a/src/game/systems/damage.ts
+++ b/src/game/systems/damage.ts
@@ -1,3 +1,4 @@
+import { Vector3 } from 'three';
 import type {
   GameEntity,
   GameState,
@@ -20,7 +21,9 @@ import {
   queueTargetLossInterrupts,
 } from './decision/interrupts.js';
 import type { ProjectileCategory } from '../../types/combat.js';
-import { TEMP_DIR } from './projectiles.js';
+import { safeNormalize } from '../../utils/steering.js';
+
+const TEMP_RIPPLE_DIR = new Vector3();
 
 export interface ProjectileDamageOutcome {
   totalDamage: number;
@@ -62,13 +65,13 @@ export function applyProjectileDamage(
     rngSeed: projectile.id + state.time,
     callbacks: {
       emitShieldRipple: ({ strength }) => {
-        const dir = TEMP_DIR.copy(projectile.transform.position).sub(ship.transform.position);
-        if (dir.lengthSq() > 1e-5) {
-          dir.normalize();
-        } else {
-          dir.set(0, 0, 1);
-        }
-        const ripple: ShieldRipple = { dir: dir.clone(), t0: state.time, amp: strength };
+        TEMP_RIPPLE_DIR.copy(projectile.transform.position).sub(ship.transform.position);
+        safeNormalize(TEMP_RIPPLE_DIR, TEMP_RIPPLE_DIR);
+        const ripple: ShieldRipple = {
+          dir: TEMP_RIPPLE_DIR.clone(),
+          t0: state.time,
+          amp: strength,
+        };
         const list = (ship.shieldRipples ??= []);
         list.push(ripple);
         if (list.length > 64) list.shift();

--- a/src/game/systems/decision/profile-adjustment.ts
+++ b/src/game/systems/decision/profile-adjustment.ts
@@ -1,51 +1,29 @@
 import type { GameState, ShipEntity, BehaviorProfile } from '../../../types/index.js';
-import { AI_CONFIG } from '../../config.js';
 import { applyDoctrineToProfile } from '../../aiDoctrine.js';
+import { adjustBehaviorProfileRange, isLegacyRangePolicy } from '../../utils/rangePolicy.js';
 
 export function getEffectiveProfile(
   state: GameState,
   ship: ShipEntity,
   baseProfile: BehaviorProfile,
 ): BehaviorProfile {
-  if (AI_CONFIG.rangePolicy !== 'v0.1.1-exp') {
+  if (!isLegacyRangePolicy()) {
     return applyDoctrineToProfile(state, ship, baseProfile);
   }
-  let [min, max] = baseProfile.desiredRange;
-  switch (baseProfile.style) {
-    case 'artillery':
-      min += 30;
-      max += 50;
-      break;
-    case 'brawler':
-      min = Math.max(20, min - 20);
-      max = Math.max(min + 40, max - 10);
-      break;
-    case 'escort':
-      min = Math.max(15, min - 10);
-      max = Math.max(min + 40, max);
-      break;
-    case 'kiter':
-      min += 10;
-      max += 30;
-      break;
-    default:
-      break;
-  }
-  if (ship.ship.hull === 'carrier' || ship.ship.hull === 'destroyer') {
-    min += 10;
-    max += 30;
-  }
-  if (max - min < 40) {
-    max = min + 40;
-  }
-  if (min < 10) min = 10;
-  if (max <= min) max = min + 40;
-  if (min === baseProfile.desiredRange[0] && max === baseProfile.desiredRange[1]) {
+
+  const desiredRange = adjustBehaviorProfileRange(
+    baseProfile.desiredRange,
+    baseProfile.style,
+    ship.ship.hull,
+  );
+
+  if (desiredRange === baseProfile.desiredRange) {
     return applyDoctrineToProfile(state, ship, baseProfile);
   }
+
   const adjusted = {
     ...baseProfile,
-    desiredRange: [min, max] as const,
+    desiredRange,
   };
   return applyDoctrineToProfile(state, ship, adjusted);
 }

--- a/src/game/systems/motion.ts
+++ b/src/game/systems/motion.ts
@@ -7,6 +7,7 @@ import {
   deferSetNextKinematicTranslation,
   deferSetNextKinematicRotation,
 } from '../physics/safeKinematics.js';
+import { FORWARD, orientQuaternionFromDirection } from '../../utils/steering.js';
 
 // Reusable temporary objects to avoid per-frame allocations
 const TEMP_FORWARD = new Vector3();
@@ -143,7 +144,7 @@ function updateAngularMotion(ship: ShipEntity, targetHeading: Vector3, dt: numbe
 
   const s = motion.smoothing?.rotationSlerp ?? 0;
   if (s > 0 && !withinSettleBand) {
-    TEMP_ROTATION.setFromUnitVectors(TEMP_RIGHT.set(0, 0, 1), desiredForward);
+    orientQuaternionFromDirection(desiredForward, FORWARD, TEMP_ROTATION);
     currentRotation.slerp(TEMP_ROTATION, Math.min(1, s));
     currentRotation.normalize();
   }

--- a/src/game/systems/projectiles.ts
+++ b/src/game/systems/projectiles.ts
@@ -15,12 +15,20 @@ import {
   deferSetNextKinematicTranslation,
   deferSetNextKinematicRotation,
 } from '../physics/safeKinematics.js';
+import {
+  createKinematicBodyWithCollider,
+  registerColliderHandle,
+} from '../utils/physicsFactory.js';
+import { adjustProjectileSpeedForHullAndBullet } from '../utils/rangePolicy.js';
+import {
+  FORWARD,
+  computeLeadDirection,
+  orientQuaternionFromDirection,
+  steerDirection,
+} from '../../utils/steering.js';
 
-export const FORWARD = new Vector3(0, 0, 1);
-export const TEMP_DIR = new Vector3();
 export const TEMP_POS = new Vector3();
 const TEMP_TARGET = new Vector3();
-const TEMP_LEAD = new Vector3();
 
 interface FireProjectileOverride
   extends Partial<
@@ -53,26 +61,28 @@ function steerProjectileTowardTarget(
   delta: number,
 ): void {
   const currentDir = projectile.direction;
-  const desired = TEMP_TARGET.copy(target.transform.position).sub(projectile.transform.position);
-  if (desired.lengthSq() <= 1e-6) {
+  const separationSq = TEMP_TARGET.copy(target.transform.position)
+    .sub(projectile.transform.position)
+    .lengthSq();
+  if (separationSq <= 1e-6) {
     return;
   }
-  desired.normalize();
 
-  if (homing.lead) {
-    TEMP_LEAD.copy(target.ship.velocity).normalize().multiplyScalar(0.5);
-    desired.add(TEMP_LEAD).normalize();
-  }
+  const desired = computeLeadDirection(
+    target.transform.position,
+    projectile.transform.position,
+    target.ship.velocity,
+    homing.lead ? 0.5 : 0,
+    TEMP_TARGET,
+  );
 
-  const angle = currentDir.angleTo(desired);
+  const { newDir, angle } = steerDirection(currentDir, desired, homing.turnRate, delta, currentDir);
   if (angle < 1e-5) {
     return;
   }
-  const maxTurn = Math.max(0, homing.turnRate) * delta;
-  const t = Math.min(1, angle > 0 ? maxTurn / angle : 1);
-  currentDir.lerp(desired, t).normalize();
-  projectile.direction = currentDir;
-  projectile.transform.rotation.setFromUnitVectors(FORWARD, currentDir);
+
+  projectile.direction = newDir;
+  orientQuaternionFromDirection(newDir, FORWARD, projectile.transform.rotation);
 }
 
 function populateProjectileBehaviour(
@@ -163,26 +173,13 @@ function resolveProjectileSpeed(
   bulletType: string,
   override?: FireProjectileOverride,
 ): number {
-  if (AI_CONFIG.rangePolicy !== 'v0.1.1-exp' || override) {
-    return speed;
-  }
-  let adjusted = speed;
-  if (origin.ship.hull === 'destroyer' || origin.ship.hull === 'carrier') {
-    adjusted *= 1.05;
-  } else if (origin.ship.hull === 'fighter') {
-    adjusted *= 1.02;
-  } else if (origin.ship.hull === 'corvette') {
-    adjusted *= 0.98;
-  } else if (origin.ship.hull === 'frigate') {
-    adjusted *= 0.96;
-  }
-
-  if (bulletType.includes('laser')) {
-    adjusted *= 0.97;
-  } else if (bulletType.includes('heavy') || bulletType.includes('ion')) {
-    adjusted *= 1.03;
-  }
-  return adjusted;
+  return adjustProjectileSpeedForHullAndBullet(
+    origin.ship.hull,
+    speed,
+    bulletType,
+    Boolean(override),
+    AI_CONFIG,
+  );
 }
 
 function createBeamHitInfo(
@@ -219,7 +216,7 @@ export function fireProjectile(
   const startPosition = opts?.originPosition
     ? opts.originPosition.clone()
     : origin.transform.position.clone().addScaledVector(direction, muzzleOffset);
-  const rotation = new Quaternion().setFromUnitVectors(FORWARD, direction);
+  const rotation = orientQuaternionFromDirection(direction);
 
   const bulletKey = opts?.override?.bulletType ?? origin.ship.bulletType;
   const info = resolveProjectileInfo(bulletKey);
@@ -256,15 +253,11 @@ export function fireProjectile(
   };
 
   enqueuePostPhysicsMutation(state, () => {
-    const bodyDesc = state.rapier.RigidBodyDesc.kinematicPositionBased()
-      .setTranslation(positionComponents.x, positionComponents.y, positionComponents.z)
-      .setRotation(rotationComponents);
-    const body = state.physicsWorld.createRigidBody(bodyDesc);
-
-    const colliderDesc = state.rapier.ColliderDesc.ball(colliderRadius)
-      .setActiveEvents(state.rapier.ActiveEvents.COLLISION_EVENTS)
-      .setActiveCollisionTypes(state.rapier.ActiveCollisionTypes.ALL);
-    const collider = state.physicsWorld.createCollider(colliderDesc, body);
+    const { body, collider } = createKinematicBodyWithCollider(state, {
+      position: startPosition,
+      rotation,
+      collider: { type: 'ball', radius: colliderRadius },
+    });
 
     const projectile = state.world.add({
       id: state.nextEntityId++,
@@ -306,8 +299,6 @@ export function fireProjectile(
 
     populateProjectileBehaviour(projectile, info, category, opts?.override, state, targetId);
 
-    if (collider?.handle != null) {
-      state.colliderLookup.set(collider.handle, projectile);
-    }
+    registerColliderHandle(state, collider, projectile);
   });
 }

--- a/src/game/systems/turrets.ts
+++ b/src/game/systems/turrets.ts
@@ -1,9 +1,11 @@
 import { Vector3 } from 'three';
 import type { GameState, ShipEntity, TurretEntity, TurretState } from '../../types/index.js';
 import { recordShotMetrics } from '../metrics.js';
-import { fireProjectile, TEMP_DIR, TEMP_POS } from './projectiles.js';
+import { fireProjectile, TEMP_POS } from './projectiles.js';
 import type { KinematicBody } from '../physics/safeKinematics.js';
 import { deferSetNextKinematicTranslation } from '../physics/safeKinematics.js';
+
+const TEMP_TURRET_DIR = new Vector3();
 
 export function findNearestEnemy(state: GameState, origin: ShipEntity): ShipEntity | null {
   const ships = state.queries.ships.entities as ShipEntity[];
@@ -33,7 +35,7 @@ export function runEmbeddedTurrets(state: GameState, ship: ShipEntity, target: S
   for (const turret of ship.turrets ?? []) {
     if (turret.cooldown > 0) continue;
     const turretOrigin = getTurretWorldPosition(ship, turret);
-    const toTarget = TEMP_DIR.copy(target.transform.position).sub(turretOrigin);
+    const toTarget = TEMP_TURRET_DIR.copy(target.transform.position).sub(turretOrigin);
     const dist = toTarget.length();
     if (dist > turret.range) continue;
     if (dist > 1e-5) toTarget.divideScalar(dist);
@@ -108,7 +110,7 @@ export function updateTurrets(state: GameState, delta: number): void {
     }
     t.turret.cooldown = Math.max(0, t.turret.cooldown - delta);
     if (!target || t.turret.cooldown > 0) continue;
-    const toTarget = TEMP_DIR.copy(target.transform.position).sub(origin);
+    const toTarget = TEMP_TURRET_DIR.copy(target.transform.position).sub(origin);
     const dist = toTarget.length();
     if (dist > t.turret.range) continue;
     if (dist > 1e-5) toTarget.divideScalar(dist);

--- a/src/game/utils/physicsFactory.ts
+++ b/src/game/utils/physicsFactory.ts
@@ -1,0 +1,115 @@
+import type { Collider, RigidBody } from '../../types/index.js';
+import type { GameEntity, GameState } from '../../types/index.js';
+import type { Quaternion, Vector3 } from 'three';
+
+type ColliderShapeConfig =
+  | { type: 'ball'; radius: number }
+  | { type: 'capsule'; halfHeight: number; radius: number };
+
+export interface CreateBodyColliderOpts {
+  position?: Vector3;
+  rotation?: Quaternion | { x: number; y: number; z: number; w: number };
+  collider: ColliderShapeConfig;
+  sensor?: boolean;
+  activeEvents?: number;
+  activeCollisionTypes?: number;
+  ccd?: boolean;
+}
+
+function toRotationObject(rotation?: Quaternion | { x: number; y: number; z: number; w: number }): {
+  x: number;
+  y: number;
+  z: number;
+  w: number;
+} {
+  if (!rotation) {
+    return { x: 0, y: 0, z: 0, w: 1 };
+  }
+  if (typeof (rotation as Quaternion).x === 'number') {
+    const rot = rotation as Quaternion;
+    return { x: rot.x, y: rot.y, z: rot.z, w: rot.w };
+  }
+  return rotation;
+}
+
+function ensureNumbers(position?: Vector3): { x: number; y: number; z: number } {
+  if (!position) {
+    return { x: 0, y: 0, z: 0 };
+  }
+  return { x: position.x, y: position.y, z: position.z };
+}
+
+export function createKinematicBodyWithCollider(
+  state: GameState,
+  opts: CreateBodyColliderOpts,
+): { body: RigidBody; collider: Collider | null } {
+  const translation = ensureNumbers(opts.position);
+  const rotation = toRotationObject(opts.rotation);
+
+  const bodyDesc = state.rapier.RigidBodyDesc.kinematicPositionBased()
+    .setTranslation(translation.x, translation.y, translation.z)
+    .setRotation(rotation);
+  if (opts.ccd) {
+    bodyDesc.setCcdEnabled(true);
+  }
+
+  const body = state.physicsWorld.createRigidBody(bodyDesc) as RigidBody;
+
+  const colliderDesc = (() => {
+    if (opts.collider.type === 'ball') {
+      return state.rapier.ColliderDesc.ball(opts.collider.radius);
+    }
+    return state.rapier.ColliderDesc.capsule(opts.collider.halfHeight, opts.collider.radius);
+  })();
+
+  const activeEvents = opts.activeEvents ?? state.rapier.ActiveEvents.COLLISION_EVENTS;
+  const activeCollisionTypes = opts.activeCollisionTypes ?? state.rapier.ActiveCollisionTypes.ALL;
+
+  colliderDesc.setActiveEvents(activeEvents).setActiveCollisionTypes(activeCollisionTypes);
+
+  if (typeof opts.sensor === 'boolean') {
+    colliderDesc.setSensor(opts.sensor as unknown as boolean);
+  }
+
+  const collider = state.physicsWorld.createCollider(colliderDesc, body) as Collider | null;
+
+  return { body, collider };
+}
+
+export function registerColliderHandle(
+  state: GameState,
+  collider: Collider | null | undefined,
+  entity: GameEntity,
+): void {
+  const handle = collider?.handle;
+  if (handle == null) {
+    return;
+  }
+  state.colliderLookup.set(handle, entity);
+}
+
+export function unregisterColliderHandle(
+  state: GameState,
+  collider: Collider | null | undefined,
+): void {
+  const handle = collider?.handle;
+  if (handle == null) {
+    return;
+  }
+  state.colliderLookup.delete(handle);
+}
+
+export function createAndRegisterEntityBody<T extends GameEntity>(
+  state: GameState,
+  entityFactory: (body: RigidBody, collider: Collider | null) => T,
+  opts: CreateBodyColliderOpts,
+  registerEntity?: (entity: T) => void,
+): { entity: T; collider: Collider | null; body: RigidBody } {
+  const { body, collider } = createKinematicBodyWithCollider(state, opts);
+  const entity = entityFactory(body, collider);
+  if (registerEntity) {
+    registerEntity(entity);
+  }
+  registerColliderHandle(state, collider, entity);
+  return { entity, collider, body };
+}

--- a/src/game/utils/rangePolicy.ts
+++ b/src/game/utils/rangePolicy.ts
@@ -1,0 +1,110 @@
+import { AI_CONFIG } from '../config.js';
+import { SeededRng } from '../../utils/rng.js';
+
+export type RangePolicyConfig = typeof AI_CONFIG;
+
+export function isLegacyRangePolicy(config: RangePolicyConfig = AI_CONFIG): boolean {
+  return config.rangePolicy === 'v0.1.1-exp';
+}
+
+export function applyRangeVariance(
+  baseRange: number,
+  traitSeed: number,
+  weaponIndex = 0,
+  config: RangePolicyConfig = AI_CONFIG,
+): number {
+  if (!isLegacyRangePolicy(config)) {
+    return baseRange;
+  }
+
+  const rangeSeed = Math.abs((traitSeed ^ (weaponIndex * 7919)) >>> 0) || 1;
+  const rng = new SeededRng(rangeSeed);
+  const variance = 0.05;
+  const modifier = 1 + (rng.next() * 2 - 1) * variance;
+  return Math.round(baseRange * modifier);
+}
+
+export function adjustProjectileSpeedForHullAndBullet(
+  hull: string,
+  baseSpeed: number,
+  bulletType: string,
+  overrideProvided = false,
+  config: RangePolicyConfig = AI_CONFIG,
+): number {
+  if (!isLegacyRangePolicy(config) || overrideProvided) {
+    return baseSpeed;
+  }
+
+  let adjusted = baseSpeed;
+  if (hull === 'destroyer' || hull === 'carrier') {
+    adjusted *= 1.05;
+  } else if (hull === 'fighter') {
+    adjusted *= 1.02;
+  } else if (hull === 'corvette') {
+    adjusted *= 0.98;
+  } else if (hull === 'frigate') {
+    adjusted *= 0.96;
+  }
+
+  if (bulletType.includes('laser')) {
+    adjusted *= 0.97;
+  } else if (bulletType.includes('heavy') || bulletType.includes('ion')) {
+    adjusted *= 1.03;
+  }
+
+  return adjusted;
+}
+
+export function adjustBehaviorProfileRange(
+  baseRange: readonly [number, number],
+  style: string,
+  hull: string,
+  config: RangePolicyConfig = AI_CONFIG,
+): readonly [number, number] {
+  if (!isLegacyRangePolicy(config)) {
+    return baseRange;
+  }
+
+  let [min, max] = baseRange;
+  switch (style) {
+    case 'artillery':
+      min += 30;
+      max += 50;
+      break;
+    case 'brawler':
+      min = Math.max(20, min - 20);
+      max = Math.max(min + 40, max - 10);
+      break;
+    case 'escort':
+      min = Math.max(15, min - 10);
+      max = Math.max(min + 40, max);
+      break;
+    case 'kiter':
+      min += 10;
+      max += 30;
+      break;
+    default:
+      break;
+  }
+
+  if (hull === 'carrier' || hull === 'destroyer') {
+    min += 10;
+    max += 30;
+  }
+
+  if (max - min < 40) {
+    max = min + 40;
+  }
+  if (min < 10) {
+    min = 10;
+  }
+  if (max <= min) {
+    max = min + 40;
+  }
+
+  if (min === baseRange[0] && max === baseRange[1]) {
+    return baseRange;
+  }
+
+  return [min, max] as const;
+}

--- a/src/renderer/starDiskOrientation.ts
+++ b/src/renderer/starDiskOrientation.ts
@@ -1,4 +1,5 @@
 import { Quaternion, Vector3 } from 'three';
+import { orientQuaternionFromDirection } from '../utils/steering.js';
 
 export interface Vector3Like {
   x: number;
@@ -30,10 +31,7 @@ export function computeStarDiskQuaternion(direction: Vector3Like): Quaternion {
   ) {
     return new Quaternion();
   }
-  vector.normalize();
-  const quaternion = new Quaternion();
-  quaternion.setFromUnitVectors(new Vector3(0, 0, 1), vector);
-  return quaternion;
+  return orientQuaternionFromDirection(vector);
 }
 
 export function createViewAlignmentScratch(): ViewAlignmentScratch {

--- a/src/utils/steering.ts
+++ b/src/utils/steering.ts
@@ -1,0 +1,98 @@
+import { Quaternion, Vector3 } from 'three';
+
+export const FORWARD = new Vector3(0, 0, 1);
+const DEFAULT_FALLBACK = new Vector3(0, 0, 1);
+const TEMP_DIR = new Vector3();
+const TEMP_LEAD = new Vector3();
+
+export function safeNormalize(
+  dst: Vector3,
+  src: Vector3,
+  fallback: Vector3 = DEFAULT_FALLBACK,
+): Vector3 {
+  if (src.lengthSq() > 1e-12) {
+    if (dst !== src) {
+      dst.copy(src);
+    }
+    return dst.normalize();
+  }
+  if (fallback.lengthSq() > 1e-12) {
+    dst.copy(fallback);
+    return dst.normalize();
+  }
+  dst.set(0, 0, 1);
+  return dst;
+}
+
+export function orientQuaternionFromDirection(
+  direction: Vector3,
+  fallbackDirection: Vector3 = DEFAULT_FALLBACK,
+  target = new Quaternion(),
+): Quaternion {
+  const normalised = safeNormalize(TEMP_DIR, direction, fallbackDirection);
+  target.setFromUnitVectors(FORWARD, normalised);
+  if (!Number.isFinite(target.x) || !Number.isFinite(target.y) || !Number.isFinite(target.z)) {
+    return target.identity();
+  }
+  return target;
+}
+
+export function computeLeadDirection(
+  targetPos: Vector3,
+  sourcePos: Vector3,
+  targetVelocity: Vector3,
+  leadFactor = 0.5,
+  out: Vector3 = new Vector3(),
+): Vector3 {
+  TEMP_DIR.copy(targetPos).sub(sourcePos);
+  safeNormalize(out, TEMP_DIR, FORWARD);
+
+  if (leadFactor !== 0 && targetVelocity.lengthSq() > 1e-10) {
+    safeNormalize(TEMP_LEAD, targetVelocity, FORWARD).multiplyScalar(leadFactor);
+    out.add(TEMP_LEAD);
+    safeNormalize(out, out, FORWARD);
+  }
+
+  return out;
+}
+
+export function steerDirection(
+  currentDir: Vector3,
+  desiredDir: Vector3,
+  turnRate: number,
+  delta: number,
+  out: Vector3 = new Vector3(),
+): { newDir: Vector3; angle: number } {
+  const angle = currentDir.angleTo(desiredDir);
+  if (!Number.isFinite(angle) || angle < 1e-6) {
+    safeNormalize(out, currentDir, desiredDir);
+    return { newDir: out, angle: Math.max(angle, 0) };
+  }
+
+  const maxTurn = Math.max(0, turnRate) * Math.max(delta, 0);
+  if (maxTurn <= 0) {
+    safeNormalize(out, currentDir, desiredDir);
+    return { newDir: out, angle };
+  }
+
+  const t = Math.min(1, maxTurn / angle);
+  out.copy(currentDir).lerp(desiredDir, t);
+  safeNormalize(out, out, desiredDir);
+  return { newDir: out, angle };
+}
+
+export function clampAngle(angle: number, min: number, max: number): number {
+  if (!Number.isFinite(angle)) {
+    return Math.min(Math.max(0, Math.min(min, max)), Math.max(min, max));
+  }
+  const twoPi = Math.PI * 2;
+  let normalised = angle % twoPi;
+  if (normalised < -Math.PI) normalised += twoPi;
+  if (normalised > Math.PI) normalised -= twoPi;
+
+  const minBound = Math.min(min, max);
+  const maxBound = Math.max(min, max);
+  if (normalised < minBound) return minBound;
+  if (normalised > maxBound) return maxBound;
+  return normalised;
+}

--- a/test/vitest/physics-factory.spec.ts
+++ b/test/vitest/physics-factory.spec.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { Quaternion, Vector3 } from 'three';
+import type { Collider, GameEntity, GameState, RigidBody } from '../../src/types/index.js';
+import {
+  createKinematicBodyWithCollider,
+  registerColliderHandle,
+  unregisterColliderHandle,
+} from '../../src/game/utils/physicsFactory.js';
+
+class MockBodyDesc {
+  translation: [number, number, number] = [0, 0, 0];
+  rotation = { x: 0, y: 0, z: 0, w: 1 };
+  ccd = false;
+
+  setTranslation(x: number, y: number, z: number): this {
+    this.translation = [x, y, z];
+    return this;
+  }
+
+  setRotation(rotation: { x: number; y: number; z: number; w: number }): this {
+    this.rotation = rotation;
+    return this;
+  }
+
+  setCcdEnabled(enabled: boolean): this {
+    this.ccd = enabled;
+    return this;
+  }
+}
+
+class MockColliderDesc {
+  readonly kind: 'ball' | 'capsule';
+  readonly radius: number;
+  readonly halfHeight?: number;
+  activeEvents: number | undefined;
+  activeCollisionTypes: number | undefined;
+  sensor: boolean | undefined;
+
+  constructor(kind: 'ball' | 'capsule', radius: number, halfHeight?: number) {
+    this.kind = kind;
+    this.radius = radius;
+    this.halfHeight = halfHeight;
+  }
+
+  setActiveEvents(value: number): this {
+    this.activeEvents = value;
+    return this;
+  }
+
+  setActiveCollisionTypes(value: number): this {
+    this.activeCollisionTypes = value;
+    return this;
+  }
+
+  setSensor(value: boolean): this {
+    this.sensor = value;
+    return this;
+  }
+}
+
+function createMockState(): {
+  state: GameState;
+  bodyDesc: () => MockBodyDesc;
+  colliderDesc: () => MockColliderDesc;
+} {
+  let latestBody: MockBodyDesc | undefined;
+  let latestCollider: MockColliderDesc | undefined;
+
+  const state = {
+    rapier: {
+      RigidBodyDesc: {
+        kinematicPositionBased: () => {
+          latestBody = new MockBodyDesc();
+          return latestBody;
+        },
+      },
+      ColliderDesc: {
+        ball: (radius: number) => {
+          latestCollider = new MockColliderDesc('ball', radius);
+          return latestCollider;
+        },
+        capsule: (halfHeight: number, radius: number) => {
+          latestCollider = new MockColliderDesc('capsule', radius, halfHeight);
+          return latestCollider;
+        },
+      },
+      ActiveEvents: { COLLISION_EVENTS: 1 },
+      ActiveCollisionTypes: { ALL: 3 },
+    },
+    physicsWorld: {
+      createRigidBody: (desc: MockBodyDesc) => ({ desc }) as unknown as RigidBody,
+      createCollider: (desc: MockColliderDesc) => ({ handle: 42, desc }) as unknown as Collider,
+    },
+    colliderLookup: new Map<number, GameEntity>(),
+  } as unknown as GameState;
+
+  return {
+    state,
+    bodyDesc: () => latestBody as MockBodyDesc,
+    colliderDesc: () => latestCollider as MockColliderDesc,
+  };
+}
+
+describe('physicsFactory', () => {
+  it('creates a kinematic body and collider with provided transforms', () => {
+    const { state, bodyDesc, colliderDesc } = createMockState();
+    const position = new Vector3(5, 6, 7);
+    const rotation = new Quaternion(0.1, 0.2, 0.3, 0.9);
+
+    const { body, collider } = createKinematicBodyWithCollider(state, {
+      position,
+      rotation,
+      collider: { type: 'capsule', halfHeight: 0.8, radius: 0.6 },
+      ccd: true,
+    });
+
+    expect(body).toBeTruthy();
+    expect(collider).toBeTruthy();
+    expect(bodyDesc().translation).toEqual([5, 6, 7]);
+    expect(bodyDesc().rotation).toEqual({ x: 0.1, y: 0.2, z: 0.3, w: 0.9 });
+    expect(bodyDesc().ccd).toBe(true);
+    expect(colliderDesc().kind).toBe('capsule');
+    expect(colliderDesc().radius).toBe(0.6);
+    expect(colliderDesc().halfHeight).toBe(0.8);
+    expect(colliderDesc().activeEvents).toBe(1);
+    expect(colliderDesc().activeCollisionTypes).toBe(3);
+  });
+
+  it('applies overrides and sensor flag when provided', () => {
+    const { state, colliderDesc } = createMockState();
+
+    createKinematicBodyWithCollider(state, {
+      collider: { type: 'ball', radius: 0.25 },
+      sensor: true,
+      activeEvents: 9,
+      activeCollisionTypes: 12,
+    });
+
+    expect(colliderDesc().kind).toBe('ball');
+    expect(colliderDesc().radius).toBe(0.25);
+    expect(colliderDesc().sensor).toBe(true);
+    expect(colliderDesc().activeEvents).toBe(9);
+    expect(colliderDesc().activeCollisionTypes).toBe(12);
+  });
+
+  it('safely registers and unregisters collider handles', () => {
+    const { state } = createMockState();
+    const collider = { handle: 77 } as Collider;
+    const entity = { id: 1 } as unknown as GameEntity;
+
+    registerColliderHandle(state, collider, entity);
+    expect(state.colliderLookup.get(77)).toBe(entity);
+
+    unregisterColliderHandle(state, collider);
+    expect(state.colliderLookup.has(77)).toBe(false);
+  });
+
+  it('ignores colliders without handles when registering', () => {
+    const { state } = createMockState();
+    registerColliderHandle(state, null, { id: 2 } as unknown as GameEntity);
+    expect(state.colliderLookup.size).toBe(0);
+  });
+});

--- a/test/vitest/range-policy.spec.ts
+++ b/test/vitest/range-policy.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import {
+  adjustBehaviorProfileRange,
+  adjustProjectileSpeedForHullAndBullet,
+  applyRangeVariance,
+  isLegacyRangePolicy,
+  type RangePolicyConfig,
+} from '../../src/game/utils/rangePolicy.js';
+import { SeededRng } from '../../src/utils/rng.js';
+
+const legacyConfig: RangePolicyConfig = { rangePolicy: 'v0.1.1-exp' } as RangePolicyConfig;
+const modernConfig: RangePolicyConfig = { rangePolicy: 'none' } as RangePolicyConfig;
+
+describe('rangePolicy', () => {
+  it('detects legacy range policy', () => {
+    expect(isLegacyRangePolicy(legacyConfig)).toBe(true);
+    expect(isLegacyRangePolicy(modernConfig)).toBe(false);
+  });
+
+  it('applies deterministic range variance for legacy policy', () => {
+    const baseRange = 300;
+    const traitSeed = 12345;
+
+    const expectedPrimary = (() => {
+      const seed = Math.abs((traitSeed ^ (0 * 7919)) >>> 0) || 1;
+      const rng = new SeededRng(seed);
+      const variance = 0.05;
+      const modifier = 1 + (rng.next() * 2 - 1) * variance;
+      return Math.round(baseRange * modifier);
+    })();
+
+    const expectedTurret = (() => {
+      const seed = Math.abs((traitSeed ^ (2 * 7919)) >>> 0) || 1;
+      const rng = new SeededRng(seed);
+      const variance = 0.05;
+      const modifier = 1 + (rng.next() * 2 - 1) * variance;
+      return Math.round(baseRange * modifier);
+    })();
+
+    expect(applyRangeVariance(baseRange, traitSeed, 0, legacyConfig)).toBe(expectedPrimary);
+    expect(applyRangeVariance(baseRange, traitSeed, 2, legacyConfig)).toBe(expectedTurret);
+    expect(applyRangeVariance(baseRange, traitSeed, 0, modernConfig)).toBe(baseRange);
+  });
+
+  it('adjusts projectile speed according to hull and bullet type under legacy policy', () => {
+    const baseSpeed = 100;
+    const destroyerLaser = adjustProjectileSpeedForHullAndBullet(
+      'destroyer',
+      baseSpeed,
+      'bullet:laser',
+      false,
+      legacyConfig,
+    );
+    expect(destroyerLaser).toBeCloseTo(baseSpeed * 1.05 * 0.97, 5);
+
+    const fighterIon = adjustProjectileSpeedForHullAndBullet(
+      'fighter',
+      baseSpeed,
+      'bullet:ion',
+      false,
+      legacyConfig,
+    );
+    expect(fighterIon).toBeCloseTo(baseSpeed * 1.02 * 1.03, 5);
+
+    const overridden = adjustProjectileSpeedForHullAndBullet(
+      'frigate',
+      baseSpeed,
+      'bullet:kinetic',
+      true,
+      legacyConfig,
+    );
+    expect(overridden).toBe(baseSpeed);
+
+    const nonLegacy = adjustProjectileSpeedForHullAndBullet(
+      'destroyer',
+      baseSpeed,
+      'bullet:laser',
+      false,
+      modernConfig,
+    );
+    expect(nonLegacy).toBe(baseSpeed);
+  });
+
+  it('adjusts behaviour profile ranges consistent with legacy policy rules', () => {
+    const baseRange: readonly [number, number] = [150, 220];
+    const artillery = adjustBehaviorProfileRange(baseRange, 'artillery', 'carrier', legacyConfig);
+    expect(artillery).toEqual([190, 300]);
+
+    const escort = adjustBehaviorProfileRange([60, 110], 'escort', 'frigate', legacyConfig);
+    expect(escort).toEqual([50, 110]);
+
+    const unchanged = adjustBehaviorProfileRange(baseRange, 'support', 'frigate', legacyConfig);
+    expect(unchanged).toBe(baseRange);
+
+    const nonLegacy = adjustBehaviorProfileRange(baseRange, 'artillery', 'carrier', modernConfig);
+    expect(nonLegacy).toBe(baseRange);
+  });
+});

--- a/test/vitest/steering-utils.spec.ts
+++ b/test/vitest/steering-utils.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { Vector3 } from 'three';
+import {
+  FORWARD,
+  clampAngle,
+  computeLeadDirection,
+  orientQuaternionFromDirection,
+  safeNormalize,
+  steerDirection,
+} from '../../src/utils/steering.js';
+
+describe('steering utilities', () => {
+  it('safely normalises vectors with fallback', () => {
+    const result = safeNormalize(new Vector3(), new Vector3(2, 0, 0));
+    expect(result.length()).toBeCloseTo(1, 6);
+    expect(result.x).toBeCloseTo(1, 6);
+
+    const fallbackResult = safeNormalize(new Vector3(), new Vector3(0, 0, 0), new Vector3(0, 5, 0));
+    expect(fallbackResult).toEqual(new Vector3(0, 1, 0));
+
+    const defaultFallback = safeNormalize(new Vector3(), new Vector3(0, 0, 0));
+    expect(defaultFallback).toEqual(new Vector3(0, 0, 1));
+  });
+
+  it('orients quaternion from direction safely', () => {
+    const direction = new Vector3(0, 1, 0);
+    const quaternion = orientQuaternionFromDirection(direction);
+    const rotated = new Vector3().copy(FORWARD).applyQuaternion(quaternion);
+    expect(rotated.distanceTo(direction.normalize())).toBeLessThan(1e-6);
+
+    const fallbackQuaternion = orientQuaternionFromDirection(
+      new Vector3(0, 0, 0),
+      new Vector3(0, 1, 0),
+    );
+    const fallbackRotated = new Vector3().copy(FORWARD).applyQuaternion(fallbackQuaternion);
+    expect(fallbackRotated.distanceTo(new Vector3(0, 1, 0))).toBeLessThan(1e-6);
+  });
+
+  it('computes lead direction with optional velocity component', () => {
+    const targetPos = new Vector3(10, 0, 0);
+    const sourcePos = new Vector3(0, 0, 0);
+    const velocity = new Vector3(0, 2, 0);
+    const leadDir = computeLeadDirection(targetPos, sourcePos, velocity, 0.5);
+    expect(leadDir.length()).toBeCloseTo(1, 6);
+    expect(leadDir.x).toBeGreaterThan(0.7);
+    expect(leadDir.y).toBeGreaterThan(0.2);
+
+    const noLead = computeLeadDirection(targetPos, sourcePos, velocity, 0);
+    expect(noLead.y).toBeCloseTo(0, 6);
+  });
+
+  it('steers direction respecting turn limits', () => {
+    const current = new Vector3(1, 0, 0);
+    const desired = new Vector3(0, 1, 0);
+    const { newDir, angle } = steerDirection(current, desired, Math.PI, 0.1, new Vector3());
+    expect(angle).toBeCloseTo(Math.PI / 2, 5);
+    expect(newDir.length()).toBeCloseTo(1, 6);
+    expect(newDir.x).toBeGreaterThan(0);
+    expect(newDir.y).toBeGreaterThan(0);
+
+    const { newDir: limited } = steerDirection(current, desired, 0, 0.1, new Vector3());
+    expect(limited.x).toBeCloseTo(1, 6);
+    expect(limited.y).toBeCloseTo(0, 6);
+  });
+
+  it('clamps angles within bounds with wrapping', () => {
+    expect(clampAngle(4 * Math.PI, -Math.PI / 2, Math.PI / 2)).toBeCloseTo(0, 6);
+    expect(clampAngle((-3 * Math.PI) / 2, -Math.PI / 2, Math.PI / 2)).toBeCloseTo(Math.PI / 2, 6);
+    expect(clampAngle(Math.PI / 4, -Math.PI / 2, Math.PI / 2)).toBeCloseTo(Math.PI / 4, 6);
+  });
+});


### PR DESCRIPTION
## Summary
- add a kinematic physics factory helper with safe collider registration utilities
- centralize range policy variance and projectile speed adjustments for legacy AI configs
- extract reusable steering math and migrate ships, projectiles, and rendering helpers to the shared utilities
- expand coverage with unit tests for the new utilities and update range variance script

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ffe0256810832abe119a56af5ea972