### PR TITLE
refactor: split star disk and ship lod modules

### DIFF
--- a/docs/large-file-refactor-candidates.md
+++ b/docs/large-file-refactor-candidates.md
@@ -1,0 +1,82 @@
+# Large `src/` files ready for decomposition
+
+This note highlights three oversized source files whose responsibilities have accreted over time. Each section calls out the
+current scope and proposes concrete seams for extracting smaller, easier-to-own modules.
+
+## Summary snapshot
+
+| File | Approx. LOC | Primary responsibilities | Suggested split points |
+| --- | --- | --- | --- |
+| `src/components/environment/StarDisk.tsx` | ~824 | Shader material wiring, runtime uniform updates, debug tooling, and fallback animation | Extract hooks for uniforms/timekeeping, standalone debug overlay module, and lightweight presentational component |
+| `src/components/lod/ShipLODManager.tsx` | ~325 | LOD classification math, instanced impostor layer, and React orchestration | Move pure partitioning helpers to `src/game` utils, split instanced layer into its own module, and expose a hook-driven manager |
+| `src/types/ai.ts` | ~323 | Doctrine definitions, AI state, sensor visibility, metrics, and telemetry | Separate doctrine/state typings from metrics/telemetry into focused declaration files with an index re-export |
+
+## `src/components/environment/StarDisk.tsx`
+
+*Why it is large:* The component owns material creation, star textures, bloom hookup, optional game-state fallbacks, and a very
+large `useFrame` loop that updates uniforms, debug overlays, and telemetry snapshots in one place (see the imports and setup up
+front, plus the 200+ line frame handler that pushes alignment, diagnostic DOM markers, and debug telemetry).
+
+*Pain points:*
+
+- Debug logic (overlay DOM manipulations, telemetry buffers, console dumps) is intertwined with the render path, making the core
+  star disk update loop hard to follow and risky to change when debugging is disabled.
+- Timekeeping fallbacks and Rapier panic handling live alongside camera-alignment math and uniform uploads, so even small changes
+  to progression handling require editing the monolithic frame update.
+- Resource lifecycle (textures, shader material, debug overlay cleanup) is scattered through many `useEffect` blocks, increasing
+  the cognitive load for future modifications.
+
+*Recommended split:*
+
+1. Extract a `useStarDiskUniforms` hook that encapsulates the `useFrame` block: compute time, wrap cycles, view alignment, and
+   return the uniform payload for the presentational mesh.
+2. Move debug-only behavior (DOM overlay management, telemetry export, forced material reapply) into a `StarDiskDebug` helper
+   module invoked conditionally so the render path stays minimal.
+3. Create a small wrapper component (e.g. `StarDiskView`) that only receives derived props (material, uniforms, offsets), while
+   resource acquisition (textures, bloom routing) shifts to composable hooks.
+
+## `src/components/lod/ShipLODManager.tsx`
+
+*Why it is large:* The file mixes low-level partitioning algorithms (`classifyLod`, `partitionShipsByDistance`), instanced mesh
+population helpers (`populateImpostorInstances` and the nested `ShipImpostorLayer` component), plus the high-level `ShipLODManager`
+React component that orchestrates hooks, state refs, and frame updates.
+
+*Pain points:*
+
+- Pure math helpers that belong near the game simulation live beside React-specific logic, so they cannot be reused by tests or
+  non-React callers without importing the heavy component file.
+- The instanced impostor layer implements its own frame loop and warning system inline, complicating targeted refactors to switch
+  materials or pooling strategies.
+- State refs for thresholds, ship collections, and partition results are hand-rolled inside the main component, obscuring the
+  actual rendering responsibilities.
+
+*Recommended split:*
+
+1. Move partitioning helpers (`classifyLod`, `partitionShipsByDistance`, `computeLodPartition`, `partitionsEqual`) into a new
+   `src/game/lod/partition.ts` module with unit coverage, letting both the React layer and any future systems reuse the math.
+2. Extract `ShipImpostorLayer` and related instancing utilities into `src/components/lod/ShipImpostorLayer.tsx` so shader/material
+   work can iterate independently of the manager.
+3. Wrap the manager’s ref bookkeeping and frame updates in a custom hook (e.g. `useShipLodPartition`) that returns `{nearShips,
+   farShips}`, reducing component size and clarifying render vs. data responsibilities.
+
+## `src/types/ai.ts`
+
+*Why it is large:* The file aggregates nearly every AI-related type in the project: intents, commands, doctrine card definitions,
+blackboard structures, escort assignments, interrupt events, and the full metrics/telemetry schema for analytics dashboards.
+
+*Pain points:*
+
+- Downstream modules must import this monolithic declaration file even when they only need a narrow slice (e.g. doctrine cards or
+  telemetry summaries), increasing TypeScript compile time and making diffs noisy.
+- Documentation comments and optional legacy fields (e.g. vertical dispersion tracking, tie summaries) crowd the core intent
+  types, making it difficult to spot breaking changes or audit unused telemetry.
+- The metrics structures change more frequently than the stable runtime state, but both share the same file, forcing unrelated
+  review for each tweak.
+
+*Recommended split:*
+
+1. Create a `src/types/ai/state.ts` module that defines intents, commands, AI state, blackboard data, and escort assignments.
+2. Move doctrine-specific types (cards, modifiers, posture) into `src/types/ai/doctrine.ts` so doctrine work is isolated from
+   runtime/metric changes.
+3. Place metrics and telemetry summaries into `src/types/ai/metrics.ts`, leaving the main `ai.ts` file to re-export these slices
+   via `index.ts` to preserve the public surface while enabling focused maintenance.

--- a/src/components/environment/StarDisk.tsx
+++ b/src/components/environment/StarDisk.tsx
@@ -1,33 +1,28 @@
 import { useMemo, useRef, useEffect } from 'react';
 import type { Mesh } from 'three';
-import {
-  Vector3,
-  ShaderMaterial,
-  Quaternion,
-  MeshBasicMaterial,
-  DoubleSide,
-} from 'three';
-import { useFrame, useThree } from '@react-three/fiber';
-import type { StarLightConfig, CelestialEnvironmentConfig, StarDiskHazeConfig, StarDiskBoundaryConfig } from '../../config/environment.js';
+import { Vector3, ShaderMaterial, Quaternion } from 'three';
+import { useThree } from '@react-three/fiber';
+import type {
+  StarLightConfig,
+  CelestialEnvironmentConfig,
+  StarDiskHazeConfig,
+  StarDiskBoundaryConfig,
+} from '../../config/environment.js';
 import { useOptionalGameState } from '../../game/context.js';
-import {
-  createMainSequenceStarMaterial,
-  updateMainSequenceStarUniforms,
-  type MainSequenceStarUniformUpdate,
-} from '../../renderer/starDiskMaterial.js';
+import { type MainSequenceStarUniformUpdate } from '../../renderer/starDiskMaterial.js';
 import {
   computeStarDiskQuaternion,
   createViewAlignmentScratch,
-  computeViewAlignment,
   type ViewAlignment,
 } from '../../renderer/starDiskOrientation.js';
-import { wrapStarTime, isCopilotDebugEnabled, STAR_TIME_WRAP_SECONDS } from '../../utils/starDisk.js';
 import { useStarTextures } from '../../hooks/useStarTextures.js';
 import { useStarMaterial } from '../../hooks/useStarMaterial.js';
 import { useStarBloom } from '../../hooks/useStarBloom.js';
 import { useDevShaderCompile } from '../../hooks/useDevShaderCompile.js';
 import { useStarDebug, useDebugOverlayCleanup } from '../../hooks/useStarDebug.js';
 import { StarDiskMesh } from './StarDiskMesh.js';
+import { useStarDiskFrameLoop } from './starDisk/useStarDiskFrameLoop.js';
+import { useStarDiskDebugCleanup } from './starDisk/useStarDiskDebugCleanup.js';
 
 interface StarDiskProps {
   config: StarLightConfig;
@@ -45,9 +40,18 @@ interface StarDiskProps {
   boundary?: StarDiskBoundaryConfig;
 }
 
-export function StarDisk({ config, size, opacity, distanceMultiplier, enabled = true, haze, boundary }: StarDiskProps): React.ReactElement | null {
+export function StarDisk({
+  config,
+  size,
+  opacity,
+  distanceMultiplier,
+  enabled = true,
+  haze,
+  boundary,
+}: StarDiskProps): React.ReactElement | null {
   // Allow defaults to be supplied via the environment config when not passed explicitly
-  const env = (globalThis as unknown as { __CELESTIAL__?: CelestialEnvironmentConfig }).__CELESTIAL__;
+  const env = (globalThis as unknown as { __CELESTIAL__?: CelestialEnvironmentConfig })
+    .__CELESTIAL__;
   const defaultSize = size ?? env?.starDisk?.size ?? 800;
   const defaultOpacity = opacity ?? env?.starDisk?.opacity ?? 0.12;
   const defaultDistanceMultiplier = distanceMultiplier ?? env?.starDisk?.distanceMultiplier ?? 0.8;
@@ -55,14 +59,10 @@ export function StarDisk({ config, size, opacity, distanceMultiplier, enabled = 
   const fallbackBoundary = env?.starDisk?.boundary;
   const meshRef = useRef<Mesh>(null);
   const aspectWarnedRef = useRef(false);
-  const fallbackTimeRef = useRef(0);
-  const lastUniformTimeRef = useRef(0);
-  const previousUniformTimeRef = useRef(0);
-  const baseQuaternion = useMemo<Quaternion>(() => computeStarDiskQuaternion(config.direction), [
-    config.direction.x,
-    config.direction.y,
-    config.direction.z,
-  ]);
+  const baseQuaternion = useMemo<Quaternion>(
+    () => computeStarDiskQuaternion(config.direction),
+    [config.direction.x, config.direction.y, config.direction.z],
+  );
   const meshWorldPosition = useMemo(() => new Vector3(), []);
   const viewScratch = useMemo(() => createViewAlignmentScratch(), []);
   const viewAlignmentRef = useRef<ViewAlignment>({ x: 0, y: 0, z: 1 });
@@ -120,9 +120,9 @@ export function StarDisk({ config, size, opacity, distanceMultiplier, enabled = 
   useEffect(() => {
     shaderMaterialRef.current = shaderMaterial;
   }, [shaderMaterial]);
-  
+
   const removeDebugOverlay = useDebugOverlayCleanup();
-  
+
   useEffect(() => {
     const mesh = meshRef.current;
     if (!mesh || typeof (mesh.quaternion as unknown as { copy?: unknown })?.copy !== 'function') {
@@ -133,10 +133,20 @@ export function StarDisk({ config, size, opacity, distanceMultiplier, enabled = 
 
   // Local offset from the parent (StarLight group's origin). When parented, this is the disk's local position.
   const localOffset = useMemo(() => {
-    const direction = new Vector3(config.direction.x, config.direction.y, config.direction.z).normalize();
+    const direction = new Vector3(
+      config.direction.x,
+      config.direction.y,
+      config.direction.z,
+    ).normalize();
     const distance = Math.max(config.distance * defaultDistanceMultiplier, 8000);
     return direction.multiplyScalar(-distance).toArray();
-  }, [config.direction.x, config.direction.y, config.direction.z, config.distance, defaultDistanceMultiplier]);
+  }, [
+    config.direction.x,
+    config.direction.y,
+    config.direction.z,
+    config.distance,
+    defaultDistanceMultiplier,
+  ]);
 
   // Ensure the shader material is explicitly assigned to the mesh when
   // available. This guards against render-order or attach timing issues
@@ -150,7 +160,9 @@ export function StarDisk({ config, size, opacity, distanceMultiplier, enabled = 
         if (mesh.material !== (mat as any)) {
           mesh.material = mat as any;
           // mark needsUpdate to ensure renderer picks up any shader swap
-          try { (mat as any).needsUpdate = true; } catch {
+          try {
+            (mat as any).needsUpdate = true;
+          } catch {
             /* ignore */
           }
         }
@@ -166,646 +178,23 @@ export function StarDisk({ config, size, opacity, distanceMultiplier, enabled = 
 
   useStarBloom(meshRef, enabled, shaderMaterial);
 
-  // Make the disk always face the camera (billboard behavior)
-  useFrame((state, delta) => {
-    if (!enabled) {
-      return;
-    }
-    const debugWin = debugEnabled && typeof window !== 'undefined' ? (window as any) : undefined;
-
-    // DEV: handle force-opaque requests early so they apply even if the
-    // shader material hasn't been created yet. This sets a global flag and
-    // triggers `needsUpdate` once the material exists.
-    if (debugWin && debugWin.__copilot_forceStarOpaqueRequest) {
-      try {
-        debugWin.__copilot_forceStarOpaque = true;
-      } catch {
-        /* ignore */
-      }
-      const pendingMat = shaderMaterialRef.current;
-      if (pendingMat) {
-        try {
-          pendingMat.needsUpdate = true;
-        } catch {
-          /* ignore */
-        }
-        try {
-          debugWin.__copilot_forceStarOpaqueApplied = Date.now();
-        } catch {
-          /* ignore */
-        }
-        try {
-          debugWin.__copilot_forceStarOpaqueRequest = false;
-        } catch {
-          /* ignore */
-        }
-      }
-    }
-
-    const mat = shaderMaterialRef.current;
-    if (!mat) {
-      return;
-    }
-
-    // DEV: unconditional per-frame mesh status for automation (runs before
-    // material checks so it captures presence/visibility early each frame)
-    if (debugWin) {
-      const meshLocal = meshRef.current;
-      if (meshLocal) {
-        try {
-          const matAny: any = (meshLocal.material as any) || null;
-          const wp = meshLocal.getWorldPosition ? meshLocal.getWorldPosition(new Vector3()) : meshLocal.position;
-          debugWin.__copilot_starMeshStatus = {
-            present: true,
-            visible: !!meshLocal.visible,
-            renderOrder: Number(meshLocal.renderOrder || 0),
-            materialType: matAny ? (matAny.type || null) : null,
-            materialTransparent: matAny ? !!matAny.transparent : false,
-            materialOpacity: matAny && typeof matAny.opacity === 'number' ? matAny.opacity : null,
-            userDataKeys: Object.keys(meshLocal.userData || {}),
-            worldPosition: { x: wp.x, y: wp.y, z: wp.z },
-            timestamp: Date.now(),
-          };
-        } catch {
-          /* ignore */
-        }
-      } else {
-        try {
-          debugWin.__copilot_starMeshStatus = { present: false, timestamp: Date.now() };
-        } catch {
-          /* ignore */
-        }
-      }
-    }
-
-    const { camera, viewport } = state;
-    // DEV: allow external automation to request a small camera rotation by
-    // setting `window.__copilot_rotateCameraDeltaDeg = <degrees>`. We apply
-    // the rotation here (in the render loop) so the page evaluation does not
-    // need to serialize functions or reach into React internals.
-    if (debugWin && debugWin.__copilot_rotateCameraDeltaDeg !== undefined && debugWin.__copilot_rotateCameraDeltaDeg !== null) {
-      const deg = Number(debugWin.__copilot_rotateCameraDeltaDeg);
-      if (Number.isFinite(deg)) {
-        camera.rotation.y += deg * Math.PI / 180;
-        try {
-          debugWin.__copilot_rotateAppliedAt = Date.now();
-        } catch {
-          /* ignore */
-        }
-      }
-      try {
-        debugWin.__copilot_rotateCameraDeltaDeg = null;
-      } catch {
-        /* ignore */
-      }
-    }
-
-    const mesh = meshRef.current;
-    const meshQuaternion = mesh?.quaternion ?? null;
-    const sim = gameState?.simulation;
-    const deltaSeconds = Number.isFinite(delta) && delta > 0 ? delta : 0;
-    const simTime = sim ? sim.lastTickStart + sim.alpha * sim.step : undefined;
-    const hasSimTime = typeof simTime === 'number' && Number.isFinite(simTime);
-    const renderClock = (state as { clock?: { getElapsedTime?: () => number; elapsedTime?: number } }).clock;
-    let renderTime: number | undefined;
-    if (renderClock) {
-      if (typeof renderClock.getElapsedTime === 'function') {
-        renderTime = renderClock.getElapsedTime();
-      } else if (Number.isFinite(renderClock.elapsedTime ?? NaN)) {
-        renderTime = renderClock.elapsedTime as number;
-      }
-    }
-    if (typeof renderTime !== 'number' || !Number.isFinite(renderTime)) {
-      renderTime = undefined;
-    }
-
-    const EPSILON = 1e-6;
-    const fallbackStep = deltaSeconds > 0 ? deltaSeconds : 1 / 60;
-    let candidateTime = Number.NEGATIVE_INFINITY;
-    if (hasSimTime) {
-      candidateTime = Math.max(candidateTime, simTime as number);
-    }
-    if (typeof renderTime === 'number') {
-      candidateTime = Math.max(candidateTime, renderTime);
-    }
-
-    const previousRawTime = lastUniformTimeRef.current;
-    let rawElapsed: number;
-    const usedFallback = !(Number.isFinite(candidateTime) && candidateTime > previousRawTime + EPSILON);
-    if (!usedFallback) {
-      rawElapsed = candidateTime;
-      fallbackTimeRef.current = rawElapsed;
-    } else {
-      const base = Math.max(previousRawTime, fallbackTimeRef.current);
-      fallbackTimeRef.current = base + fallbackStep;
-      rawElapsed = fallbackTimeRef.current;
-    }
-
-    lastUniformTimeRef.current = rawElapsed;
-    const { wrapped: wrappedElapsed, cycles: wrapCycles } = wrapStarTime(rawElapsed);
-
-    // DEV: publish StarDisk uniform telemetry for debugging and correlation with Rapier diagnostics
-    if (isCopilotDebugEnabled()) {
-      const now = Date.now();
-      const deltaTime = rawElapsed - previousUniformTimeRef.current;
-      const isProgressing = deltaTime > 0;
-      const rapierDiagnostics = gameState?.simulation?.rapierDiagnostics;
-
-      try {
-        const debugWin = window as Window & {
-          __copilot_starDiskTelemetry?: {
-            iTime: number;
-            rawTime?: number;
-            wrapCycle?: number;
-            deltaTime: number;
-            isProgressing: boolean;
-            timestamp: number;
-            frameCount: number;
-            simTime?: number;
-            renderTime?: number;
-            usedFallback: boolean;
-            rapierPanicCount?: number;
-            lastRapierPanicTick?: number;
-            ticksSinceLastPanic?: number;
-          };
-        };
-
-        const prevTelemetry = debugWin.__copilot_starDiskTelemetry;
-        const frameCount = (prevTelemetry?.frameCount ?? 0) + 1;
-
-        debugWin.__copilot_starDiskTelemetry = {
-          iTime: wrappedElapsed,
-          rawTime: rawElapsed,
-          wrapCycle: wrapCycles,
-          deltaTime,
-          isProgressing,
-          timestamp: now,
-          frameCount,
-          simTime: hasSimTime ? simTime as number : undefined,
-          renderTime,
-          usedFallback,
-          rapierPanicCount: rapierDiagnostics?.stepPanics,
-          lastRapierPanicTick: rapierDiagnostics?.lastStepPanicTick !== -1 ? rapierDiagnostics?.lastStepPanicTick : undefined,
-          ticksSinceLastPanic: rapierDiagnostics && rapierDiagnostics.lastStepPanicTick !== -1
-            ? (sim?.lastTickIndex ?? 0) - rapierDiagnostics.lastStepPanicTick
-            : undefined,
-        };
-      } catch {
-        // ignore telemetry publishing errors
-      }
-
-      previousUniformTimeRef.current = rawElapsed;
-    }
-
-    const rawAspect = viewport.aspect;
-    const safeAspect = Number.isFinite(rawAspect) && rawAspect > 0 ? rawAspect : 1;
-    if (safeAspect > 8 && !aspectWarnedRef.current) {
-      console.warn(`[StarDisk] Unusually high viewport aspect detected: ${safeAspect.toFixed(2)}.`);
-      aspectWarnedRef.current = true;
-    }
-    const { width, height } = state.size;
-    const uniformUpdate: MainSequenceStarUniformUpdate = {
-      time: wrappedElapsed,
-      resolution: {
-        width: Number.isFinite(width) && width > 0 ? width : 1,
-        height: Number.isFinite(height) && height > 0 ? height : 1,
-      },
-    };
-
-    const alignment = viewAlignmentRef.current;
-    alignment.x = 0;
-    alignment.y = 0;
-    alignment.z = 1;
-    const cameraPosition = (camera as { position?: Vector3 }).position;
-    if (
-      mesh &&
-      meshQuaternion &&
-      cameraPosition &&
-      Number.isFinite(cameraPosition.x) &&
-      Number.isFinite(cameraPosition.y) &&
-      Number.isFinite(cameraPosition.z)
-    ) {
-      mesh.updateMatrixWorld();
-      meshWorldPosition.setFromMatrixPosition(mesh.matrixWorld);
-      computeViewAlignment(meshQuaternion, meshWorldPosition, cameraPosition, viewScratch, alignment);
-
-      // DEV: when debug overlay is enabled, compute screen projection and
-      // write a DOM marker so we can sample the canvas at the star's
-      // actual on-screen location.
-      if (debugEnabled) {
-        try {
-          const pos = meshWorldPosition.clone();
-          const proj = pos.project(camera);
-          const ndcX = proj.x; const ndcY = proj.y; const ndcZ = proj.z;
-          const pxX = Math.round((ndcX * 0.5 + 0.5) * width);
-          const pxY = Math.round((-ndcY * 0.5 + 0.5) * height);
-          try {
-            let el = document.getElementById('copilot-star-screen-indicator');
-            if (!el) {
-              el = document.createElement('div');
-              el.id = 'copilot-star-screen-indicator';
-              el.style.position = 'fixed';
-              el.style.pointerEvents = 'none';
-              el.style.width = '12px';
-              el.style.height = '12px';
-              el.style.borderRadius = '50%';
-              el.style.background = 'rgba(255,0,0,0.9)';
-              el.style.zIndex = '2147483647';
-              el.style.transform = 'translate(-50%, -50%)';
-              document.body.appendChild(el);
-            }
-            el.style.left = pxX + 'px';
-            el.style.top = pxY + 'px';
-            el.setAttribute('data-copilot-screen-pos', `${pxX},${pxY}`);
-          } catch {
-            // swallow overlay errors
-          }
-        } catch {
-          // ignore projection errors in environments without window/camera
-        }
-      }
-    }
-
-    uniformUpdate.viewAlignment = alignment;
-    if (hazeConfig) {
-      uniformUpdate.haze = hazeConfig;
-    }
-    uniformUpdate.boundary = boundaryConfig;
-
-    const roll = (camera as any).rotation?.z as number | undefined;
-    if (typeof roll === 'number' && Number.isFinite(roll)) {
-      uniformUpdate.cameraRoll = roll;
-    } else {
-      uniformUpdate.cameraRoll = 0;
-    }
-    uniformUpdate.starNorth = 0;
-    if (organicTexture) {
-      uniformUpdate.organic = organicTexture;
-    }
-    if (noiseTexture) {
-      uniformUpdate.noise = noiseTexture;
-    }
-    updateMainSequenceStarUniforms(mat, uniformUpdate);
-
-    // DEV: diagnostic dump & forced apply — when debug automation sets
-    // `window.__copilot_dumpStarDebug = true` we'll log state and ensure
-    // the shader material is actually assigned to the mesh. This helps
-    // diagnose cases where iTime increases but the disk appears static.
-    if (debugEnabled && debugWin && (debugWin.__copilot_dumpStarDebug === true)) {
-      try {
-        const meshLocal = meshRef.current;
-        const matCurrent = shaderMaterialRef.current;
-        const applied = !!(meshLocal && matCurrent && meshLocal.material === matCurrent);
-        // Lightweight console summary for quick inspection
-        // eslint-disable-next-line no-console
-        console.info('[StarDisk][DBG] dumpStarDebug', { iTime: uniformUpdate.time, applied, materialType: meshLocal ? (meshLocal.material as any)?.type : null, starCompiled: (window as any).__STAR_COMPILED });
-
-        // Try to reassign material if it wasn't applied
-        if (!applied && meshLocal && matCurrent) {
-          try {
-            meshLocal.material = matCurrent as any;
-            matCurrent.needsUpdate = true;
-            // eslint-disable-next-line no-console
-            console.info('[StarDisk][DBG] Reassigned shader material to mesh and flagged needsUpdate');
-          } catch (e) {
-            // eslint-disable-next-line no-console
-            console.warn('[StarDisk][DBG] failed to reassign material', e);
-          }
-        }
-
-        // Publish a small diagnostics snapshot for automation to inspect
-        try {
-          const win = window as any;
-          win.__copilot_starDiskDiagnostics = win.__copilot_starDiskDiagnostics || [];
-          win.__copilot_starDiskDiagnostics.push({ time: Date.now(), iTime: uniformUpdate.time, applied, materialType: meshLocal ? (meshLocal.material as any)?.type : null, starCompiled: (window as any).__STAR_COMPILED });
-          if (win.__copilot_starDiskDiagnostics.length > 20) win.__copilot_starDiskDiagnostics.shift();
-        } catch {
-          /* ignore */
-        }
-      } catch {
-        /* ignore */
-      }
-      try { debugWin.__copilot_dumpStarDebug = false; } catch { /* ignore */ }
-    }
-
-    // DEV: allow automation to request the StarDisk be forced on-top at
-    // runtime — only when explicit debug mode is enabled via URL.
-    if (debugEnabled && debugWin && debugWin.__copilot_forceStarOnTopRequest) {
-      try {
-        const meshLocal = meshRef.current;
-        if (meshLocal) {
-          meshLocal.renderOrder = 99999;
-        }
-      } catch {
-        /* ignore */
-      }
-      const matImmediate = shaderMaterialRef.current;
-      if (matImmediate) {
-        try {
-          (matImmediate as any).depthTest = false;
-          matImmediate.depthWrite = false;
-        } catch {
-          /* ignore */
-        }
-      }
-      try {
-        debugWin.__copilot_star_forceOnTop = true;
-      } catch {
-        /* ignore */
-      }
-      try {
-        debugWin.__copilot_forceStarOnTopRequest = false;
-      } catch {
-        /* ignore */
-      }
-    }
-
-    // DEV: allow automation to request the shader be forced opaque white — only in
-    // explicit debug mode.
-    if (debugEnabled && debugWin && debugWin.__copilot_forceStarOpaqueRequest) {
-      const matImmediate = shaderMaterialRef.current;
-      if (matImmediate) {
-        try {
-          debugWin.__copilot_forceStarOpaque = true;
-        } catch {
-          /* ignore */
-        }
-        try {
-          matImmediate.needsUpdate = true;
-        } catch {
-          /* ignore */
-        }
-        try {
-          debugWin.__copilot_forceStarOpaqueRequest = false;
-        } catch {
-          /* ignore */
-        }
-        try {
-          debugWin.__copilot_forceStarOpaqueApplied = Date.now();
-        } catch {
-          /* ignore */
-        }
-      }
-    }
-
-    // DEV: allow automation to replace the disk material at runtime for diagnostics
-    // — only when explicit debug mode is enabled.
-    if (debugEnabled && debugWin) {
-      if (debugWin.__copilot_forceBasicMaterialRequest) {
-        const meshLocal = meshRef.current;
-        if (meshLocal) {
-          try {
-            if (!meshLocal.userData.__copilot_origMaterial) {
-              meshLocal.userData.__copilot_origMaterial = meshLocal.material;
-            }
-          } catch {
-            /* ignore */
-          }
-          try {
-            const basic = new MeshBasicMaterial({ color: '#ffffff', depthTest: false, depthWrite: false, side: DoubleSide });
-            meshLocal.material = basic;
-            try {
-              debugWin.__copilot_forceBasicMaterialApplied = Date.now();
-            } catch {
-              /* ignore */
-            }
-          } catch {
-            /* ignore */
-          }
-        }
-        try {
-          debugWin.__copilot_forceBasicMaterialRequest = false;
-        } catch {
-          /* ignore */
-        }
-      }
-      if (debugWin.__copilot_restoreOriginalStarMaterial) {
-        const meshLocal = meshRef.current;
-        if (meshLocal && meshLocal.userData && meshLocal.userData.__copilot_origMaterial) {
-          try {
-            if (!Array.isArray(meshLocal.material)) {
-              (meshLocal.material as any).dispose();
-            }
-          } catch {
-            /* ignore */
-          }
-          try {
-            meshLocal.material = meshLocal.userData.__copilot_origMaterial;
-          } catch {
-            /* ignore */
-          }
-          try {
-            delete meshLocal.userData.__copilot_origMaterial;
-          } catch {
-            /* ignore */
-          }
-          try {
-            debugWin.__copilot_restoreOriginalStarMaterialApplied = Date.now();
-          } catch {
-            /* ignore */
-          }
-        }
-        try {
-          debugWin.__copilot_restoreOriginalStarMaterial = false;
-        } catch {
-          /* ignore */
-        }
-      }
-    }
-
-    // DEV: ensure Playwright can always access helper APIs once the mesh exists
-    if (debugEnabled && debugWin && mesh) {
-      if (!debugWin.__copilot_setStarBasicMaterial) {
-        debugWin.__copilot_setStarBasicMaterial = (opts: any = {}) => {
-          try {
-            const meshLocal = meshRef.current;
-            if (!meshLocal) return { applied: false, reason: 'no-mesh' };
-            if (!meshLocal.userData.__copilot_origMaterial) meshLocal.userData.__copilot_origMaterial = meshLocal.material;
-            const color = typeof opts.color === 'string' ? opts.color : '#ffffff';
-            if (!meshLocal.userData.__copilot_forcedMaterial) {
-              meshLocal.userData.__copilot_forcedMaterial = new MeshBasicMaterial({ color, depthTest: false, depthWrite: false, side: DoubleSide });
-            } else {
-              try {
-                meshLocal.userData.__copilot_forcedMaterial.color.set(color);
-              } catch {
-                /* ignore */
-              }
-            }
-            meshLocal.material = meshLocal.userData.__copilot_forcedMaterial;
-            try {
-              debugWin.__copilot_forceBasicMaterialActive = true;
-            } catch {
-              /* ignore */
-            }
-            try {
-              debugWin.__copilot_forceBasicMaterialColor = color;
-            } catch {
-              /* ignore */
-            }
-            try {
-              debugWin.__copilot_forceBasicMaterialApplied = Date.now();
-            } catch {
-              /* ignore */
-            }
-            return { applied: true };
-          } catch (e) {
-            return { applied: false, reason: String(e) };
-          }
-        };
-      }
-
-      if (!debugWin.__copilot_restoreStarMaterial) {
-        debugWin.__copilot_restoreStarMaterial = () => {
-          try {
-            const meshLocal = meshRef.current;
-            if (!meshLocal) return { restored: false, reason: 'no-mesh' };
-            if (meshLocal.userData && meshLocal.userData.__copilot_origMaterial) {
-              try {
-                if (!Array.isArray(meshLocal.material)) {
-                  (meshLocal.material as any).dispose();
-                }
-              } catch {
-                /* ignore */
-              }
-              try {
-                meshLocal.material = meshLocal.userData.__copilot_origMaterial;
-              } catch {
-                /* ignore */
-              }
-              try {
-                delete meshLocal.userData.__copilot_origMaterial;
-              } catch {
-                /* ignore */
-              }
-              try {
-                debugWin.__copilot_restoreOriginalStarMaterialApplied = Date.now();
-              } catch {
-                /* ignore */
-              }
-              return { restored: true };
-            }
-            return { restored: false, reason: 'no-orig' };
-          } catch (e) {
-            return { restored: false, reason: String(e) };
-          }
-        };
-      }
-
-      if (!mesh.userData) mesh.userData = {};
-      if (!mesh.userData.__copilot_origLayerMask) {
-        try {
-          mesh.userData.__copilot_origLayerMask = (mesh.layers as any).mask;
-        } catch {
-          mesh.userData.__copilot_origLayerMask = 1;
-        }
-      }
-
-      if (!debugWin.__copilot_setStarLayer) {
-        debugWin.__copilot_setStarLayer = (layerIndex: any = 0) => {
-          try {
-            const meshLocal = meshRef.current;
-            if (!meshLocal) return { set: false, reason: 'no-mesh' };
-            const n = Number(layerIndex);
-            const idx = Number.isFinite(n) ? Math.max(0, Math.min(Math.floor(n), 31)) : 0;
-            meshLocal.layers.set(idx);
-            try {
-              debugWin.__copilot_starLayerSetAt = Date.now();
-            } catch {
-              /* ignore */
-            }
-            return { set: true, layer: idx };
-          } catch (e) {
-            return { set: false, reason: String(e) };
-          }
-        };
-      }
-
-      if (!debugWin.__copilot_resetStarLayer) {
-        debugWin.__copilot_resetStarLayer = () => {
-          try {
-            const meshLocal = meshRef.current;
-            if (!meshLocal) return { reset: false, reason: 'no-mesh' };
-            const orig = meshLocal.userData && meshLocal.userData.__copilot_origLayerMask;
-            if (typeof orig === 'number') {
-              try {
-                (meshLocal.layers as any).mask = orig;
-              } catch {
-                meshLocal.layers.set(0);
-              }
-            } else {
-              meshLocal.layers.set(0);
-            }
-            try {
-              debugWin.__copilot_starLayerResetAt = Date.now();
-            } catch {
-              /* ignore */
-            }
-            return { reset: true };
-          } catch (e) {
-            return { reset: false, reason: String(e) };
-          }
-        };
-      }
-    }
-
-    // DEV: persistent forced basic material enforcement (active until cleared)
-    // Only enforce when explicit debug mode is enabled.
-    if (debugEnabled && debugWin && debugWin.__copilot_forceBasicMaterialActive) {
-      const meshLocal = meshRef.current;
-      if (meshLocal) {
-        if (!meshLocal.userData.__copilot_origMaterial) meshLocal.userData.__copilot_origMaterial = meshLocal.material;
-        if (!meshLocal.userData.__copilot_forcedMaterial) {
-          const color = typeof debugWin.__copilot_forceBasicMaterialColor === 'string' ? debugWin.__copilot_forceBasicMaterialColor : '#ffffff';
-          meshLocal.userData.__copilot_forcedMaterial = new MeshBasicMaterial({ color, depthTest: false, depthWrite: false, side: DoubleSide });
-        } else if (typeof debugWin.__copilot_forceBasicMaterialColor === 'string') {
-          try {
-            meshLocal.userData.__copilot_forcedMaterial.color.set(debugWin.__copilot_forceBasicMaterialColor);
-          } catch {
-            /* ignore */
-          }
-        }
-        if (meshLocal.material !== meshLocal.userData.__copilot_forcedMaterial) {
-          meshLocal.material = meshLocal.userData.__copilot_forcedMaterial;
-        }
-        try {
-          debugWin.__copilot_forceBasicMaterialApplied = debugWin.__copilot_forceBasicMaterialApplied || Date.now();
-        } catch {
-          /* ignore */
-        }
-      }
-    }
+  useStarDiskFrameLoop({
+    enabled,
+    debugEnabled,
+    meshRef,
+    shaderMaterialRef,
+    gameState,
+    hazeConfig,
+    boundaryConfig,
+    organicTexture,
+    noiseTexture,
+    viewAlignmentRef,
+    meshWorldPosition,
+    viewScratch,
+    aspectWarnedRef,
   });
 
-  // Cleanup / restore when not in explicit debug mode. Minimal and
-  // well-formed: revert forced debug artifacts if debug is not enabled.
-  useEffect(() => {
-    if (debugEnabled) {
-      return;
-    }
-    const mesh = meshRef.current;
-    if (!mesh) return;
-
-    // restore original material if present
-    try {
-      const orig = mesh.userData && mesh.userData.__copilot_origMaterial;
-      if (orig && mesh.material !== orig) {
-        try { if (!(Array.isArray(mesh.material))) { (mesh.material as any).dispose(); } } catch { /* ignore */ }
-        try { mesh.material = orig; } catch { /* ignore */ }
-        try { delete mesh.userData.__copilot_forcedMaterial; } catch { /* ignore */ }
-        try { delete mesh.userData.__copilot_origMaterial; } catch { /* ignore */ }
-      }
-    } catch { /* ignore */ }
-
-    try { if (typeof mesh.renderOrder === 'number') mesh.renderOrder = 0; } catch { /* ignore */ }
-    try {
-      const mat: any = mesh.material as any;
-      if (mat) {
-        try { if (typeof mat.depthTest === 'boolean') mat.depthTest = true; } catch { /* ignore */ }
-        try { if (typeof mat.depthWrite === 'boolean') mat.depthWrite = true; } catch { /* ignore */ }
-      }
-    } catch { /* ignore */ }
-    removeDebugOverlay();
-  }, [debugEnabled, removeDebugOverlay]);
+  useStarDiskDebugCleanup({ debugEnabled, meshRef, removeDebugOverlay });
 
   if (!enabled) return null;
 

--- a/src/components/environment/starDisk/useStarDiskDebugCleanup.ts
+++ b/src/components/environment/starDisk/useStarDiskDebugCleanup.ts
@@ -1,0 +1,61 @@
+import { useEffect, type MutableRefObject } from 'react';
+import type { Material, Mesh } from 'three';
+
+interface CopilotMeshUserData {
+  __copilot_origMaterial?: Material;
+  __copilot_forcedMaterial?: Material;
+}
+
+function resolveMaterial(material: Mesh['material']): Material | null {
+  if (Array.isArray(material)) {
+    return (material[0] as Material | undefined) ?? null;
+  }
+  return material ?? null;
+}
+
+interface UseStarDiskDebugCleanupParams {
+  debugEnabled: boolean;
+  meshRef: MutableRefObject<Mesh | null>;
+  removeDebugOverlay: () => void;
+}
+
+export function useStarDiskDebugCleanup({
+  debugEnabled,
+  meshRef,
+  removeDebugOverlay,
+}: UseStarDiskDebugCleanupParams): void {
+  useEffect(() => {
+    if (debugEnabled) {
+      return;
+    }
+    const mesh = meshRef.current;
+    if (!mesh) return;
+
+    const userData = (mesh.userData ?? {}) as CopilotMeshUserData;
+    const originalMaterial = userData.__copilot_origMaterial;
+    if (originalMaterial && mesh.material !== originalMaterial) {
+      const currentMaterial = resolveMaterial(mesh.material);
+      currentMaterial?.dispose();
+      mesh.material = originalMaterial;
+      delete userData.__copilot_forcedMaterial;
+      delete userData.__copilot_origMaterial;
+    }
+
+    try {
+      if (typeof mesh.renderOrder === 'number') mesh.renderOrder = 0;
+    } catch {
+      /* ignore */
+    }
+
+    const material = resolveMaterial(mesh.material);
+    if (material) {
+      if (typeof material.depthTest === 'boolean') {
+        material.depthTest = true;
+      }
+      if (typeof material.depthWrite === 'boolean') {
+        material.depthWrite = true;
+      }
+    }
+    removeDebugOverlay();
+  }, [debugEnabled, meshRef, removeDebugOverlay]);
+}

--- a/src/components/environment/starDisk/useStarDiskFrameLoop.ts
+++ b/src/components/environment/starDisk/useStarDiskFrameLoop.ts
@@ -1,0 +1,773 @@
+import { useFrame } from '@react-three/fiber';
+import { useRef, type MutableRefObject } from 'react';
+import {
+  DoubleSide,
+  MeshBasicMaterial,
+  ShaderMaterial,
+  Vector3,
+  type Material,
+  type Mesh,
+  type Texture,
+} from 'three';
+import type { GameState } from '../../../types/index.js';
+import {
+  updateMainSequenceStarUniforms,
+  type MainSequenceStarUniformUpdate,
+} from '../../../renderer/starDiskMaterial.js';
+import {
+  computeViewAlignment,
+  type ViewAlignment,
+  type ViewAlignmentScratch,
+} from '../../../renderer/starDiskOrientation.js';
+import { wrapStarTime, isCopilotDebugEnabled } from '../../../utils/starDisk.js';
+
+interface CopilotStarMeshStatus {
+  present: boolean;
+  visible?: boolean;
+  renderOrder?: number;
+  materialType?: string | null;
+  materialTransparent?: boolean;
+  materialOpacity?: number | null;
+  userDataKeys?: string[];
+  worldPosition?: { x: number; y: number; z: number };
+  timestamp: number;
+}
+
+interface CopilotDiagnosticsEntry {
+  time: number;
+  iTime: number;
+  applied: boolean;
+  materialType: string | null;
+  starCompiled: unknown;
+}
+
+interface CopilotDebugWindow extends Window {
+  __copilot_forceStarOpaqueRequest?: boolean;
+  __copilot_forceStarOpaque?: boolean;
+  __copilot_forceStarOpaqueApplied?: number;
+  __copilot_starMeshStatus?: CopilotStarMeshStatus;
+  __copilot_rotateCameraDeltaDeg?: number | null;
+  __copilot_rotateAppliedAt?: number;
+  __copilot_starDiskTelemetry?: {
+    iTime: number;
+    rawTime?: number;
+    wrapCycle?: number;
+    deltaTime: number;
+    isProgressing: boolean;
+    timestamp: number;
+    frameCount: number;
+    simTime?: number;
+    renderTime?: number;
+    usedFallback: boolean;
+    rapierPanicCount?: number;
+    lastRapierPanicTick?: number;
+    ticksSinceLastPanic?: number;
+  };
+  __copilot_dumpStarDebug?: boolean;
+  __copilot_starDiskDiagnostics?: CopilotDiagnosticsEntry[];
+  __copilot_forceStarOnTopRequest?: boolean;
+  __copilot_star_forceOnTop?: boolean;
+  __copilot_forceBasicMaterialRequest?: boolean;
+  __copilot_forceBasicMaterialApplied?: number;
+  __copilot_restoreOriginalStarMaterial?: boolean;
+  __copilot_restoreOriginalStarMaterialApplied?: number;
+  __copilot_forceBasicMaterialActive?: boolean;
+  __copilot_setStarBasicMaterial?: (opts?: { color?: string }) => {
+    applied: boolean;
+    reason?: string;
+  };
+  __copilot_restoreStarMaterial?: () => { restored: boolean; reason?: string };
+  __copilot_forceBasicMaterial?: boolean;
+  __copilot_setStarLayer?: (layerIndex?: unknown) => {
+    set: boolean;
+    layer?: number;
+    reason?: string;
+  };
+  __copilot_starLayerSetAt?: number;
+  __copilot_resetStarLayer?: () => { reset: boolean; reason?: string };
+  __copilot_starLayerResetAt?: number;
+  __copilot_forceBasicMaterialColor?: string;
+  __STAR_COMPILED?: boolean;
+}
+
+interface CopilotMeshUserData {
+  __copilot_origMaterial?: Material;
+  __copilot_forcedMaterial?: MeshBasicMaterial;
+  __copilot_origLayerMask?: number;
+}
+
+function resolveMaterial(material: Mesh['material']): Material | null {
+  if (Array.isArray(material)) {
+    return (material[0] as Material | undefined) ?? null;
+  }
+  return material ?? null;
+}
+
+function getCopilotUserData(mesh: Mesh): CopilotMeshUserData {
+  if (!mesh.userData || typeof mesh.userData !== 'object') {
+    // three.js always initialises userData to an object, but guard defensively
+    // to satisfy the type checker when mocks replace the mesh implementation.
+    mesh.userData = {} as Record<string, unknown>;
+  }
+  return mesh.userData as CopilotMeshUserData;
+}
+
+export interface UseStarDiskFrameLoopParams {
+  enabled: boolean;
+  debugEnabled: boolean;
+  meshRef: MutableRefObject<Mesh | null>;
+  shaderMaterialRef: MutableRefObject<ShaderMaterial | null>;
+  gameState: GameState | null | undefined;
+  hazeConfig: MainSequenceStarUniformUpdate['haze'];
+  boundaryConfig: MainSequenceStarUniformUpdate['boundary'];
+  organicTexture: Texture | undefined;
+  noiseTexture: Texture | undefined;
+  viewAlignmentRef: MutableRefObject<ViewAlignment>;
+  meshWorldPosition: Vector3;
+  viewScratch: ViewAlignmentScratch;
+  aspectWarnedRef: MutableRefObject<boolean>;
+}
+
+export function useStarDiskFrameLoop({
+  enabled,
+  debugEnabled,
+  meshRef,
+  shaderMaterialRef,
+  gameState,
+  hazeConfig,
+  boundaryConfig,
+  organicTexture,
+  noiseTexture,
+  viewAlignmentRef,
+  meshWorldPosition,
+  viewScratch,
+  aspectWarnedRef,
+}: UseStarDiskFrameLoopParams): void {
+  const fallbackTimeRef = useRef(0);
+  const lastUniformTimeRef = useRef(0);
+  const previousUniformTimeRef = useRef(0);
+
+  useFrame((state, delta) => {
+    if (!enabled) {
+      return;
+    }
+
+    const debugWin =
+      debugEnabled && typeof window !== 'undefined' ? (window as CopilotDebugWindow) : undefined;
+
+    if (debugWin && debugWin.__copilot_forceStarOpaqueRequest) {
+      try {
+        debugWin.__copilot_forceStarOpaque = true;
+      } catch {
+        /* ignore */
+      }
+      const pendingMat = shaderMaterialRef.current;
+      if (pendingMat) {
+        try {
+          pendingMat.needsUpdate = true;
+        } catch {
+          /* ignore */
+        }
+        try {
+          debugWin.__copilot_forceStarOpaqueApplied = Date.now();
+        } catch {
+          /* ignore */
+        }
+        try {
+          debugWin.__copilot_forceStarOpaqueRequest = false;
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+
+    const mat = shaderMaterialRef.current;
+    if (!mat) {
+      return;
+    }
+
+    if (debugWin) {
+      const meshLocal = meshRef.current;
+      if (meshLocal) {
+        try {
+          const meshMaterial = meshLocal.material;
+          const resolvedMaterial = Array.isArray(meshMaterial)
+            ? ((meshMaterial[0] as Material | undefined) ?? null)
+            : (meshMaterial ?? null);
+          const materialTransparent =
+            resolvedMaterial != null &&
+            typeof (resolvedMaterial as { transparent?: unknown }).transparent === 'boolean'
+              ? Boolean((resolvedMaterial as { transparent: boolean }).transparent)
+              : false;
+          const materialOpacity =
+            resolvedMaterial != null &&
+            typeof (resolvedMaterial as { opacity?: unknown }).opacity === 'number'
+              ? (resolvedMaterial as { opacity: number }).opacity
+              : null;
+          const materialType = resolvedMaterial?.type ?? null;
+          const wp = meshLocal.getWorldPosition
+            ? meshLocal.getWorldPosition(new Vector3())
+            : meshLocal.position;
+          debugWin.__copilot_starMeshStatus = {
+            present: true,
+            visible: !!meshLocal.visible,
+            renderOrder: Number(meshLocal.renderOrder || 0),
+            materialType,
+            materialTransparent,
+            materialOpacity,
+            userDataKeys: Object.keys(meshLocal.userData ?? {}),
+            worldPosition: { x: wp.x, y: wp.y, z: wp.z },
+            timestamp: Date.now(),
+          };
+        } catch {
+          /* ignore */
+        }
+      } else {
+        try {
+          debugWin.__copilot_starMeshStatus = { present: false, timestamp: Date.now() };
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+
+    const { camera, viewport } = state;
+    if (
+      debugWin &&
+      debugWin.__copilot_rotateCameraDeltaDeg !== undefined &&
+      debugWin.__copilot_rotateCameraDeltaDeg !== null
+    ) {
+      const deg = Number(debugWin.__copilot_rotateCameraDeltaDeg);
+      if (Number.isFinite(deg)) {
+        camera.rotation.y += (deg * Math.PI) / 180;
+        try {
+          debugWin.__copilot_rotateAppliedAt = Date.now();
+        } catch {
+          /* ignore */
+        }
+      }
+      try {
+        debugWin.__copilot_rotateCameraDeltaDeg = null;
+      } catch {
+        /* ignore */
+      }
+    }
+
+    const mesh = meshRef.current;
+    const meshQuaternion = mesh?.quaternion ?? null;
+    const sim = gameState?.simulation;
+    const deltaSeconds = Number.isFinite(delta) && delta > 0 ? delta : 0;
+    const simTime = sim ? sim.lastTickStart + sim.alpha * sim.step : undefined;
+    const hasSimTime = typeof simTime === 'number' && Number.isFinite(simTime);
+    const renderClock = (
+      state as { clock?: { getElapsedTime?: () => number; elapsedTime?: number } }
+    ).clock;
+    let renderTime: number | undefined;
+    if (renderClock) {
+      if (typeof renderClock.getElapsedTime === 'function') {
+        renderTime = renderClock.getElapsedTime();
+      } else if (Number.isFinite(renderClock.elapsedTime ?? NaN)) {
+        renderTime = renderClock.elapsedTime as number;
+      }
+    }
+    if (typeof renderTime !== 'number' || !Number.isFinite(renderTime)) {
+      renderTime = undefined;
+    }
+
+    const EPSILON = 1e-6;
+    const fallbackStep = deltaSeconds > 0 ? deltaSeconds : 1 / 60;
+    let candidateTime = Number.NEGATIVE_INFINITY;
+    if (hasSimTime) {
+      candidateTime = Math.max(candidateTime, simTime as number);
+    }
+    if (typeof renderTime === 'number') {
+      candidateTime = Math.max(candidateTime, renderTime);
+    }
+
+    const previousRawTime = lastUniformTimeRef.current;
+    let rawElapsed: number;
+    const usedFallback = !(
+      Number.isFinite(candidateTime) && candidateTime > previousRawTime + EPSILON
+    );
+    if (!usedFallback) {
+      rawElapsed = candidateTime;
+      fallbackTimeRef.current = rawElapsed;
+    } else {
+      const base = Math.max(previousRawTime, fallbackTimeRef.current);
+      fallbackTimeRef.current = base + fallbackStep;
+      rawElapsed = fallbackTimeRef.current;
+    }
+
+    lastUniformTimeRef.current = rawElapsed;
+    const { wrapped: wrappedElapsed, cycles: wrapCycles } = wrapStarTime(rawElapsed);
+
+    if (isCopilotDebugEnabled()) {
+      const now = Date.now();
+      const deltaTime = rawElapsed - previousUniformTimeRef.current;
+      const isProgressing = deltaTime > 0;
+      const rapierDiagnostics = gameState?.simulation?.rapierDiagnostics;
+
+      try {
+        const debugGlobal = window as Window & {
+          __copilot_starDiskTelemetry?: {
+            iTime: number;
+            rawTime?: number;
+            wrapCycle?: number;
+            deltaTime: number;
+            isProgressing: boolean;
+            timestamp: number;
+            frameCount: number;
+            simTime?: number;
+            renderTime?: number;
+            usedFallback: boolean;
+            rapierPanicCount?: number;
+            lastRapierPanicTick?: number;
+            ticksSinceLastPanic?: number;
+          };
+        };
+
+        const prevTelemetry = debugGlobal.__copilot_starDiskTelemetry;
+        const frameCount = (prevTelemetry?.frameCount ?? 0) + 1;
+
+        debugGlobal.__copilot_starDiskTelemetry = {
+          iTime: wrappedElapsed,
+          rawTime: rawElapsed,
+          wrapCycle: wrapCycles,
+          deltaTime,
+          isProgressing,
+          timestamp: now,
+          frameCount,
+          simTime: hasSimTime ? (simTime as number) : undefined,
+          renderTime,
+          usedFallback,
+          rapierPanicCount: rapierDiagnostics?.stepPanics,
+          lastRapierPanicTick:
+            rapierDiagnostics?.lastStepPanicTick !== -1
+              ? rapierDiagnostics?.lastStepPanicTick
+              : undefined,
+          ticksSinceLastPanic:
+            rapierDiagnostics && rapierDiagnostics.lastStepPanicTick !== -1
+              ? (sim?.lastTickIndex ?? 0) - rapierDiagnostics.lastStepPanicTick
+              : undefined,
+        };
+      } catch {
+        // ignore telemetry publishing errors
+      }
+
+      previousUniformTimeRef.current = rawElapsed;
+    }
+
+    const rawAspect = viewport.aspect;
+    const safeAspect = Number.isFinite(rawAspect) && rawAspect > 0 ? rawAspect : 1;
+    if (safeAspect > 8 && !aspectWarnedRef.current) {
+      console.warn(`[StarDisk] Unusually high viewport aspect detected: ${safeAspect.toFixed(2)}.`);
+      aspectWarnedRef.current = true;
+    }
+    const { width, height } = state.size;
+    const uniformUpdate: MainSequenceStarUniformUpdate = {
+      time: wrappedElapsed,
+      resolution: {
+        width: Number.isFinite(width) && width > 0 ? width : 1,
+        height: Number.isFinite(height) && height > 0 ? height : 1,
+      },
+    };
+
+    const alignment = viewAlignmentRef.current;
+    alignment.x = 0;
+    alignment.y = 0;
+    alignment.z = 1;
+    const cameraPosition = (camera as { position?: Vector3 }).position;
+    if (
+      mesh &&
+      meshQuaternion &&
+      cameraPosition &&
+      Number.isFinite(cameraPosition.x) &&
+      Number.isFinite(cameraPosition.y) &&
+      Number.isFinite(cameraPosition.z)
+    ) {
+      mesh.updateMatrixWorld();
+      meshWorldPosition.setFromMatrixPosition(mesh.matrixWorld);
+      computeViewAlignment(
+        meshQuaternion,
+        meshWorldPosition,
+        cameraPosition,
+        viewScratch,
+        alignment,
+      );
+
+      if (debugEnabled) {
+        try {
+          const pos = meshWorldPosition.clone();
+          const proj = pos.project(camera);
+          const ndcX = proj.x;
+          const ndcY = proj.y;
+          const pxX = Math.round((ndcX * 0.5 + 0.5) * width);
+          const pxY = Math.round((-ndcY * 0.5 + 0.5) * height);
+          try {
+            let el = document.getElementById('copilot-star-screen-indicator');
+            if (!el) {
+              el = document.createElement('div');
+              el.id = 'copilot-star-screen-indicator';
+              el.style.position = 'fixed';
+              el.style.pointerEvents = 'none';
+              el.style.width = '12px';
+              el.style.height = '12px';
+              el.style.borderRadius = '50%';
+              el.style.background = 'rgba(255,0,0,0.9)';
+              el.style.zIndex = '2147483647';
+              el.style.transform = 'translate(-50%, -50%)';
+              document.body.appendChild(el);
+            }
+            el.style.left = pxX + 'px';
+            el.style.top = pxY + 'px';
+            el.setAttribute('data-copilot-screen-pos', `${pxX},${pxY}`);
+          } catch {
+            /* ignore */
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+
+    uniformUpdate.viewAlignment = alignment;
+    if (hazeConfig) {
+      uniformUpdate.haze = hazeConfig;
+    }
+    uniformUpdate.boundary = boundaryConfig;
+
+    const cameraRotation = (camera as { rotation?: { z?: unknown } }).rotation;
+    const roll =
+      cameraRotation && typeof cameraRotation.z === 'number' ? cameraRotation.z : undefined;
+    if (typeof roll === 'number' && Number.isFinite(roll)) {
+      uniformUpdate.cameraRoll = roll;
+    } else {
+      uniformUpdate.cameraRoll = 0;
+    }
+    uniformUpdate.starNorth = 0;
+    if (organicTexture) {
+      uniformUpdate.organic = organicTexture;
+    }
+    if (noiseTexture) {
+      uniformUpdate.noise = noiseTexture;
+    }
+    updateMainSequenceStarUniforms(mat, uniformUpdate);
+
+    if (debugEnabled && debugWin && debugWin.__copilot_dumpStarDebug === true) {
+      try {
+        const meshLocal = meshRef.current;
+        const matCurrent = shaderMaterialRef.current;
+        const applied = !!(meshLocal && matCurrent && meshLocal.material === matCurrent);
+        const diagnosticsMaterial = meshLocal ? resolveMaterial(meshLocal.material) : null;
+        const starCompiled = (globalThis as unknown as CopilotDebugWindow).__STAR_COMPILED;
+        console.info('[StarDisk][DBG] dumpStarDebug', {
+          iTime: uniformUpdate.time,
+          applied,
+          materialType: diagnosticsMaterial?.type ?? null,
+          starCompiled,
+        });
+
+        if (!applied && meshLocal && matCurrent) {
+          try {
+            meshLocal.material = matCurrent;
+            matCurrent.needsUpdate = true;
+            console.info(
+              '[StarDisk][DBG] Reassigned shader material to mesh and flagged needsUpdate',
+            );
+          } catch (e) {
+            console.warn('[StarDisk][DBG] failed to reassign material', e);
+          }
+        }
+
+        try {
+          const win = globalThis as unknown as CopilotDebugWindow;
+          win.__copilot_starDiskDiagnostics = win.__copilot_starDiskDiagnostics || [];
+          win.__copilot_starDiskDiagnostics.push({
+            time: Date.now(),
+            iTime: uniformUpdate.time,
+            applied,
+            materialType: diagnosticsMaterial?.type ?? null,
+            starCompiled,
+          });
+          if (win.__copilot_starDiskDiagnostics.length > 20) {
+            win.__copilot_starDiskDiagnostics.shift();
+          }
+        } catch {
+          /* ignore */
+        }
+      } catch {
+        /* ignore */
+      }
+      try {
+        debugWin.__copilot_dumpStarDebug = false;
+      } catch {
+        /* ignore */
+      }
+    }
+
+    if (debugEnabled && debugWin && debugWin.__copilot_forceStarOnTopRequest) {
+      try {
+        const meshLocal = meshRef.current;
+        if (meshLocal) {
+          meshLocal.renderOrder = 99999;
+        }
+      } catch {
+        /* ignore */
+      }
+      const matImmediate = shaderMaterialRef.current;
+      if (matImmediate) {
+        try {
+          matImmediate.depthTest = false;
+          matImmediate.depthWrite = false;
+        } catch {
+          /* ignore */
+        }
+      }
+      try {
+        debugWin.__copilot_star_forceOnTop = true;
+      } catch {
+        /* ignore */
+      }
+      try {
+        debugWin.__copilot_forceStarOnTopRequest = false;
+      } catch {
+        /* ignore */
+      }
+    }
+
+    if (debugEnabled && debugWin && debugWin.__copilot_forceStarOpaqueRequest) {
+      const matImmediate = shaderMaterialRef.current;
+      if (matImmediate) {
+        try {
+          debugWin.__copilot_forceStarOpaque = true;
+        } catch {
+          /* ignore */
+        }
+        try {
+          matImmediate.needsUpdate = true;
+        } catch {
+          /* ignore */
+        }
+        try {
+          debugWin.__copilot_forceStarOpaqueRequest = false;
+        } catch {
+          /* ignore */
+        }
+        try {
+          debugWin.__copilot_forceStarOpaqueApplied = Date.now();
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+
+    if (debugEnabled && debugWin) {
+      const meshLocal = meshRef.current;
+      if (debugWin.__copilot_forceBasicMaterialRequest && meshLocal) {
+        const userData = getCopilotUserData(meshLocal);
+        if (!userData.__copilot_origMaterial) {
+          userData.__copilot_origMaterial = resolveMaterial(meshLocal.material) ?? undefined;
+        }
+        const basic = new MeshBasicMaterial({
+          color: '#ffffff',
+          depthTest: false,
+          depthWrite: false,
+          side: DoubleSide,
+        });
+        userData.__copilot_forcedMaterial = basic;
+        meshLocal.material = basic;
+        try {
+          debugWin.__copilot_forceBasicMaterialApplied = Date.now();
+        } catch {
+          /* ignore */
+        }
+        try {
+          debugWin.__copilot_forceBasicMaterialRequest = false;
+        } catch {
+          /* ignore */
+        }
+      }
+      if (debugWin.__copilot_restoreOriginalStarMaterial && meshLocal) {
+        const userData = getCopilotUserData(meshLocal);
+        const originalMaterial = userData.__copilot_origMaterial;
+        if (originalMaterial) {
+          const forcedMaterial = resolveMaterial(meshLocal.material);
+          forcedMaterial?.dispose();
+          meshLocal.material = originalMaterial;
+          delete userData.__copilot_origMaterial;
+          delete userData.__copilot_forcedMaterial;
+          try {
+            debugWin.__copilot_restoreOriginalStarMaterialApplied = Date.now();
+          } catch {
+            /* ignore */
+          }
+        }
+        try {
+          debugWin.__copilot_restoreOriginalStarMaterial = false;
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+
+    if (debugEnabled && debugWin && mesh) {
+      if (!debugWin.__copilot_setStarBasicMaterial) {
+        debugWin.__copilot_setStarBasicMaterial = (opts: { color?: string } = {}) => {
+          try {
+            const meshLocal = meshRef.current;
+            if (!meshLocal) {
+              return { applied: false, reason: 'no-mesh' };
+            }
+            const userData = getCopilotUserData(meshLocal);
+            if (!userData.__copilot_origMaterial) {
+              userData.__copilot_origMaterial = resolveMaterial(meshLocal.material) ?? undefined;
+            }
+            const color = typeof opts.color === 'string' ? opts.color : '#ffffff';
+            if (!userData.__copilot_forcedMaterial) {
+              userData.__copilot_forcedMaterial = new MeshBasicMaterial({
+                color,
+                depthTest: false,
+                depthWrite: false,
+                side: DoubleSide,
+              });
+            } else {
+              userData.__copilot_forcedMaterial.color.set(color);
+            }
+            meshLocal.material = userData.__copilot_forcedMaterial;
+            debugWin.__copilot_forceBasicMaterialActive = true;
+            debugWin.__copilot_forceBasicMaterialColor = color;
+            debugWin.__copilot_forceBasicMaterialApplied = Date.now();
+            return { applied: true };
+          } catch (error) {
+            return { applied: false, reason: String(error) };
+          }
+        };
+      }
+
+      if (!debugWin.__copilot_restoreStarMaterial) {
+        debugWin.__copilot_restoreStarMaterial = () => {
+          try {
+            const meshLocal = meshRef.current;
+            if (!meshLocal) {
+              return { restored: false, reason: 'no-mesh' };
+            }
+            const userData = getCopilotUserData(meshLocal);
+            const originalMaterial = userData.__copilot_origMaterial;
+            if (originalMaterial) {
+              const forcedMaterial = resolveMaterial(meshLocal.material);
+              forcedMaterial?.dispose();
+              meshLocal.material = originalMaterial;
+              delete userData.__copilot_origMaterial;
+              delete userData.__copilot_forcedMaterial;
+              debugWin.__copilot_restoreOriginalStarMaterialApplied = Date.now();
+              return { restored: true };
+            }
+            return { restored: false, reason: 'no-orig' };
+          } catch (error) {
+            return { restored: false, reason: String(error) };
+          }
+        };
+      }
+
+      if (!mesh.userData) {
+        mesh.userData = {};
+      }
+      const meshUserData = getCopilotUserData(mesh);
+      if (meshUserData.__copilot_origLayerMask == null) {
+        const rawLayers = mesh.layers as { mask?: number } | undefined;
+        const mask = rawLayers && typeof rawLayers.mask === 'number' ? rawLayers.mask : 1;
+        meshUserData.__copilot_origLayerMask = Number.isFinite(mask) ? mask : 1;
+      }
+
+      if (!debugWin.__copilot_setStarLayer) {
+        debugWin.__copilot_setStarLayer = (layerIndex: unknown = 0) => {
+          try {
+            const meshLocal = meshRef.current;
+            if (!meshLocal) {
+              return { set: false, reason: 'no-mesh' };
+            }
+            const value = Number(layerIndex);
+            const idx = Number.isFinite(value) ? Math.max(0, Math.min(Math.floor(value), 31)) : 0;
+            const layers = meshLocal.layers as
+              | { set?: (layer: number) => void; mask?: number }
+              | undefined;
+            if (layers && typeof layers.set === 'function') {
+              layers.set(idx);
+            } else if (layers) {
+              layers.mask = idx;
+            }
+            debugWin.__copilot_starLayerSetAt = Date.now();
+            return { set: true, layer: idx };
+          } catch (error) {
+            return { set: false, reason: String(error) };
+          }
+        };
+      }
+
+      if (!debugWin.__copilot_resetStarLayer) {
+        debugWin.__copilot_resetStarLayer = () => {
+          try {
+            const meshLocal = meshRef.current;
+            if (!meshLocal) {
+              return { reset: false, reason: 'no-mesh' };
+            }
+            const userData = getCopilotUserData(meshLocal);
+            const orig = userData.__copilot_origLayerMask;
+            if (typeof orig === 'number') {
+              const layers = meshLocal.layers as
+                | { mask?: number; set?: (layer: number) => void }
+                | undefined;
+              if (layers && typeof layers.set === 'function') {
+                layers.set(orig);
+              } else if (layers) {
+                layers.mask = orig;
+              }
+            } else {
+              const layers = meshLocal.layers as
+                | { mask?: number; set?: (layer: number) => void }
+                | undefined;
+              if (layers && typeof layers.set === 'function') {
+                layers.set(0);
+              } else if (layers) {
+                layers.mask = 0;
+              }
+            }
+            debugWin.__copilot_starLayerResetAt = Date.now();
+            return { reset: true };
+          } catch (error) {
+            return { reset: false, reason: String(error) };
+          }
+        };
+      }
+    }
+
+    if (debugEnabled && debugWin && debugWin.__copilot_forceBasicMaterialActive) {
+      const meshLocal = meshRef.current;
+      if (meshLocal) {
+        const userData = getCopilotUserData(meshLocal);
+        if (!userData.__copilot_origMaterial) {
+          userData.__copilot_origMaterial = resolveMaterial(meshLocal.material) ?? undefined;
+        }
+        const activeColor =
+          typeof debugWin.__copilot_forceBasicMaterialColor === 'string'
+            ? debugWin.__copilot_forceBasicMaterialColor
+            : '#ffffff';
+        if (!userData.__copilot_forcedMaterial) {
+          userData.__copilot_forcedMaterial = new MeshBasicMaterial({
+            color: activeColor,
+            depthTest: false,
+            depthWrite: false,
+            side: DoubleSide,
+          });
+        } else if (typeof debugWin.__copilot_forceBasicMaterialColor === 'string') {
+          userData.__copilot_forcedMaterial.color.set(activeColor);
+        }
+        if (meshLocal.material !== userData.__copilot_forcedMaterial) {
+          meshLocal.material = userData.__copilot_forcedMaterial;
+        }
+        debugWin.__copilot_forceBasicMaterialApplied =
+          debugWin.__copilot_forceBasicMaterialApplied || Date.now();
+      }
+    }
+  });
+}

--- a/src/components/lod/ShipImpostorLayer.tsx
+++ b/src/components/lod/ShipImpostorLayer.tsx
@@ -1,0 +1,168 @@
+import { useFrame } from '@react-three/fiber';
+import { useEffect, useMemo, useRef } from 'react';
+import type { ReactElement } from 'react';
+import { Color, InstancedMesh, Matrix4, PlaneGeometry, Quaternion, Vector3 } from 'three';
+import type { ShipEntity } from '../../types/index.js';
+import { getInstanceFriendlyMaterial } from '../../renderer/materialRegistry.js';
+import { TEAM_COLORS } from '../../config/renderer.js';
+import { createSaturationWarningState, warnOnSaturation } from '../layers/saturationWarning.js';
+import { createInstancedLayerManager } from '../layers/instancedLayer.js';
+
+export interface PopulateImpostorParams {
+  ships: readonly ShipEntity[];
+  capacity: number;
+  cameraQuaternion: Quaternion;
+  mesh: InstancedMesh | null;
+  temp: {
+    matrix: Matrix4;
+    scale: Vector3;
+    quat: Quaternion;
+    pos: Vector3;
+    color: Color;
+  };
+}
+
+export function populateImpostorInstances({
+  ships,
+  capacity,
+  cameraQuaternion,
+  mesh,
+  temp,
+}: PopulateImpostorParams): { count: number; saturated: boolean } {
+  if (!mesh) {
+    return { count: 0, saturated: false };
+  }
+
+  let index = 0;
+  let saturated = false;
+
+  for (const ship of ships) {
+    if (index >= capacity) {
+      saturated = true;
+      break;
+    }
+
+    temp.pos.copy(ship.transform.position);
+    const scale = Math.max(ship.transform.scale * 6, 4);
+    temp.scale.setScalar(scale);
+    temp.quat.copy(cameraQuaternion);
+    temp.matrix.compose(temp.pos, temp.quat, temp.scale);
+    mesh.setMatrixAt(index, temp.matrix);
+
+    const teamColor = TEAM_COLORS[ship.ship.team] ?? '#a0a0a0';
+    temp.color.set(teamColor);
+    mesh.setColorAt(index, temp.color);
+
+    index += 1;
+  }
+
+  mesh.count = index;
+  mesh.visible = index > 0;
+  mesh.instanceMatrix.needsUpdate = true;
+  if (mesh.instanceColor) {
+    mesh.instanceColor.needsUpdate = true;
+  }
+
+  return { count: index, saturated };
+}
+
+interface ShipImpostorLayerProps {
+  ships: readonly ShipEntity[];
+  capacity: number;
+}
+
+export function ShipImpostorLayer({ ships, capacity }: ShipImpostorLayerProps): ReactElement {
+  const meshRef = useRef<InstancedMesh>(null);
+  const managerRef = useRef(
+    createInstancedLayerManager<number>(meshRef, {
+      capacity,
+      supportsInstanceColor: true,
+      baseColor: new Color('#a0a0a0'),
+    }),
+  );
+  const warningStateRef = useRef(createSaturationWarningState());
+  const frameRef = useRef(0);
+  const geometry = useMemo(() => new PlaneGeometry(1, 1, 1, 1), []);
+  const materialInfo = useMemo(
+    () =>
+      getInstanceFriendlyMaterial('ship:impostor', {
+        requireInstanceColor: true,
+        fallbackKey: 'thruster:glow',
+      }),
+    [],
+  );
+  const temp = useMemo(
+    () => ({
+      matrix: new Matrix4(),
+      scale: new Vector3(),
+      quat: new Quaternion(),
+      pos: new Vector3(),
+      color: new Color('#6fc3ff'),
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    managerRef.current.initMesh();
+    return () => {
+      managerRef.current.dispose();
+    };
+  }, []);
+
+  useEffect(
+    () => () => {
+      geometry.dispose();
+    },
+    [geometry],
+  );
+
+  useEffect(
+    () => () => {
+      materialInfo.material.dispose();
+    },
+    [materialInfo.material],
+  );
+
+  useFrame(({ camera }) => {
+    frameRef.current += 1;
+    const frameId = frameRef.current;
+
+    const manager = managerRef.current;
+    manager.beginFrame();
+
+    for (const ship of ships) {
+      const key = ship.id;
+      const idx = manager.allocate(key);
+      if (idx == null) continue;
+      temp.pos.copy(ship.transform.position);
+      const scale = Math.max(ship.transform.scale * 6, 4);
+      temp.scale.setScalar(scale);
+      temp.quat.copy(camera.quaternion);
+      temp.matrix.compose(temp.pos, temp.quat, temp.scale);
+      manager.setMatrixAt(idx, temp.matrix);
+
+      const teamColor = TEAM_COLORS[ship.ship.team] ?? '#a0a0a0';
+      temp.color.set(teamColor);
+      manager.setColorAt(idx, temp.color);
+    }
+
+    const summary = manager.endFrame();
+
+    warnOnSaturation({
+      saturated: summary.saturated,
+      frameId,
+      state: warningStateRef.current,
+      message: '[ShipImpostorLayer] Capacity saturated, clamping distant ship impostors.',
+    });
+  });
+
+  return (
+    <instancedMesh
+      ref={meshRef}
+      args={[geometry, materialInfo.material, capacity]}
+      matrixAutoUpdate={false}
+      frustumCulled={false}
+      visible={false}
+    />
+  );
+}

--- a/src/components/lod/ShipLODManager.tsx
+++ b/src/components/lod/ShipLODManager.tsx
@@ -1,21 +1,25 @@
 import { useThree, useFrame } from '@react-three/fiber';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  Color,
-  InstancedBufferAttribute,
-  InstancedMesh,
-  Matrix4,
-  PlaneGeometry,
-  Quaternion,
-  Vector3,
-} from 'three';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ReactElement } from 'react';
+import type { Vector3 } from 'three';
 import type { ShipEntity } from '../../types/index.js';
 import { ShipObject } from '../Ship.js';
 import { ThrusterInstancedManager } from '../thrusters/ThrusterInstancedManager.js';
-import { getInstanceFriendlyMaterial } from '../../renderer/materialRegistry.js';
-import { TEAM_COLORS } from '../../config/renderer.js';
-import { createSaturationWarningState, warnOnSaturation } from '../layers/saturationWarning.js';
-import { createInstancedLayerManager } from '../layers/instancedLayer.js';
+import {
+  computeLodPartition,
+  partitionShipsByDistance,
+  partitionsEqual,
+  DEFAULT_DISTANCE_THRESHOLD,
+  DEFAULT_HYSTERESIS,
+  DEFAULT_IMPOSTOR_CAPACITY,
+  type LodLevel,
+  type LodPartitionResult,
+} from './shipLodPartition.js';
+import {
+  ShipImpostorLayer,
+  populateImpostorInstances,
+  type PopulateImpostorParams,
+} from './ShipImpostorLayer.js';
 
 export interface ShipLODManagerProps {
   ships: readonly ShipEntity[];
@@ -24,253 +28,25 @@ export interface ShipLODManagerProps {
   impostorCapacity?: number;
 }
 
-export type LodLevel = 'near' | 'far';
-
-export const DEFAULT_DISTANCE_THRESHOLD = 8000;
-export const DEFAULT_HYSTERESIS = 80;
-export const DEFAULT_IMPOSTOR_CAPACITY = 256;
-
-export interface LodPartitionResult {
-  nearShips: ShipEntity[];
-  farShips: ShipEntity[];
-}
-
-function classifyLod(
-  distance: number,
-  previous: LodLevel | undefined,
-  threshold: number,
-  hysteresis: number,
-): LodLevel {
-  if (previous === 'far') {
-    return distance < threshold - hysteresis ? 'near' : 'far';
-  }
-  if (previous === 'near') {
-    return distance > threshold + hysteresis ? 'far' : 'near';
-  }
-  return distance > threshold ? 'far' : 'near';
-}
-
-export function partitionShipsByDistance(
-  ships: readonly ShipEntity[],
-  cameraPosition: Vector3,
-  threshold: number,
-  hysteresis: number,
-  previous: Map<number, LodLevel>,
-): LodPartitionResult {
-  const nearShips: ShipEntity[] = [];
-  const farShips: ShipEntity[] = [];
-
-  const activeIds = new Set<number>();
-
-  for (const ship of ships) {
-    activeIds.add(ship.id);
-    const previousLevel = previous.get(ship.id);
-    const distance = ship.transform.position.distanceTo(cameraPosition);
-    const level = classifyLod(distance, previousLevel, threshold, hysteresis);
-    previous.set(ship.id, level);
-    if (level === 'near') {
-      nearShips.push(ship);
-    } else {
-      farShips.push(ship);
-    }
-  }
-
-  for (const id of previous.keys()) {
-    if (!activeIds.has(id)) {
-      previous.delete(id);
-    }
-  }
-
-  return { nearShips, farShips };
-}
-
-export function computeLodPartition(
-  ships: readonly ShipEntity[],
-  cameraPosition: Vector3,
-  threshold: number,
-  hysteresis: number,
-  previous: Map<number, LodLevel>,
-): LodPartitionResult {
-  return partitionShipsByDistance(ships, cameraPosition, threshold, hysteresis, previous);
-}
-
-export function partitionsEqual(a: LodPartitionResult, b: LodPartitionResult): boolean {
-  if (a.nearShips.length !== b.nearShips.length || a.farShips.length !== b.farShips.length) {
-    return false;
-  }
-  for (let i = 0; i < a.nearShips.length; i += 1) {
-    if (a.nearShips[i] !== b.nearShips[i]) {
-      return false;
-    }
-  }
-  for (let i = 0; i < a.farShips.length; i += 1) {
-    if (a.farShips[i] !== b.farShips[i]) {
-      return false;
-    }
-  }
-  return true;
-}
-
-export interface PopulateImpostorParams {
-  ships: readonly ShipEntity[];
-  capacity: number;
-  cameraQuaternion: Quaternion;
-  mesh: InstancedMesh | null;
-  temp: {
-    matrix: Matrix4;
-    scale: Vector3;
-    quat: Quaternion;
-    pos: Vector3;
-    color: Color;
-  };
-}
-
-export function populateImpostorInstances({
-  ships,
-  capacity,
-  cameraQuaternion,
-  mesh,
-  temp,
-}: PopulateImpostorParams): { count: number; saturated: boolean } {
-  if (!mesh) {
-    return { count: 0, saturated: false };
-  }
-
-  let index = 0;
-  let saturated = false;
-
-  for (const ship of ships) {
-    if (index >= capacity) {
-      saturated = true;
-      break;
-    }
-
-    temp.pos.copy(ship.transform.position);
-    const scale = Math.max(ship.transform.scale * 6, 4);
-    temp.scale.setScalar(scale);
-    temp.quat.copy(cameraQuaternion);
-    temp.matrix.compose(temp.pos, temp.quat, temp.scale);
-    mesh.setMatrixAt(index, temp.matrix);
-
-    const teamColor = TEAM_COLORS[ship.ship.team] ?? '#a0a0a0';
-    temp.color.set(teamColor);
-    mesh.setColorAt(index, temp.color);
-
-    index += 1;
-  }
-
-  mesh.count = index;
-  mesh.visible = index > 0;
-  mesh.instanceMatrix.needsUpdate = true;
-  if (mesh.instanceColor) {
-    mesh.instanceColor.needsUpdate = true;
-  }
-
-  return { count: index, saturated };
-}
-interface ShipImpostorLayerProps {
-  ships: readonly ShipEntity[];
-  capacity: number;
-}
-
-function ShipImpostorLayer({ ships, capacity }: ShipImpostorLayerProps): React.ReactElement {
-  const meshRef = useRef<InstancedMesh>(null);
-  const managerRef = useRef(createInstancedLayerManager<number>(meshRef, {
-    capacity,
-    supportsInstanceColor: true,
-    baseColor: new Color('#a0a0a0'),
-  }));
-  const warningStateRef = useRef(createSaturationWarningState());
-  const frameRef = useRef(0);
-  const geometry = useMemo(() => new PlaneGeometry(1, 1, 1, 1), []);
-  const materialInfo = useMemo(
-    () =>
-      getInstanceFriendlyMaterial('ship:impostor', {
-        requireInstanceColor: true,
-        fallbackKey: 'thruster:glow',
-      }),
-    [],
-  );
-  const temp = useMemo(() => ({
-    matrix: new Matrix4(),
-    scale: new Vector3(),
-    quat: new Quaternion(),
-    pos: new Vector3(),
-    color: new Color('#6fc3ff'),
-  }), []);
-
-  useEffect(() => {
-    managerRef.current.initMesh();
-    return () => {
-      managerRef.current.dispose();
-    };
-  }, []);
-
-  useEffect(() => () => {
-    geometry.dispose();
-  }, [geometry]);
-
-  useEffect(() => () => {
-    materialInfo.material.dispose();
-  }, [materialInfo.material]);
-
-  useFrame(({ camera }) => {
-    frameRef.current += 1;
-    const frameId = frameRef.current;
-
-    const manager = managerRef.current;
-    manager.beginFrame();
-
-    for (const ship of ships) {
-      const key = ship.id;
-      const idx = manager.allocate(key);
-      if (idx == null) continue;
-      temp.pos.copy(ship.transform.position);
-      const scale = Math.max(ship.transform.scale * 6, 4);
-      temp.scale.setScalar(scale);
-      temp.quat.copy(camera.quaternion);
-      temp.matrix.compose(temp.pos, temp.quat, temp.scale);
-      manager.setMatrixAt(idx, temp.matrix);
-
-      const teamColor = TEAM_COLORS[ship.ship.team] ?? '#a0a0a0';
-      temp.color.set(teamColor);
-      manager.setColorAt(idx, temp.color);
-    }
-
-    const summary = manager.endFrame();
-
-    warnOnSaturation({
-      saturated: summary.saturated,
-      frameId,
-      state: warningStateRef.current,
-      message: '[ShipImpostorLayer] Capacity saturated, clamping distant ship impostors.',
-    });
-  });
-
-  return (
-    <instancedMesh
-      ref={meshRef}
-      args={[geometry, materialInfo.material, capacity]}
-      matrixAutoUpdate={false}
-      frustumCulled={false}
-      visible={false}
-    />
-  );
-}
-
 export function ShipLODManager({
   ships,
   distanceThreshold = DEFAULT_DISTANCE_THRESHOLD,
   hysteresis = DEFAULT_HYSTERESIS,
   impostorCapacity = DEFAULT_IMPOSTOR_CAPACITY,
-}: ShipLODManagerProps): React.ReactElement {
+}: ShipLODManagerProps): ReactElement {
   const { camera } = useThree();
   const lodStateRef = useRef(new Map<number, LodLevel>());
   const shipsRef = useRef<readonly ShipEntity[]>(ships);
   const thresholdsRef = useRef({ distanceThreshold, hysteresis });
 
   const [partition, setPartition] = useState<LodPartitionResult>(() =>
-    computeLodPartition(ships, camera.position.clone(), distanceThreshold, hysteresis, lodStateRef.current),
+    computeLodPartition(
+      ships,
+      camera.position.clone(),
+      distanceThreshold,
+      hysteresis,
+      lodStateRef.current,
+    ),
   );
   const partitionRef = useRef(partition);
 
@@ -286,22 +62,19 @@ export function ShipLODManager({
     partitionRef.current = partition;
   }, [partition]);
 
-  const updatePartition = useCallback(
-    (cameraPosition: Vector3) => {
-      const next = computeLodPartition(
-        shipsRef.current,
-        cameraPosition,
-        thresholdsRef.current.distanceThreshold,
-        thresholdsRef.current.hysteresis,
-        lodStateRef.current,
-      );
-      if (!partitionsEqual(partitionRef.current, next)) {
-        partitionRef.current = next;
-        setPartition(next);
-      }
-    },
-    [],
-  );
+  const updatePartition = useCallback((cameraPosition: Vector3) => {
+    const next = computeLodPartition(
+      shipsRef.current,
+      cameraPosition,
+      thresholdsRef.current.distanceThreshold,
+      thresholdsRef.current.hysteresis,
+      lodStateRef.current,
+    );
+    if (!partitionsEqual(partitionRef.current, next)) {
+      partitionRef.current = next;
+      setPartition(next);
+    }
+  }, []);
 
   useEffect(() => {
     updatePartition(camera.position.clone());
@@ -322,4 +95,14 @@ export function ShipLODManager({
   );
 }
 
+export {
+  DEFAULT_DISTANCE_THRESHOLD,
+  DEFAULT_HYSTERESIS,
+  DEFAULT_IMPOSTOR_CAPACITY,
+  partitionShipsByDistance,
+  computeLodPartition,
+  partitionsEqual,
+  populateImpostorInstances,
+};
 
+export type { LodLevel, LodPartitionResult, PopulateImpostorParams };

--- a/src/components/lod/shipLodPartition.ts
+++ b/src/components/lod/shipLodPartition.ts
@@ -1,0 +1,89 @@
+import type { Vector3 } from 'three';
+import type { ShipEntity } from '../../types/index.js';
+
+export type LodLevel = 'near' | 'far';
+
+export const DEFAULT_DISTANCE_THRESHOLD = 8000;
+export const DEFAULT_HYSTERESIS = 80;
+export const DEFAULT_IMPOSTOR_CAPACITY = 256;
+
+export interface LodPartitionResult {
+  nearShips: ShipEntity[];
+  farShips: ShipEntity[];
+}
+
+function classifyLod(
+  distance: number,
+  previous: LodLevel | undefined,
+  threshold: number,
+  hysteresis: number,
+): LodLevel {
+  if (previous === 'far') {
+    return distance < threshold - hysteresis ? 'near' : 'far';
+  }
+  if (previous === 'near') {
+    return distance > threshold + hysteresis ? 'far' : 'near';
+  }
+  return distance > threshold ? 'far' : 'near';
+}
+
+export function partitionShipsByDistance(
+  ships: readonly ShipEntity[],
+  cameraPosition: Vector3,
+  threshold: number,
+  hysteresis: number,
+  previous: Map<number, LodLevel>,
+): LodPartitionResult {
+  const nearShips: ShipEntity[] = [];
+  const farShips: ShipEntity[] = [];
+
+  const activeIds = new Set<number>();
+
+  for (const ship of ships) {
+    activeIds.add(ship.id);
+    const previousLevel = previous.get(ship.id);
+    const distance = ship.transform.position.distanceTo(cameraPosition);
+    const level = classifyLod(distance, previousLevel, threshold, hysteresis);
+    previous.set(ship.id, level);
+    if (level === 'near') {
+      nearShips.push(ship);
+    } else {
+      farShips.push(ship);
+    }
+  }
+
+  for (const id of previous.keys()) {
+    if (!activeIds.has(id)) {
+      previous.delete(id);
+    }
+  }
+
+  return { nearShips, farShips };
+}
+
+export function computeLodPartition(
+  ships: readonly ShipEntity[],
+  cameraPosition: Vector3,
+  threshold: number,
+  hysteresis: number,
+  previous: Map<number, LodLevel>,
+): LodPartitionResult {
+  return partitionShipsByDistance(ships, cameraPosition, threshold, hysteresis, previous);
+}
+
+export function partitionsEqual(a: LodPartitionResult, b: LodPartitionResult): boolean {
+  if (a.nearShips.length !== b.nearShips.length || a.farShips.length !== b.farShips.length) {
+    return false;
+  }
+  for (let i = 0; i < a.nearShips.length; i += 1) {
+    if (a.nearShips[i] !== b.nearShips[i]) {
+      return false;
+    }
+  }
+  for (let i = 0; i < a.farShips.length; i += 1) {
+    if (a.farShips[i] !== b.farShips[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -1,323 +1,46 @@
-import type { Vector3 } from 'three';
-import type { EntityId } from './core.js';
-import type { Team, ShipHull } from './gameplay.js';
+export type {
+  AIIntent,
+  AICommand,
+  AITraits,
+  AIState,
+  BehaviorProfile,
+  TeamPosture,
+  AIBlackboard,
+  AITeamAssignments,
+  EscortAssignment,
+  AIIntentSnapshot,
+  PrioritisedTarget,
+  AIInterruptReason,
+  IntentInterruptEvent,
+  AIInterruptState,
+  AIShotHistogram,
+  AIInBandStats,
+  SensorVisibility,
+  SensorState,
+  AIManagerState,
+} from './ai/state.js';
 
-export type AIIntent =
-  | 'Attack'
-  | 'Kite'
-  | 'Escort'
-  | 'Intercept'
-  | 'Flee'
-  | 'Regroup'
-  | 'Reposition';
+export type {
+  DoctrineCardId,
+  DoctrineCard,
+  DoctrineState,
+  DoctrineProfileModifiers,
+  DoctrineThreatModifiers,
+  DoctrineSquadDirectives,
+  DoctrineSensorModifiers,
+  DoctrineRuntimeState,
+} from './ai/doctrine.js';
 
-export interface AICommand {
-  heading: Vector3;
-  thrust: number;
-  /** Optional lateral strafe input in range [-1, 1]. */
-  strafe?: number;
-  firePrimary: boolean;
-  orbit?: number;
-  targetId?: EntityId;
-  ttl: number;
-}
-
-export interface AITraits {
-  aggression: number;
-  patience: number;
-  dodge: number;
-}
-
-export type DoctrineCardId = 'aggressivePush' | 'elasticDefense' | 'ambush';
-
-export interface DoctrineProfileModifiers {
-  aggressionMultiplier?: number;
-  patienceMultiplier?: number;
-  desiredRangeOffset?: number;
-  desiredRangeScale?: number;
-  bandPreference?: BehaviorProfile['bandPreference'];
-  engagementBiasBonus?: number;
-  orbitMultiplier?: number;
-}
-
-export interface DoctrineThreatModifiers {
-  focusPenaltyMultiplier?: number;
-  vipBonusMultiplier?: number;
-  distanceScaleMultiplier?: number;
-  hullBiasAdd?: Partial<Record<ShipHull, number>>;
-}
-
-export interface DoctrineSquadDirectives {
-  postureOverride?: TeamPosture;
-  escortReserveRatio?: number;
-}
-
-export interface DoctrineSensorModifiers {
-  detectionMultiplier?: number;
-  stealthBonus?: number;
-  contactRetentionMultiplier?: number;
-}
-
-export interface DoctrineCard {
-  id: DoctrineCardId;
-  label: string;
-  description: string;
-  profile?: DoctrineProfileModifiers;
-  threat?: DoctrineThreatModifiers;
-  squad?: DoctrineSquadDirectives;
-  sensor?: DoctrineSensorModifiers;
-}
-
-export interface DoctrineRuntimeState {
-  cardId: DoctrineCardId;
-  expiresAtTick: number | null;
-  lastSwitchTick: number;
-}
-
-export interface DoctrineState {
-  defaultCard: DoctrineCardId;
-  teams: Record<Team, DoctrineRuntimeState>;
-}
-
-export interface SensorVisibility {
-  strength: number;
-  lastSeenTick: number;
-  sourceId: EntityId;
-  occluded: boolean;
-  distance: number;
-}
-
-export interface SensorState {
-  lastUpdateTick: number;
-  visibilityByTeam: Record<Team, Map<EntityId, SensorVisibility>>;
-  decayRate: number;
-  threshold: number;
-  staleDecay: number;
-}
-
-export interface AIState {
-  profileId: string;
-  intent: AIIntent;
-  nextThinkAt: number;
-  cooldowns: {
-    dodgeAt: number;
-    burstAt: number;
-  };
-  lod: 0 | 1 | 2;
-  traitSeed: number;
-  traits: AITraits;
-  targetId?: EntityId;
-  lastScore?: number;
-  command: AICommand;
-  stickinessUntil: number;
-  stickinessHeading: Vector3;
-  stickinessTargetId?: EntityId;
-  desiredRange?: readonly [number, number];
-}
-
-export interface BehaviorProfile {
-  desiredRange: readonly [number, number];
-  orbit: number;
-  aggression: number;
-  patience: number;
-  dodgeFreq: number;
-  classBias: Partial<Record<ShipHull, number>>;
-  style: 'brawler' | 'kiter' | 'artillery' | 'escort';
-  gates?: {
-    ammoMin?: number;
-    hpRetreatPct?: number;
-  };
-  verticalManeuver: number;
-  elevationPreference?: 'above' | 'below' | 'follow';
-  bandPreference?: 'outer' | 'mid' | 'inner';
-  engagementBias?: number;
-}
-
-export type TeamPosture = 'aggressive' | 'hold' | 'retreat';
-
-export interface AIBlackboard {
-  tickIndex: number;
-  teamPosture: Record<Team, TeamPosture>;
-  allyCentroid: Record<Team, Vector3>;
-  nearestEnemy: Map<EntityId, EntityId>;
-  threatToVip: Map<EntityId, EntityId>;
-  tmpVectors: Vector3[];
-  strengthRatio: Record<Team, number>;
-  teamPriority: Record<Team, PrioritisedTarget[]>;
-  priorityIndex: Record<Team, Map<EntityId, number>>;
-  focusFire: Record<Team, Map<EntityId, number>>;
-  visibleEnemies?: Record<Team, Map<EntityId, SensorVisibility>>;
-  teamCounts?: Record<Team, number>;
-  // Vertical dispersion tracking for validation (optional for backward compatibility)
-  verticalDispersion?: {
-    headingYSamples: number[];
-    positionYSamples: number[];
-    lastUpdateTick: number;
-  };
-}
-
-export interface AITeamAssignments {
-  escorts: Map<EntityId, EscortAssignment>;
-}
-
-export interface EscortAssignment {
-  vipId: EntityId;
-  offset: Vector3;
-  threatId?: EntityId;
-}
-
-export interface AIIntentSnapshot {
-  tick: number;
-  time: number;
-  counts: Partial<Record<AIIntent, number>>;
-  total: number;
-}
-
-export interface PrioritisedTarget {
-  id: EntityId;
-  threat: number;
-  distanceSq: number;
-  focusLoad: number;
-}
-
-export type AIInterruptReason = 'hp-drop' | 'target-lost' | 'vip-threat' | 'manual';
-
-export interface IntentInterruptEvent {
-  shipId: EntityId;
-  reason: AIInterruptReason;
-  tick: number;
-  sourceId?: EntityId;
-}
-
-export interface AIInterruptState {
-  cooldownTick: Map<string, number>;
-  damageThisTick: Map<EntityId, number>;
-  lastDamageTick: number;
-  vipThreatAssignments: Map<EntityId, EntityId>;
-}
-
-export interface AIShotHistogram {
-  buckets: readonly number[];
-  counts: number[];
-  total: number;
-}
-
-export interface AIInBandStats {
-  samples: number;
-  satisfied: number;
-}
-
-export interface AIInBandSummary {
-  samples: number;
-  satisfied: number;
-  ratio: number | null;
-}
-
-export interface AIInBandSummaryByHull {
-  overall: AIInBandSummary;
-  byHull: Record<ShipHull, AIInBandSummary>;
-}
-
-export interface AIFirstShotSummary {
-  samples: number;
-  p50: number | null;
-  p90: number | null;
-}
-
-export interface AIOpeningAggressionSummary {
-  total: number;
-  aggressive: number;
-  ratio: number | null;
-}
-
-export interface AIVerticalSummary {
-  samples: number;
-  aboveThreshold: number;
-  threshold: number;
-  ratio: number | null;
-}
-
-export interface AIDecisionLatencySummary {
-  buckets: [number, number, number, number];
-  total: number;
-}
-
-export interface AIFocusFireSummary {
-  samples: number;
-  ratioAvg: number | null;
-  ratioMax: number | null;
-}
-
-export interface AIHeadingAmplitudeSummary {
-  samples: number;
-  avg: number | null;
-  min: number | null;
-  max: number | null;
-}
-
-export interface AITieSummary {
-  decisions: number;
-  fallbacks: number;
-  ratio: number | null;
-}
-
-export interface AIKpiSummary {
-  firstShot: AIFirstShotSummary;
-  openingAggression: AIOpeningAggressionSummary;
-  inBand: AIInBandSummaryByHull;
-  vertical: AIVerticalSummary;
-  decisionLatency: AIDecisionLatencySummary;
-  focusFire: AIFocusFireSummary;
-  headingAmplitude: AIHeadingAmplitudeSummary;
-  ties: AITieSummary;
-}
-
-export interface AIManagerState {
-  enabled: boolean;
-  tickInterval: number;
-  maxPerTick: number;
-  accumulator: number;
-  tickIndex: number;
-  cursor: number;
-  slices: number;
-  assignments: AITeamAssignments;
-  metrics: AIMetrics;
-  doctrine?: DoctrineState;
-  interrupts?: IntentInterruptEvent[];
-  interruptState?: AIInterruptState;
-}
-
-export interface AIMetrics {
-  totalDecisions: number;
-  totalSkipped: number;
-  budgetHits: number;
-  lastDecisions: number;
-  lastSkipped: number;
-  lastSliceSize: number;
-  lastTotalShips: number;
-  verticalSamples: number;
-  verticalAboveThreshold: number;
-  inBandSamples: number;
-  inBandSatisfied: number;
-  openingAggressiveIntents: number;
-  openingTotalIntents: number;
-  tieDecisions: number;
-  tieFallbacks: number;
-  decisionLatencyBuckets: [number, number, number, number];
-  focusFireSamples: number;
-  focusFireRatioSum: number;
-  focusFireRatioMax: number;
-  headingAmplitudeSamples: number;
-  headingAmplitudeSum: number;
-  headingAmplitudeMin: number;
-  headingAmplitudeMax: number;
-  firstShotTimes: number[];
-  firstShotByShip: Record<number, number>;
-  intentTimeline: AIIntentSnapshot[];
-  inBandByHull: Record<ShipHull, AIInBandStats>;
-  shotDistanceHist: Record<ShipHull, AIShotHistogram>;
-  shotDeltaYHist: Record<ShipHull, AIShotHistogram>;
-  shotVerticalThreshold: number;
-  lastAggregationTick: number;
-  kpis: AIKpiSummary;
-}
+export type {
+  AIInBandSummary,
+  AIInBandSummaryByHull,
+  AIFirstShotSummary,
+  AIOpeningAggressionSummary,
+  AIVerticalSummary,
+  AIDecisionLatencySummary,
+  AIFocusFireSummary,
+  AIHeadingAmplitudeSummary,
+  AITieSummary,
+  AIKpiSummary,
+  AIMetrics,
+} from './ai/metrics.js';

--- a/src/types/ai/doctrine.ts
+++ b/src/types/ai/doctrine.ts
@@ -1,0 +1,53 @@
+import type { Team, ShipHull } from '../gameplay.js';
+import type { BehaviorProfile, TeamPosture } from './state.js';
+
+export type DoctrineCardId = 'aggressivePush' | 'elasticDefense' | 'ambush';
+
+export interface DoctrineProfileModifiers {
+  aggressionMultiplier?: number;
+  patienceMultiplier?: number;
+  desiredRangeOffset?: number;
+  desiredRangeScale?: number;
+  bandPreference?: BehaviorProfile['bandPreference'];
+  engagementBiasBonus?: number;
+  orbitMultiplier?: number;
+}
+
+export interface DoctrineThreatModifiers {
+  focusPenaltyMultiplier?: number;
+  vipBonusMultiplier?: number;
+  distanceScaleMultiplier?: number;
+  hullBiasAdd?: Partial<Record<ShipHull, number>>;
+}
+
+export interface DoctrineSquadDirectives {
+  postureOverride?: TeamPosture;
+  escortReserveRatio?: number;
+}
+
+export interface DoctrineSensorModifiers {
+  detectionMultiplier?: number;
+  stealthBonus?: number;
+  contactRetentionMultiplier?: number;
+}
+
+export interface DoctrineCard {
+  id: DoctrineCardId;
+  label: string;
+  description: string;
+  profile?: DoctrineProfileModifiers;
+  threat?: DoctrineThreatModifiers;
+  squad?: DoctrineSquadDirectives;
+  sensor?: DoctrineSensorModifiers;
+}
+
+export interface DoctrineRuntimeState {
+  cardId: DoctrineCardId;
+  expiresAtTick: number | null;
+  lastSwitchTick: number;
+}
+
+export interface DoctrineState {
+  defaultCard: DoctrineCardId;
+  teams: Record<Team, DoctrineRuntimeState>;
+}

--- a/src/types/ai/metrics.ts
+++ b/src/types/ai/metrics.ts
@@ -1,0 +1,102 @@
+import type { ShipHull } from '../gameplay.js';
+import type { AIInBandStats, AIIntentSnapshot, AIShotHistogram } from './state.js';
+
+export interface AIInBandSummary {
+  samples: number;
+  satisfied: number;
+  ratio: number | null;
+}
+
+export interface AIInBandSummaryByHull {
+  overall: AIInBandSummary;
+  byHull: Record<ShipHull, AIInBandSummary>;
+}
+
+export interface AIFirstShotSummary {
+  samples: number;
+  p50: number | null;
+  p90: number | null;
+}
+
+export interface AIOpeningAggressionSummary {
+  total: number;
+  aggressive: number;
+  ratio: number | null;
+}
+
+export interface AIVerticalSummary {
+  samples: number;
+  aboveThreshold: number;
+  threshold: number;
+  ratio: number | null;
+}
+
+export interface AIDecisionLatencySummary {
+  buckets: [number, number, number, number];
+  total: number;
+}
+
+export interface AIFocusFireSummary {
+  samples: number;
+  ratioAvg: number | null;
+  ratioMax: number | null;
+}
+
+export interface AIHeadingAmplitudeSummary {
+  samples: number;
+  avg: number | null;
+  min: number | null;
+  max: number | null;
+}
+
+export interface AITieSummary {
+  decisions: number;
+  fallbacks: number;
+  ratio: number | null;
+}
+
+export interface AIKpiSummary {
+  firstShot: AIFirstShotSummary;
+  openingAggression: AIOpeningAggressionSummary;
+  inBand: AIInBandSummaryByHull;
+  vertical: AIVerticalSummary;
+  decisionLatency: AIDecisionLatencySummary;
+  focusFire: AIFocusFireSummary;
+  headingAmplitude: AIHeadingAmplitudeSummary;
+  ties: AITieSummary;
+}
+
+export interface AIMetrics {
+  totalDecisions: number;
+  totalSkipped: number;
+  budgetHits: number;
+  lastDecisions: number;
+  lastSkipped: number;
+  lastSliceSize: number;
+  lastTotalShips: number;
+  verticalSamples: number;
+  verticalAboveThreshold: number;
+  inBandSamples: number;
+  inBandSatisfied: number;
+  openingAggressiveIntents: number;
+  openingTotalIntents: number;
+  tieDecisions: number;
+  tieFallbacks: number;
+  decisionLatencyBuckets: [number, number, number, number];
+  focusFireSamples: number;
+  focusFireRatioSum: number;
+  focusFireRatioMax: number;
+  headingAmplitudeSamples: number;
+  headingAmplitudeSum: number;
+  headingAmplitudeMin: number;
+  headingAmplitudeMax: number;
+  firstShotTimes: number[];
+  firstShotByShip: Record<number, number>;
+  intentTimeline: AIIntentSnapshot[];
+  inBandByHull: Record<ShipHull, AIInBandStats>;
+  shotDistanceHist: Record<ShipHull, AIShotHistogram>;
+  shotDeltaYHist: Record<ShipHull, AIShotHistogram>;
+  shotVerticalThreshold: number;
+  lastAggregationTick: number;
+  kpis: AIKpiSummary;
+}

--- a/src/types/ai/state.ts
+++ b/src/types/ai/state.ts
@@ -1,0 +1,174 @@
+import type { Vector3 } from 'three';
+import type { EntityId } from '../core.js';
+import type { Team, ShipHull } from '../gameplay.js';
+import type { DoctrineState } from './doctrine.js';
+import type { AIMetrics } from './metrics.js';
+
+export type AIIntent =
+  | 'Attack'
+  | 'Kite'
+  | 'Escort'
+  | 'Intercept'
+  | 'Flee'
+  | 'Regroup'
+  | 'Reposition';
+
+export interface AICommand {
+  heading: Vector3;
+  thrust: number;
+  /** Optional lateral strafe input in range [-1, 1]. */
+  strafe?: number;
+  firePrimary: boolean;
+  orbit?: number;
+  targetId?: EntityId;
+  ttl: number;
+}
+
+export interface AITraits {
+  aggression: number;
+  patience: number;
+  dodge: number;
+}
+
+export interface AIState {
+  profileId: string;
+  intent: AIIntent;
+  nextThinkAt: number;
+  cooldowns: {
+    dodgeAt: number;
+    burstAt: number;
+  };
+  lod: 0 | 1 | 2;
+  traitSeed: number;
+  traits: AITraits;
+  targetId?: EntityId;
+  lastScore?: number;
+  command: AICommand;
+  stickinessUntil: number;
+  stickinessHeading: Vector3;
+  stickinessTargetId?: EntityId;
+  desiredRange?: readonly [number, number];
+}
+
+export interface BehaviorProfile {
+  desiredRange: readonly [number, number];
+  orbit: number;
+  aggression: number;
+  patience: number;
+  dodgeFreq: number;
+  classBias: Partial<Record<ShipHull, number>>;
+  style: 'brawler' | 'kiter' | 'artillery' | 'escort';
+  gates?: {
+    ammoMin?: number;
+    hpRetreatPct?: number;
+  };
+  verticalManeuver: number;
+  elevationPreference?: 'above' | 'below' | 'follow';
+  bandPreference?: 'outer' | 'mid' | 'inner';
+  engagementBias?: number;
+}
+
+export type TeamPosture = 'aggressive' | 'hold' | 'retreat';
+
+export interface AIBlackboard {
+  tickIndex: number;
+  teamPosture: Record<Team, TeamPosture>;
+  allyCentroid: Record<Team, Vector3>;
+  nearestEnemy: Map<EntityId, EntityId>;
+  threatToVip: Map<EntityId, EntityId>;
+  tmpVectors: Vector3[];
+  strengthRatio: Record<Team, number>;
+  teamPriority: Record<Team, PrioritisedTarget[]>;
+  priorityIndex: Record<Team, Map<EntityId, number>>;
+  focusFire: Record<Team, Map<EntityId, number>>;
+  visibleEnemies?: Record<Team, Map<EntityId, SensorVisibility>>;
+  teamCounts?: Record<Team, number>;
+  // Vertical dispersion tracking for validation (optional for backward compatibility)
+  verticalDispersion?: {
+    headingYSamples: number[];
+    positionYSamples: number[];
+    lastUpdateTick: number;
+  };
+}
+
+export interface AITeamAssignments {
+  escorts: Map<EntityId, EscortAssignment>;
+}
+
+export interface EscortAssignment {
+  vipId: EntityId;
+  offset: Vector3;
+  threatId?: EntityId;
+}
+
+export interface AIIntentSnapshot {
+  tick: number;
+  time: number;
+  counts: Partial<Record<AIIntent, number>>;
+  total: number;
+}
+
+export interface PrioritisedTarget {
+  id: EntityId;
+  threat: number;
+  distanceSq: number;
+  focusLoad: number;
+}
+
+export type AIInterruptReason = 'hp-drop' | 'target-lost' | 'vip-threat' | 'manual';
+
+export interface IntentInterruptEvent {
+  shipId: EntityId;
+  reason: AIInterruptReason;
+  tick: number;
+  sourceId?: EntityId;
+}
+
+export interface AIInterruptState {
+  cooldownTick: Map<string, number>;
+  damageThisTick: Map<EntityId, number>;
+  lastDamageTick: number;
+  vipThreatAssignments: Map<EntityId, EntityId>;
+}
+
+export interface AIShotHistogram {
+  buckets: readonly number[];
+  counts: number[];
+  total: number;
+}
+
+export interface AIInBandStats {
+  samples: number;
+  satisfied: number;
+}
+
+export interface SensorVisibility {
+  strength: number;
+  lastSeenTick: number;
+  sourceId: EntityId;
+  occluded: boolean;
+  distance: number;
+}
+
+export interface SensorState {
+  lastUpdateTick: number;
+  visibilityByTeam: Record<Team, Map<EntityId, SensorVisibility>>;
+  decayRate: number;
+  threshold: number;
+  staleDecay: number;
+}
+
+export interface AIManagerState {
+  enabled: boolean;
+  tickInterval: number;
+  maxPerTick: number;
+  accumulator: number;
+  tickIndex: number;
+  cursor: number;
+  slices: number;
+  assignments: AITeamAssignments;
+  metrics: AIMetrics;
+  doctrine?: DoctrineState;
+  interrupts?: IntentInterruptEvent[];
+  interruptState?: AIInterruptState;
+}

--- a/test/components/lod/ShipLODManager.spec.ts
+++ b/test/components/lod/ShipLODManager.spec.ts
@@ -14,10 +14,10 @@ import {
   partitionShipsByDistance,
   computeLodPartition,
   partitionsEqual,
-  populateImpostorInstances,
   DEFAULT_DISTANCE_THRESHOLD,
   DEFAULT_HYSTERESIS,
-} from '../../../src/components/lod/ShipLODManager.js';
+} from '../../../src/components/lod/shipLodPartition.js';
+import { populateImpostorInstances } from '../../../src/components/lod/ShipImpostorLayer.js';
 
 function createShip(
   id: number,


### PR DESCRIPTION
## Summary
- extract the StarDisk frame loop and debug teardown into dedicated hooks under `environment/starDisk`
- move ship LOD partitioning logic and impostor layer renderer into focused modules while slimming `ShipLODManager`
- split AI type definitions into `state`, `doctrine`, and `metrics` modules re-exported by `src/types/ai.ts`, and update LOD tests for the new helpers

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6903a0133380832aaae00a920dcc5f65