### PR TITLE
perf: add timings and spatialized projectiles

### DIFF
--- a/src/components/layers/ProjectilesInstancedLayer.tsx
+++ b/src/components/layers/ProjectilesInstancedLayer.tsx
@@ -39,6 +39,8 @@ interface ProjectileGroupState {
 }
 
 const DEFAULT_CAPACITY = 512;
+const HIGH_DENSITY_UPDATE_INTERVAL = 2;
+const HIGH_DENSITY_THRESHOLD = 300;
 // HIDDEN_MATRIX is exported from `instancedLayer.ts` and used globally to
 // hide released instances. Keeping a single canonical source avoids dupes.
 const TEMP_MATRIX = new Matrix4();
@@ -137,6 +139,10 @@ export function ProjectilesInstancedLayer({
   useFrame(() => {
     frameRef.current += 1;
     const frameId = frameRef.current;
+
+    if (projectiles.length >= HIGH_DENSITY_THRESHOLD && frameId % HIGH_DENSITY_UPDATE_INTERVAL === 0) {
+      return;
+    }
     let totalAllocated = 0;
     let saturated = false;
 

--- a/src/components/thrusters/ThrusterInstancedManager.tsx
+++ b/src/components/thrusters/ThrusterInstancedManager.tsx
@@ -26,6 +26,8 @@ interface ThrusterInstancedManagerProps {
 const DEFAULT_CAPACITY = 512;
 const DEFAULT_INTENSITY_BASE = 0.75;
 const DEFAULT_INTENSITY_RANGE = 1.5;
+const HIGH_DENSITY_THRESHOLD = 120;
+const HIGH_DENSITY_UPDATE_INTERVAL = 2;
 
 const HULL_SIZE_HINTS: Record<ShipHull, Vector3> = {
   fighter: new Vector3(1.4, 0.7, 2.8),
@@ -123,6 +125,10 @@ export function ThrusterInstancedManager({
     const frameId = frameRef.current;
     const mesh = meshRef.current;
     if (!mesh) return;
+
+    if (ships.length >= HIGH_DENSITY_THRESHOLD && frameId % HIGH_DENSITY_UPDATE_INTERVAL === 0) {
+      return;
+    }
 
     managerRef.current.beginFrame();
     let saturated = false;

--- a/src/game/createGameState.ts
+++ b/src/game/createGameState.ts
@@ -68,6 +68,11 @@ export async function createGameState(): Promise<GameState> {
         lastSubsystemFailureStack: undefined,
         lastSubsystemFailureTimestamp: 0,
       },
+      subsystemTimings: {
+        durations: {},
+        lastTickIndex: -1,
+        lastTickTime: 0,
+      },
     },
     ai: {
       enabled: AI_CONFIG.v2Enabled,

--- a/src/game/systems.ts
+++ b/src/game/systems.ts
@@ -49,6 +49,16 @@ export function updateGame(state: GameState, delta: number): void {
 
   state.time += delta;
 
+  const timings =
+    sim.subsystemTimings ??
+    (sim.subsystemTimings = {
+      durations: {},
+      lastTickIndex: -1,
+      lastTickTime: 0,
+    });
+  timings.lastTickIndex = sim.lastTickIndex;
+  timings.lastTickTime = state.time;
+
   const runSafely = (name: string, fn: () => void) => {
     try {
       fn();
@@ -68,16 +78,23 @@ export function updateGame(state: GameState, delta: number): void {
     }
   };
 
-  runSafely('updateDecisionSystem', () => updateDecisionSystem(state, delta));
+  const measureSubsystem = (name: string, fn: () => void) => {
+    const start = performance.now();
+    runSafely(name, fn);
+    timings.durations[name] = performance.now() - start;
+  };
 
-  runSafely('prepareShips', () => prepareShips(state, delta));
-  runSafely('updateCarrierLaunchSystem', () => updateCarrierLaunchSystem(state, delta));
-  runSafely('updateTurrets', () => updateTurrets(state, delta));
-  runSafely('updateMotionSystem', () => updateMotionSystem(state, delta));
-  runSafely('advanceProjectiles', () => advanceProjectiles(state, delta));
+  measureSubsystem('updateDecisionSystem', () => updateDecisionSystem(state, delta));
 
-  runSafely('flushDeferredMutations', () => flushDeferredMutations(state));
+  measureSubsystem('prepareShips', () => prepareShips(state, delta));
+  measureSubsystem('updateCarrierLaunchSystem', () => updateCarrierLaunchSystem(state, delta));
+  measureSubsystem('updateTurrets', () => updateTurrets(state, delta));
+  measureSubsystem('updateMotionSystem', () => updateMotionSystem(state, delta));
+  measureSubsystem('advanceProjectiles', () => advanceProjectiles(state, delta));
 
+  measureSubsystem('flushDeferredMutations', () => flushDeferredMutations(state));
+
+  const physicsStart = performance.now();
   try {
     // EventQueue created with { auto: true } is managed internally by Rapier.
     // Passing it explicitly to step() causes "recursive use" errors.
@@ -87,13 +104,15 @@ export function updateGame(state: GameState, delta: number): void {
     // upstream code can still handle a fatal physics panic if necessary.
     recordRapierStepPanic(state, error);
     throw error;
+  } finally {
+    timings.durations.physicsStep = performance.now() - physicsStart;
   }
 
-  runSafely('flushPostPhysicsMutations', () => flushPostPhysicsMutations(state));
+  measureSubsystem('flushPostPhysicsMutations', () => flushPostPhysicsMutations(state));
 
-  runSafely('syncTransforms', () => syncTransforms(state));
-  runSafely('resolveProjectiles', () => resolveProjectiles(state, delta));
-  runSafely('updateExplosions', () => updateExplosions(state, delta));
+  measureSubsystem('syncTransforms', () => syncTransforms(state));
+  measureSubsystem('resolveProjectiles', () => resolveProjectiles(state, delta));
+  measureSubsystem('updateExplosions', () => updateExplosions(state, delta));
 }
 
 export const __aiTestHooks = {

--- a/src/game/systems/damage.ts
+++ b/src/game/systems/damage.ts
@@ -23,8 +23,11 @@ import {
 import type { ProjectileCategory } from '../../types/combat.js';
 import { safeNormalize } from '../../utils/steering.js';
 import { appendCappedMutable } from '../../utils/cappedBuffer.js';
+import type { SpatialHash } from '../utils/spatialHash.js';
+import { buildSpatialHash, querySpatialHash } from '../utils/spatialHash.js';
 
 const TEMP_RIPPLE_DIR = new Vector3();
+const SHIP_GRID_CELL_SIZE = 12;
 
 export interface ProjectileDamageOutcome {
   totalDamage: number;
@@ -37,6 +40,7 @@ export function applyProjectileDamage(
   projectile: ProjectileEntity,
   ship: ShipEntity,
   ships: ShipEntity[],
+  shipsById: Map<number, ShipEntity>,
 ): ProjectileDamageOutcome {
   const projectileCategory =
     projectile.projectile.category ?? resolveProjectileCategory(projectile.projectile.bulletType);
@@ -55,7 +59,7 @@ export function applyProjectileDamage(
     category: projectileCategory,
   };
   const attackerShip = sourceMeta.id
-    ? ships.find((s) => s.id === sourceMeta.id)
+    ? shipsById.get(sourceMeta.id)
     : ships.find((s) => s.ship.team === sourceMeta.team);
 
   const outcome = applyDamageResultToShip({
@@ -136,6 +140,7 @@ function handleBeamProjectile(
   state: GameState,
   projectile: ProjectileEntity,
   ships: ShipEntity[],
+  shipsById: Map<number, ShipEntity>,
   toRemove: Set<GameEntity>,
   delta: number,
 ): void {
@@ -147,9 +152,9 @@ function handleBeamProjectile(
   }
 
   if (!beam.applied && projectile.projectile.targetId != null) {
-    const target = ships.find((s) => s.id === projectile.projectile.targetId);
+    const target = shipsById.get(projectile.projectile.targetId);
     if (target && target.ship.team !== projectile.projectile.team) {
-      const outcome = applyProjectileDamage(state, projectile, target, ships);
+      const outcome = applyProjectileDamage(state, projectile, target, ships, shipsById);
       if (outcome.destroyed) {
         toRemove.add(target);
       }
@@ -166,17 +171,20 @@ function applyAoeDamage(
   state: GameState,
   projectile: ProjectileEntity,
   ships: ShipEntity[],
+  shipsById: Map<number, ShipEntity>,
+  shipSpatialHash: SpatialHash<ShipEntity>,
   toRemove: Set<GameEntity>,
   radius: number,
   primaryTarget: ShipEntity,
 ): void {
   const origin = primaryTarget.transform.position;
-  for (const ship of ships) {
+  const nearbyShips = querySpatialHash(shipSpatialHash, origin, radius);
+  for (const ship of nearbyShips) {
     if (ship === primaryTarget) continue;
     if (ship.ship.team === projectile.projectile.team) continue;
     const distance = ship.transform.position.distanceTo(origin);
     if (distance > radius) continue;
-    const outcome = applyProjectileDamage(state, projectile, ship, ships);
+    const outcome = applyProjectileDamage(state, projectile, ship, ships, shipsById);
     if (outcome.destroyed) {
       toRemove.add(ship);
     }
@@ -185,6 +193,16 @@ function applyAoeDamage(
 
 export function resolveProjectiles(state: GameState, delta: number): void {
   const ships = state.queries.ships.entities as ShipEntity[];
+  const shipSpatialHash: SpatialHash<ShipEntity> = buildSpatialHash(
+    ships,
+    SHIP_GRID_CELL_SIZE,
+    (ship) => ship.transform.position,
+  );
+  const shipsById = new Map<number, ShipEntity>();
+  for (const ship of ships) {
+    shipsById.set(ship.id, ship);
+  }
+  const maxShipImpactRadius = ships.reduce((radius, ship) => Math.max(radius, ship.transform.scale * 0.9), 0);
   const projectiles = state.queries.projectiles.entities as ProjectileEntity[];
   const toRemove = new Set<GameEntity>();
   const manager = state.ai;
@@ -198,7 +216,7 @@ export function resolveProjectiles(state: GameState, delta: number): void {
       projectile.projectile.category ?? resolveProjectileCategory(projectile.projectile.bulletType);
 
     if (category === 'beam') {
-      handleBeamProjectile(state, projectile, ships, toRemove, delta);
+      handleBeamProjectile(state, projectile, ships, shipsById, toRemove, delta);
       continue;
     }
 
@@ -211,18 +229,25 @@ export function resolveProjectiles(state: GameState, delta: number): void {
     const info = resolveProjectileInfo(projectile.projectile.bulletType);
     const projRadius =
       info.config.colliderRadius ?? Math.max(0.08, projectile.transform.scale * 1.2);
+    const searchRadius = maxShipImpactRadius + projRadius;
 
-    for (const ship of ships) {
+    const nearbyShips = querySpatialHash(
+      shipSpatialHash,
+      projectile.transform.position,
+      searchRadius,
+    );
+
+    for (const ship of nearbyShips) {
+      const impactRadius = ship.transform.scale * 0.9 + projRadius;
       if (ship.ship.team === projectile.projectile.team) continue;
       const distance = ship.transform.position.distanceTo(projectile.transform.position);
-      const impactRadius = ship.transform.scale * 0.9 + projRadius;
       if (distance > impactRadius) continue;
       if (!isProjectileArmed(projectile, state.time)) {
         // Not armed yet — skip damage but allow future collisions.
         continue;
       }
 
-      const outcome = applyProjectileDamage(state, projectile, ship, ships);
+      const outcome = applyProjectileDamage(state, projectile, ship, ships, shipsById);
       toRemove.add(projectile);
 
       if (outcome.destroyed) {
@@ -230,7 +255,16 @@ export function resolveProjectiles(state: GameState, delta: number): void {
       }
 
       if (projectile.projectile.aoeRadius && projectile.projectile.aoeRadius > 0) {
-        applyAoeDamage(state, projectile, ships, toRemove, projectile.projectile.aoeRadius, ship);
+        applyAoeDamage(
+          state,
+          projectile,
+          ships,
+          shipsById,
+          shipSpatialHash,
+          toRemove,
+          projectile.projectile.aoeRadius,
+          ship,
+        );
       }
       break;
     }

--- a/src/game/systems/sync.ts
+++ b/src/game/systems/sync.ts
@@ -1,11 +1,35 @@
-import type { GameState, GameEntity } from '../../types/index.js';
+import type { GameState, GameEntity, RigidBody } from '../../types/index.js';
+
+function syncEntityTransform(entity: GameEntity): void {
+  const translation = entity.rigidBody.translation();
+  const rotation = entity.rigidBody.rotation();
+
+  entity.transform.position.set(translation.x, translation.y, translation.z);
+  entity.transform.rotation.set(rotation.x, rotation.y, rotation.z, rotation.w);
+}
 
 export function syncTransforms(state: GameState): void {
-  for (const entity of state.world.entities as GameEntity[]) {
-    const translation = entity.rigidBody.translation();
-    const rotation = entity.rigidBody.rotation();
+  const synced = new Set<number>();
 
-    entity.transform.position.set(translation.x, translation.y, translation.z);
-    entity.transform.rotation.set(rotation.x, rotation.y, rotation.z, rotation.w);
+  state.physicsWorld.forEachActiveRigidBody((body: RigidBody) => {
+    if (!body.isEnabled()) return;
+    const colliderCount = body.numColliders();
+    if (colliderCount <= 0) return;
+
+    const colliderHandle = body.collider(0)?.handle;
+    if (colliderHandle == null) return;
+    const entity = state.colliderLookup.get(colliderHandle) as GameEntity | undefined;
+    if (!entity || synced.has(entity.id)) return;
+
+    syncEntityTransform(entity);
+    synced.add(entity.id);
+  });
+
+  // Handle rare cases where kinematic bodies remain idle but still need to mirror their rigid body state.
+  for (const entity of state.world.entities as GameEntity[]) {
+    if (synced.has(entity.id)) continue;
+    const body = entity.rigidBody;
+    if (body.isFixed() || body.isSleeping()) continue;
+    syncEntityTransform(entity);
   }
 }

--- a/src/game/utils/spatialHash.ts
+++ b/src/game/utils/spatialHash.ts
@@ -1,0 +1,74 @@
+import type { Vector3 } from 'three';
+
+export interface SpatialHash<T> {
+  cellSize: number;
+  grid: Map<string, T[]>;
+  getPosition: (item: T) => Vector3;
+}
+
+function toCellIndex(value: number, cellSize: number): number {
+  return Math.floor(value / cellSize);
+}
+
+function toKey(x: number, y: number, z: number): string {
+  return `${x},${y},${z}`;
+}
+
+export function buildSpatialHash<T>(
+  items: readonly T[],
+  cellSize: number,
+  getPosition: (item: T) => Vector3,
+): SpatialHash<T> {
+  const grid = new Map<string, T[]>();
+
+  for (const item of items) {
+    const pos = getPosition(item);
+    const key = toKey(toCellIndex(pos.x, cellSize), toCellIndex(pos.y, cellSize), toCellIndex(pos.z, cellSize));
+    const bucket = grid.get(key);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      grid.set(key, [item]);
+    }
+  }
+
+  return { grid, cellSize, getPosition };
+}
+
+export function querySpatialHash<T>(
+  hash: SpatialHash<T>,
+  position: Vector3,
+  radius: number,
+  out: T[] = [],
+): T[] {
+  out.length = 0;
+  if (radius < 0) return out;
+  const radiusSq = radius * radius;
+
+  const cellRange = Math.max(0, Math.ceil(radius / hash.cellSize));
+  const baseX = toCellIndex(position.x, hash.cellSize);
+  const baseY = toCellIndex(position.y, hash.cellSize);
+  const baseZ = toCellIndex(position.z, hash.cellSize);
+
+  for (let dx = -cellRange; dx <= cellRange; dx += 1) {
+    for (let dy = -cellRange; dy <= cellRange; dy += 1) {
+      for (let dz = -cellRange; dz <= cellRange; dz += 1) {
+        const key = toKey(baseX + dx, baseY + dy, baseZ + dz);
+        const bucket = hash.grid.get(key);
+        if (bucket) {
+          for (const item of bucket) {
+            const pos = hash.getPosition(item);
+            const dxPos = pos.x - position.x;
+            const dyPos = pos.y - position.y;
+            const dzPos = pos.z - position.z;
+            if (dxPos * dxPos + dyPos * dyPos + dzPos * dzPos <= radiusSq) {
+              out.push(item);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return out;
+}

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -44,6 +44,15 @@ export interface RapierDiagnostics {
   lastSubsystemFailureTimestamp: number;
 }
 
+export interface SubsystemTimings {
+  /** Wall-clock durations (ms) for the latest tick keyed by subsystem name. */
+  durations: Record<string, number>;
+  /** Last simulation tick index where timings were recorded. */
+  lastTickIndex: number;
+  /** Simulation time when timings were captured. */
+  lastTickTime: number;
+}
+
 export interface SimulationClock {
   /** Fixed step size in seconds for simulation updates. */
   step: number;
@@ -65,6 +74,8 @@ export interface SimulationClock {
   postStepMutations: DeferredMutation[];
   /** Aggregated diagnostics capturing Rapier guard trips and deferred failures. */
   rapierDiagnostics: RapierDiagnostics;
+  /** Per-subsystem timing diagnostics captured each tick. */
+  subsystemTimings: SubsystemTimings;
 }
 
 export interface HudUiFlags {

--- a/test/vitest/ai-doctrine.spec.ts
+++ b/test/vitest/ai-doctrine.spec.ts
@@ -86,6 +86,11 @@ function createMockState(): GameState {
         lastSubsystemFailureStack: undefined,
         lastSubsystemFailureTimestamp: 0,
       },
+      subsystemTimings: {
+        durations: {},
+        lastTickIndex: -1,
+        lastTickTime: 0,
+      },
     },
     uiFlags: { hudHealthBars: false },
     explosions: [],

--- a/test/vitest/ai-sensors.spec.ts
+++ b/test/vitest/ai-sensors.spec.ts
@@ -81,6 +81,11 @@ function createState(): GameState {
         lastSubsystemFailureStack: undefined,
         lastSubsystemFailureTimestamp: 0,
       },
+      subsystemTimings: {
+        durations: {},
+        lastTickIndex: -1,
+        lastTickTime: 0,
+      },
     },
     uiFlags: { hudHealthBars: false },
     explosions: [],

--- a/test/vitest/explosions-event.spec.ts
+++ b/test/vitest/explosions-event.spec.ts
@@ -64,6 +64,11 @@ function makeState(rngValue = 0.42): GameState {
         lastSubsystemFailureStack: undefined,
         lastSubsystemFailureTimestamp: 0,
       },
+      subsystemTimings: {
+        durations: {},
+        lastTickIndex: -1,
+        lastTickTime: 0,
+      },
     },
     ai: undefined as any,
     blackboard: undefined as any,

--- a/test/vitest/projectile-resolve.spec.ts
+++ b/test/vitest/projectile-resolve.spec.ts
@@ -159,6 +159,11 @@ function makeStateStub(): GameState {
         lastSubsystemFailureStack: undefined,
         lastSubsystemFailureTimestamp: 0,
       },
+      subsystemTimings: {
+        durations: {},
+        lastTickIndex: -1,
+        lastTickTime: 0,
+      },
     },
   } as GameState;
 }

--- a/test/vitest/shield-regen.spec.ts
+++ b/test/vitest/shield-regen.spec.ts
@@ -157,6 +157,11 @@ function makeStateStub(): GameState {
         lastSubsystemFailureStack: undefined,
         lastSubsystemFailureTimestamp: 0,
       },
+      subsystemTimings: {
+        durations: {},
+        lastTickIndex: -1,
+        lastTickTime: 0,
+      },
     },
   } as GameState;
 }

--- a/test/vitest/spatial-hash.spec.ts
+++ b/test/vitest/spatial-hash.spec.ts
@@ -1,0 +1,31 @@
+import { Vector3 } from 'three';
+import { buildSpatialHash, querySpatialHash } from '../../src/game/utils/spatialHash.js';
+
+describe('spatial hash', () => {
+  it('groups items into cells and queries nearby buckets', () => {
+    const items = [
+      { id: 'a', position: new Vector3(0, 0, 0) },
+      { id: 'b', position: new Vector3(4.9, 0, 0) },
+      { id: 'c', position: new Vector3(12, 0, 0) },
+      { id: 'd', position: new Vector3(-3, 8, 0) },
+    ];
+
+    const hash = buildSpatialHash(items, 5, (item) => item.position);
+    const nearby = querySpatialHash(hash, new Vector3(0, 0, 0), 6);
+
+    const ids = nearby.map((item) => item.id).sort();
+    expect(ids).toEqual(['a', 'b']);
+  });
+
+  it('limits results based on radius', () => {
+    const items = [
+      { id: 'a', position: new Vector3(0, 0, 0) },
+      { id: 'b', position: new Vector3(20, 0, 0) },
+    ];
+
+    const hash = buildSpatialHash(items, 10, (item) => item.position);
+    const nearby = querySpatialHash(hash, new Vector3(0, 0, 0), 5);
+
+    expect(nearby.map((item) => item.id)).toEqual(['a']);
+  });
+});

--- a/test/vitest/turrets.spec.ts
+++ b/test/vitest/turrets.spec.ts
@@ -158,6 +158,11 @@ function makeStateStub(): GameState {
         lastSubsystemFailureStack: undefined,
         lastSubsystemFailureTimestamp: 0,
       },
+      subsystemTimings: {
+        durations: {},
+        lastTickIndex: -1,
+        lastTickTime: 0,
+      },
     },
   } as GameState;
 }


### PR DESCRIPTION
## Summary
- add per-subsystem timing diagnostics to the simulation tick and initialize diagnostics for test harnesses
- spatially bucket ships when resolving projectiles to avoid P×S scans and trim AoE queries
- throttle high-density projectile and thruster instance updates and add spatial hash utilities/tests

## Testing
- npx tsc --noEmit
- npx vitest test/vitest/projectile-resolve.spec.ts
- npx vitest test/vitest/turrets.spec.ts
- npx vitest test/vitest/shield-regen.spec.ts
- npx vitest test/vitest/systems/projectiles/projectiles.spec.ts
- npx vitest test/vitest/spatial-hash.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69191e8317ac832a85062db86b07f4db)