### PR TITLE
Fix turret prioritization logic

### DIFF
--- a/src/game/systems/turrets.ts
+++ b/src/game/systems/turrets.ts
@@ -126,7 +126,7 @@ export function updateTurrets(state: GameState, delta: number): void {
         const dSq = s.transform.position.distanceToSquared(origin);
         // Bonus scaling: multiply by typical distance magnitude to maintain
         // relative weighting when using squared distances
-        const bonusScale = 25000;
+        const bonusScale = 100000;
         const bonus = preferSmall
           ? SMALL_HULLS.has(s.ship.hull)
             ? -10 * bonusScale

--- a/test/vitest/turret-priority.spec.ts
+++ b/test/vitest/turret-priority.spec.ts
@@ -249,4 +249,34 @@ describe('Turret Prioritization Bug', () => {
     // I will assert the desired behavior, so the test fails.
     expect(projectile.projectile.targetId).toBe(redFighter.id);
   });
+
+  it('should prioritize fighter over frigate even with large distance difference (robustness check)', () => {
+    const state = makeStateStub();
+
+    // Blue ship with anti-fighter turret at origin
+    const blueShip = createShip(state, 1, 'blue', 'frigate', new Vector3(0, 0, 0));
+    createTurretEntity(state, blueShip, 'antiFighter');
+
+    // Red Fighter at distance 900 (far but in range)
+    const redFighter = createShip(state, 2, 'red', 'fighter', new Vector3(900, 0, 0));
+
+    // Red Frigate at distance 100 (very close)
+    const redFrigate = createShip(state, 3, 'red', 'frigate', new Vector3(100, 0, 0));
+
+    // Run turrets update
+    updateTurrets(state, 0.016);
+
+    // Process post-step mutations (where projectiles are spawned)
+    for (const mutation of state.simulation.postStepMutations) {
+      mutation();
+    }
+
+    // Check projectiles
+    const projectiles = (state.queries.projectiles as any).entities;
+    expect(projectiles.length).toBe(1);
+
+    const projectile = projectiles[0];
+
+    expect(projectile.projectile.targetId).toBe(redFighter.id);
+  });
 });


### PR DESCRIPTION
Enhance turret targeting to strictly adhere to target preferences, increasing the priority bonus scale for turret targeting. Add a regression test to ensure that anti-fighter turrets prioritize fighters over frigates, even when the latter are closer.