### PR TITLE
feat: Implement steering helpers, torpedo homing, and point defense targeting

### DIFF
--- a/memory/designs/DESIGN066-projectile-steering-point-defense.md
+++ b/memory/designs/DESIGN066-projectile-steering-point-defense.md
@@ -1,0 +1,80 @@
+# DESIGN066 - Steering Helpers, Torpedo Homing, Point Defense
+
+**Status:** Proposed  
+**Created:** 2026-01-09  
+
+## Summary
+
+Add robust steering helper functions (seek/arrive/pursuit/evade), enable torpedo homing by default, and introduce point-defense projectile targeting for turrets. The goal is to make guidance behavior more consistent while enabling PD turrets to prioritize and intercept incoming missiles/torpedoes.
+
+## Requirements
+
+- See `memory/requirements.md` — 2026-01-09 section.
+
+## Goals
+
+- Provide steering helpers that are safe for zero-length vectors and predictable under edge conditions.
+- Make `torpedo:standard` home by default with conservative turn rate.
+- Add a turret targeting mode that prioritizes hostile projectiles within range and falls back to ship targeting when none exist.
+
+## Non-Goals
+
+- Full projectile-vs-projectile collision simulation.
+- AI doctrine changes or balance tuning beyond torpedo homing defaults.
+- New renderer effects for PD interceptions (can be layered later).
+
+## Architecture Overview
+
+- `src/utils/steering.ts` gains new helper functions for direction selection and intercept math.
+- `src/config/projectiles.ts` adds a homing config for `torpedo:standard`.
+- `src/game/utils/targetSelection.ts` gains a projectile-target selection helper for PD.
+- `src/game/systems/turrets.ts` extends target selection logic to support `priority: 'antiProjectile'`.
+
+## Data Flow
+
+1. Turret update runs → selects target:
+   - If `priority === 'antiProjectile'`, scan enemy projectiles in range (prefer those targeting the parent ship).
+   - Otherwise use existing ship targeting (priority/nearest).
+2. If a projectile target is selected, the turret fires toward its position and the projectile is removed.
+3. If no projectile target is found, the turret falls back to ship targeting and fires as before.
+
+## Data Model & Type Changes
+
+- Extend `TurretSpec.priority` and `TurretComponent.priority` to include `'antiProjectile'`.
+- No new GameState fields. Use existing `state.queries.projectiles` and `state.shipById`.
+
+## Interfaces (planned)
+
+Steering helpers in `src/utils/steering.ts`:
+
+- `computeSeekDirection(targetPos, sourcePos, out?, fallback?)`
+- `computeArriveDirection(targetPos, sourcePos, slowRadius, stopRadius?, out?, fallback?)`
+- `computeInterceptDirection(targetPos, sourcePos, targetVelocity, sourceSpeed, out?, fallback?)`
+- `computeEvadeDirection(threatPos, sourcePos, threatVelocity, sourceSpeed, out?, fallback?)`
+
+Projectile targeting in `src/game/utils/targetSelection.ts`:
+
+- `findPointDefenseTarget(state, origin, team, options)`
+  - Prefer projectiles that are hostile and targeting the parent ship.
+  - Filter to missile/torpedo categories (or homing projectiles) by default.
+
+## Error Handling
+
+- Steering helpers clamp/validate inputs and fall back to `FORWARD` for invalid vectors.
+- PD targeting ignores invalid or friendly projectiles; no throwing in hot loops.
+
+## Testing & Validation
+
+- Extend `test/vitest/steering-utils.spec.ts` for new steering helpers and edge cases.
+- Add turret PD tests (antiProjectile selection + fallback to ships).
+- Update/extend projectile tests to ensure torpedo homing defaults are applied.
+
+## Performance Considerations
+
+- PD targeting iterates projectiles only for `antiProjectile` turrets.
+- Filtering is early-out (range + team + category checks) to minimize cost.
+
+## Open Questions
+
+- Should PD interception remove projectiles immediately or apply damage over time?
+- Should PD prioritize only homing missiles/torpedoes or include proximity-fuse flak rounds?

--- a/memory/designs/_index.md
+++ b/memory/designs/_index.md
@@ -4,6 +4,7 @@ This folder contains canonical design documents named using the pattern `DESIGNN
 
 ## In Progress
 
+- [DESIGN066](DESIGN066-projectile-steering-point-defense.md) — Steering helpers, torpedo homing default, and point-defense projectile targeting. (Proposed) (2026-01-09)
 - [DESIGN055](DESIGN055-capped-buffer-helper.md) — Shared capped-buffer helpers centralize history trimming across debug and metrics surfaces. (In Progress — implementation underway) (2025-10-29)
 - [DESIGN048](DESIGN048-renderer-large-file-plan.md) — Plan to split large renderer files into focused modules with clear test boundaries and a migration plan. (In Progress — implementation planning) (2025-10-27)
 - [DESIGN019](DESIGN019-ship-mock-test.md) — Playwright ship mock render tests (PoC implemented; follow-up: generate baselines, CI job). (In Progress — PoC implemented 2025-12-15)

--- a/memory/requirements.md
+++ b/memory/requirements.md
@@ -1,5 +1,12 @@
 # Requirements
 
+## 2026-01-09 — Steering Helpers, Torpedo Homing, Point Defense
+
+1. **WHEN** steering callers request seek/arrive/pursuit/evade outputs, **THE SYSTEM SHALL** provide helper functions that return normalized directions (and arrive speed scaling) while safely handling zero-length vectors with fallbacks. _(Acceptance: `test/vitest/steering-utils.spec.ts` covers the new helpers and edge conditions.)_
+2. **WHEN** a `torpedo:standard` projectile is spawned without overrides, **THE SYSTEM SHALL** apply the default torpedo homing configuration so torpedoes steer toward assigned targets. _(Acceptance: unit coverage confirms the torpedo config includes homing and spawned torpedoes inherit it.)_
+3. **WHEN** a turret is configured with priority `antiProjectile`, **THE SYSTEM SHALL** select the nearest enemy missile/torpedo within range, preferring projectiles targeting the parent ship, and attempt interception. _(Acceptance: turret unit test verifies the projectile is selected/cleared and a shot is recorded.)_
+4. **WHEN** no eligible projectile exists for `antiProjectile`, **THE SYSTEM SHALL** fall back to the existing ship targeting logic so turrets remain active. _(Acceptance: turret unit test asserts fallback ship targeting.)_
+
 ## 2025-10-29 — Debug History Capping Unification (TASK415)
 
 1. **WHEN** a debug, telemetry, or metrics buffer records a new entry, **THE SYSTEM SHALL** append via a shared capped-buffer helper that enforces the configured maximum length. _(Acceptance: `test/utils/cappedArray.spec.ts` appends beyond the cap and asserts the tail length equals the limit.)_

--- a/memory/tasks/TASK161-projectile-steering-point-defense.md
+++ b/memory/tasks/TASK161-projectile-steering-point-defense.md
@@ -1,0 +1,44 @@
+# [TASK161] - Steering helpers, torpedo homing, point defense targeting
+
+**Status:** In Progress  
+**Added:** 2026-01-09  
+**Updated:** 2026-01-09  
+
+## Original Request
+
+Do robust helpers for steering, make torpedoes homing by default, and design/introduce projectile-targeting point defense behavior/logic.
+
+## Thought Process
+
+- Steering utilities exist but lack higher-level seek/arrive/pursuit/evade helpers; adding them will standardize usage and edge handling.
+- Torpedoes already support homing via config overrides, so enabling homing by default should be a minimal config change plus test coverage.
+- Point defense requires selecting hostile projectiles as targets and removing them; no projectile-vs-projectile collision exists today, so PD will actively intercept by removing projectiles when fired upon.
+
+## Implementation Plan
+
+- Extend `src/utils/steering.ts` with seek/arrive/intercept/evade helpers and add unit tests.
+- Add default homing config for `torpedo:standard` in `src/config/projectiles.ts`.
+- Introduce a PD selection helper (projectile targeting) and update turret targeting to support `priority: 'antiProjectile'` with fallback to ship targeting.
+- Update `TurretSpec`/`TurretComponent` types and `createPointDefenseTurret` defaults.
+- Add/adjust tests covering PD selection and torpedo homing defaults.
+
+## Progress Tracking
+
+**Overall Status:** In Progress — 80%
+
+### Subtasks
+
+| ID  | Description                                               | Status      | Updated    | Notes |
+| --- | --------------------------------------------------------- | ----------- | ---------- | ----- |
+| 1.1 | Add steering helpers + unit tests                         | Complete    | 2026-01-09 | New seek/arrive/intercept/evade helpers |
+| 1.2 | Enable torpedo homing defaults + tests                    | Complete    | 2026-01-09 | Update projectile config and coverage |
+| 1.3 | Implement PD projectile targeting + turret logic          | Complete    | 2026-01-09 | Add selection helper + turret updates |
+| 1.4 | Update types + turret factory defaults                    | Complete    | 2026-01-09 | Add antiProjectile priority |
+| 1.5 | Add PD-focused turret tests + fallback coverage           | Complete    | 2026-01-09 | Validate selection and fallback |
+
+## Progress Log
+
+### 2026-01-09
+
+- Created design/requirements scaffolding and task tracking.
+- Added steering helpers and tests, enabled torpedo homing defaults, and implemented PD targeting logic with unit coverage.

--- a/memory/tasks/_index.md
+++ b/memory/tasks/_index.md
@@ -4,6 +4,7 @@ This folder contains canonical task documents named using the pattern `TASKNNN-t
 
 ## In Progress
 
+- [TASK161](TASK161-projectile-steering-point-defense.md) — Steering helpers, torpedo homing default, and point-defense projectile targeting. (In Progress — implementation complete; validation pending) (2026-01-09)
 - [TASK119](TASK119-flak-proximity-type-alignment.md) — Align flak proximity Vitest call sites with `FireProjectileOptions` so lint/type/test pipelines pass (design: DESIGN063). (In Progress — implementation underway) (2025-12-10)
 - [TASK156](TASK156-playwright-ship-screenshots.md) — Validate Playwright ship harness, generate representative baselines (fighter/frigate/carrier), and add a CI job to run a representative subset. (In Progress — validate PoC & generate baselines) (2025-12-15)
 - [TASK157](TASK157-offloading-simulation.md) — Offload simulation to a Web Worker (Rapier + ECS + AI), stream ship snapshots, and add worker-driven render debug modes (design: DESIGN065). (In Progress — worker sim + snapshot + render MVP landed; event sync pending) (2025-12-17)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react-dom": "^19.2.3",
         "rimraf": "^6.1.2",
         "three": "^0.182.0",
-        "three-mesh-bvh": "^0.9.4",
+        "three-mesh-bvh": "^0.9.5",
         "three-stdlib": "^2.36.1",
         "zustand": "^5.0.9"
       },
@@ -45,8 +45,8 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.182.0",
-        "@typescript-eslint/eslint-plugin": "^8.51.0",
-        "@typescript-eslint/parser": "^8.51.0",
+        "@typescript-eslint/eslint-plugin": "^8.52.0",
+        "@typescript-eslint/parser": "^8.52.0",
         "@vitejs/plugin-react": "^5.1.2",
         "@vitest/browser": "^4.0.16",
         "@vitest/coverage-v8": "^4.0.16",
@@ -57,21 +57,21 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
         "globals": "^17.0.0",
-        "happy-dom": "^20.0.11",
+        "happy-dom": "^20.1.0",
         "jiti": "^2.6.1",
         "lint-staged": "^16.2.7",
         "pixelmatch": "^7.1.0",
         "playwright": "^1.57.0",
         "pngjs": "^7.0.0",
         "prettier": "^3.7.4",
-        "pyright": "^1.1.407",
+        "pyright": "^1.1.408",
         "react-test-renderer": "^19.2.3",
-        "rollup": "^4.54.0",
+        "rollup": "^4.55.1",
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.51.0",
-        "vite": "^7.3.0",
+        "typescript-eslint": "^8.52.0",
+        "vite": "^7.3.1",
         "vite-plugin-compression": "^0.5.1",
         "vitest": "^4.0.16"
       }
@@ -2124,9 +2124,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2810,9 +2810,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
-      "integrity": "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
+      "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
       "cpu": [
         "arm"
       ],
@@ -2824,9 +2824,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.54.0.tgz",
-      "integrity": "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
+      "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
       "cpu": [
         "arm64"
       ],
@@ -2838,9 +2838,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.54.0.tgz",
-      "integrity": "sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
+      "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
       "cpu": [
         "arm64"
       ],
@@ -2852,9 +2852,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.54.0.tgz",
-      "integrity": "sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
+      "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
       "cpu": [
         "x64"
       ],
@@ -2866,9 +2866,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.54.0.tgz",
-      "integrity": "sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
+      "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
       "cpu": [
         "arm64"
       ],
@@ -2880,9 +2880,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.54.0.tgz",
-      "integrity": "sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
+      "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
       "cpu": [
         "x64"
       ],
@@ -2894,9 +2894,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.54.0.tgz",
-      "integrity": "sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
+      "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
       "cpu": [
         "arm"
       ],
@@ -2908,9 +2908,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.54.0.tgz",
-      "integrity": "sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
+      "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
       "cpu": [
         "arm"
       ],
@@ -2922,9 +2922,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.54.0.tgz",
-      "integrity": "sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
       "cpu": [
         "arm64"
       ],
@@ -2936,9 +2936,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.54.0.tgz",
-      "integrity": "sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
+      "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
       "cpu": [
         "arm64"
       ],
@@ -2950,9 +2950,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.54.0.tgz",
-      "integrity": "sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
+      "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
+      "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
       "cpu": [
         "loong64"
       ],
@@ -2964,9 +2978,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.54.0.tgz",
-      "integrity": "sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
+      "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
+      "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
       "cpu": [
         "ppc64"
       ],
@@ -2978,9 +3006,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.54.0.tgz",
-      "integrity": "sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
+      "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
       "cpu": [
         "riscv64"
       ],
@@ -2992,9 +3020,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.54.0.tgz",
-      "integrity": "sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
+      "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
       "cpu": [
         "riscv64"
       ],
@@ -3006,9 +3034,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.54.0.tgz",
-      "integrity": "sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
+      "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
       "cpu": [
         "s390x"
       ],
@@ -3020,9 +3048,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
       "cpu": [
         "x64"
       ],
@@ -3034,9 +3062,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.54.0.tgz",
-      "integrity": "sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
+      "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
       "cpu": [
         "x64"
       ],
@@ -3047,10 +3075,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
+      "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.54.0.tgz",
-      "integrity": "sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
+      "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
       "cpu": [
         "arm64"
       ],
@@ -3062,9 +3104,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.54.0.tgz",
-      "integrity": "sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
+      "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
       "cpu": [
         "arm64"
       ],
@@ -3076,9 +3118,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.54.0.tgz",
-      "integrity": "sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
+      "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
       "cpu": [
         "ia32"
       ],
@@ -3090,9 +3132,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
       "cpu": [
         "x64"
       ],
@@ -3104,9 +3146,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz",
-      "integrity": "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
+      "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
       "cpu": [
         "x64"
       ],
@@ -3473,21 +3515,31 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.51.0.tgz",
-      "integrity": "sha512-XtssGWJvypyM2ytBnSnKtHYOGT+4ZwTnBVl36TA4nRO2f4PRNGz5/1OszHzcZCvcBMh+qb7I06uoCmLTRdR9og==",
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.51.0",
-        "@typescript-eslint/type-utils": "8.51.0",
-        "@typescript-eslint/utils": "8.51.0",
-        "@typescript-eslint/visitor-keys": "8.51.0",
-        "ignore": "^7.0.0",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.52.0.tgz",
+      "integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.52.0",
+        "@typescript-eslint/type-utils": "8.52.0",
+        "@typescript-eslint/utils": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.2.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3497,23 +3549,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.51.0",
+        "@typescript-eslint/parser": "^8.52.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.51.0.tgz",
-      "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.52.0.tgz",
+      "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.51.0",
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/typescript-estree": "8.51.0",
-        "@typescript-eslint/visitor-keys": "8.51.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.52.0",
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3528,15 +3580,15 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.51.0.tgz",
-      "integrity": "sha512-Luv/GafO07Z7HpiI7qeEW5NW8HUtZI/fo/kE0YbtQEFpJRUuR0ajcWfCE5bnMvL7QQFrmT/odMe8QZww8X2nfQ==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.52.0.tgz",
+      "integrity": "sha512-xD0MfdSdEmeFa3OmVqonHi+Cciab96ls1UhIF/qX/O/gPu5KXD0bY9lu33jj04fjzrXHcuvjBcBC+D3SNSadaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.51.0",
-        "@typescript-eslint/types": "^8.51.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.52.0",
+        "@typescript-eslint/types": "^8.52.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3550,14 +3602,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.51.0.tgz",
-      "integrity": "sha512-JhhJDVwsSx4hiOEQPeajGhCWgBMBwVkxC/Pet53EpBVs7zHHtayKefw1jtPaNRXpI9RA2uocdmpdfE7T+NrizA==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.52.0.tgz",
+      "integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/visitor-keys": "8.51.0"
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3568,9 +3620,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.51.0.tgz",
-      "integrity": "sha512-Qi5bSy/vuHeWyir2C8u/uqGMIlIDu8fuiYWv48ZGlZ/k+PRPHtaAu7erpc7p5bzw2WNNSniuxoMSO4Ar6V9OXw==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.52.0.tgz",
+      "integrity": "sha512-jl+8fzr/SdzdxWJznq5nvoI7qn2tNYV/ZBAEcaFMVXf+K6jmXvAFrgo/+5rxgnL152f//pDEAYAhhBAZGrVfwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3585,17 +3637,17 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.51.0.tgz",
-      "integrity": "sha512-0XVtYzxnobc9K0VU7wRWg1yiUrw4oQzexCG2V2IDxxCxhqBMSMbjB+6o91A+Uc0GWtgjCa3Y8bi7hwI0Tu4n5Q==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.52.0.tgz",
+      "integrity": "sha512-JD3wKBRWglYRQkAtsyGz1AewDu3mTc7NtRjR/ceTyGoPqmdS5oCdx/oZMWD5Zuqmo6/MpsYs0wp6axNt88/2EQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/typescript-estree": "8.51.0",
-        "@typescript-eslint/utils": "8.51.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.2.0"
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0",
+        "@typescript-eslint/utils": "8.52.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3610,9 +3662,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.51.0.tgz",
-      "integrity": "sha512-TizAvWYFM6sSscmEakjY3sPqGwxZRSywSsPEiuZF6d5GmGD9Gvlsv0f6N8FvAAA0CD06l3rIcWNbsN1e5F/9Ag==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.52.0.tgz",
+      "integrity": "sha512-LWQV1V4q9V4cT4H5JCIx3481iIFxH1UkVk+ZkGGAV1ZGcjGI9IoFOfg3O6ywz8QqCDEp7Inlg6kovMofsNRaGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3624,21 +3676,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.51.0.tgz",
-      "integrity": "sha512-1qNjGqFRmlq0VW5iVlcyHBbCjPB7y6SxpBkrbhNWMy/65ZoncXCEPJxkRZL8McrseNH6lFhaxCIaX+vBuFnRng==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.52.0.tgz",
+      "integrity": "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.51.0",
-        "@typescript-eslint/tsconfig-utils": "8.51.0",
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/visitor-keys": "8.51.0",
-        "debug": "^4.3.4",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
+        "@typescript-eslint/project-service": "8.52.0",
+        "@typescript-eslint/tsconfig-utils": "8.52.0",
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.2.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3665,16 +3717,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.51.0.tgz",
-      "integrity": "sha512-11rZYxSe0zabiKaCP2QAwRf/dnmgFgvTmeDTtZvUvXG3UuAdg/GU02NExmmIXzz3vLGgMdtrIosI84jITQOxUA==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.52.0.tgz",
+      "integrity": "sha512-wYndVMWkweqHpEpwPhwqE2lnD2DxC6WVLupU/DOt/0/v+/+iQbbzO3jOHjmBMnhu0DgLULvOaU4h4pwHYi2oRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.51.0",
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/typescript-estree": "8.51.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.52.0",
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3689,13 +3741,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.51.0.tgz",
-      "integrity": "sha512-mM/JRQOzhVN1ykejrvwnBRV3+7yTKK8tVANVN3o1O0t0v7o+jqdVu9crPy5Y9dov15TJk/FTIgoUGHrTOVL3Zg==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.52.0.tgz",
+      "integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/types": "8.52.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -6108,15 +6160,17 @@
       "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/happy-dom": {
-      "version": "20.0.11",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.0.11.tgz",
-      "integrity": "sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.1.0.tgz",
+      "integrity": "sha512-ebvqjBqzenBk2LjzNEAzoj7yhw7rW/R2/wVevMu6Mrq3MXtcI/RUz4+ozpcOcqVLEWPqLfg2v9EAU7fFXZUUJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
-        "whatwg-mimetype": "^3.0.0"
+        "@types/ws": "^8.18.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -8730,9 +8784,9 @@
       }
     },
     "node_modules/pyright": {
-      "version": "1.1.407",
-      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.407.tgz",
-      "integrity": "sha512-zU+peTFEVUdokNQyUBhGQYt+NWI/3aiNlvBbDBSsn5Ti334XElFUs+GDjQzCbchYfkT+DvMAT3OkMcV4CuEfDg==",
+      "version": "1.1.408",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.408.tgz",
+      "integrity": "sha512-N61pxaLLCsPcUuPPHMNIrGoZgGBgrbjBX5UqkaT5UV8NVZdL7ExsO6N3ectv1DzAUsLOzdlyqoYtX76u8eF4YA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9261,9 +9315,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
-      "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
+      "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9277,28 +9331,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.54.0",
-        "@rollup/rollup-android-arm64": "4.54.0",
-        "@rollup/rollup-darwin-arm64": "4.54.0",
-        "@rollup/rollup-darwin-x64": "4.54.0",
-        "@rollup/rollup-freebsd-arm64": "4.54.0",
-        "@rollup/rollup-freebsd-x64": "4.54.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.54.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.54.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.54.0",
-        "@rollup/rollup-linux-arm64-musl": "4.54.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.54.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.54.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-musl": "4.54.0",
-        "@rollup/rollup-openharmony-arm64": "4.54.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.54.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.54.0",
-        "@rollup/rollup-win32-x64-gnu": "4.54.0",
-        "@rollup/rollup-win32-x64-msvc": "4.54.0",
+        "@rollup/rollup-android-arm-eabi": "4.55.1",
+        "@rollup/rollup-android-arm64": "4.55.1",
+        "@rollup/rollup-darwin-arm64": "4.55.1",
+        "@rollup/rollup-darwin-x64": "4.55.1",
+        "@rollup/rollup-freebsd-arm64": "4.55.1",
+        "@rollup/rollup-freebsd-x64": "4.55.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.55.1",
+        "@rollup/rollup-linux-arm64-musl": "4.55.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.55.1",
+        "@rollup/rollup-linux-loong64-musl": "4.55.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.55.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.55.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-musl": "4.55.1",
+        "@rollup/rollup-openbsd-x64": "4.55.1",
+        "@rollup/rollup-openharmony-arm64": "4.55.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.55.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.55.1",
+        "@rollup/rollup-win32-x64-gnu": "4.55.1",
+        "@rollup/rollup-win32-x64-msvc": "4.55.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -9941,9 +9998,9 @@
       "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.9.4.tgz",
-      "integrity": "sha512-+y6xLS6k5LWkNNhYsTgKXBC2D9r/z0swiehVHYhZZ8AOhaKDRCWKsN94ctV5Xy7xA4Xbnv4LKYzf7epRLPT6oQ==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.9.5.tgz",
+      "integrity": "sha512-MYpwzUWDxPAKGhSBFin9E/7K4AAHyIm4IfMZQ/3+Z/jq/swa2dAhXx0yUNDd9mjlhLuzXkMBTGDZioL2GSlIfQ==",
       "license": "MIT",
       "peerDependencies": {
         "three": ">= 0.159.0"
@@ -10101,9 +10158,9 @@
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.3.0.tgz",
-      "integrity": "sha512-6eg3Y9SF7SsAvGzRHQvvc1skDAhwI4YQ32ui1scxD1Ccr0G5qIIbUBT3pFTKX8kmWIQClHobtUdNuaBgwdfdWg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10361,16 +10418,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.51.0.tgz",
-      "integrity": "sha512-jh8ZuM5oEh2PSdyQG9YAEM1TCGuWenLSuSUhf/irbVUNW9O5FhbFVONviN2TgMTBnUmyHv7E56rYnfLZK6TkiA==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.52.0.tgz",
+      "integrity": "sha512-atlQQJ2YkO4pfTVQmQ+wvYQwexPDOIgo+RaVcD7gHgzy/IQA+XTyuxNM9M9TVXvttkF7koBHmcwisKdOAf2EcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.51.0",
-        "@typescript-eslint/parser": "8.51.0",
-        "@typescript-eslint/typescript-estree": "8.51.0",
-        "@typescript-eslint/utils": "8.51.0"
+        "@typescript-eslint/eslint-plugin": "8.52.0",
+        "@typescript-eslint/parser": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0",
+        "@typescript-eslint/utils": "8.52.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10605,9 +10662,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
-      "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/config/projectiles.ts
+++ b/src/config/projectiles.ts
@@ -87,6 +87,7 @@ export const PROJECTILE_CONFIG: Record<string, ProjectileConfigItem> = {
     colliderRadius: 0.7,
     baseGeometryRadius: 0.5,
     visualMultiplier: 1.15,
+    homing: { turnRate: Math.PI / 3, lead: true },
     armingTime: 0.8,
     aoeRadius: 12,
   },

--- a/src/data/ships/turret-factory.ts
+++ b/src/data/ships/turret-factory.ts
@@ -55,7 +55,7 @@ export function createPointDefenseTurret(
     maxYaw: Math.PI * 0.85,
     minPitch: -Math.PI * 0.35,
     maxPitch: Math.PI * 0.55,
-    priority: 'antiFighter',
+    priority: 'antiProjectile',
     ...options,
   };
 }

--- a/src/game/ships.ts
+++ b/src/game/ships.ts
@@ -80,6 +80,8 @@ export function spawnShip(state: GameState, blueprint: ShipBlueprint): ShipEntit
       projectileSpeed: t.projectileSpeed,
       range: applyRangeVariance(t.range, aiState.traitSeed, idx + 1),
       bulletType: t.bulletType,
+      projectileCategory: t.projectileCategory,
+      priority: t.priority ?? 'any',
       cooldown: t.fireRate * state.rng.next(),
     })),
     ai: aiState,

--- a/src/game/systems/projectiles/homing.ts
+++ b/src/game/systems/projectiles/homing.ts
@@ -2,7 +2,8 @@ import type { GameState, ProjectileEntity, ShipEntity } from '../../../types/ind
 import type { ProjectileHomingConfig } from '../../../types/combat.js';
 import {
   FORWARD,
-  computeLeadDirection,
+  computeInterceptDirection,
+  computeSeekDirection,
   orientQuaternionFromDirection,
   steerDirection,
 } from '../../../utils/steering.js';
@@ -47,13 +48,19 @@ export function steerProjectileTowardTarget(
     return;
   }
 
-  const desired = computeLeadDirection(
-    target.transform.position,
-    projectile.transform.position,
-    target.ship.velocity,
-    homing.lead ? 0.5 : 0,
-    TEMP_TARGET,
-  );
+  const desired = homing.lead
+    ? computeInterceptDirection(
+        target.transform.position,
+        projectile.transform.position,
+        target.ship.velocity,
+        projectile.projectile.speed,
+        TEMP_TARGET,
+      )
+    : computeSeekDirection(
+        target.transform.position,
+        projectile.transform.position,
+        TEMP_TARGET,
+      );
 
   const angle = steerDirection(currentDir, desired, homing.turnRate, delta, currentDir);
   if (angle < 1e-5) {

--- a/src/game/systems/turrets.ts
+++ b/src/game/systems/turrets.ts
@@ -1,10 +1,17 @@
 import { Quaternion, Vector3 } from 'three';
-import type { GameState, ShipEntity, TurretEntity, TurretState } from '../../types/index.js';
+import type {
+  GameState,
+  ProjectileEntity,
+  ShipEntity,
+  TurretEntity,
+  TurretState,
+} from '../../types/index.js';
 import { recordShotHelper } from '../metrics.js';
 import { fireProjectile, TEMP_POS } from './projectiles.js';
+import { destroyEntity } from '../state.js';
 import type { KinematicBody } from '../physics/safeKinematics.js';
 import { deferSetNextKinematicTranslation } from '../physics/safeKinematics.js';
-import { findNearestEnemy } from '../utils/targetSelection.js';
+import { findNearestEnemy, findPointDefenseTarget } from '../utils/targetSelection.js';
 
 const TEMP_TURRET_DIR = new Vector3();
 const TEMP_QUAT = new Quaternion();
@@ -31,12 +38,24 @@ export function runEmbeddedTurrets(state: GameState, ship: ShipEntity, target: S
   for (const turret of ship.turrets ?? []) {
     if (turret.cooldown > 0) continue;
     const turretOrigin = getTurretWorldPosition(ship, turret);
-    const toTarget = TEMP_TURRET_DIR.copy(target.transform.position).sub(turretOrigin);
+    const projectileTarget =
+      turret.priority === 'antiProjectile'
+        ? findPointDefenseTarget(state, {
+            origin: turretOrigin,
+            team: ship.ship.team,
+            maxRange: turret.range,
+            preferTargetId: ship.id,
+          })
+        : null;
+    const targetPos = projectileTarget
+      ? projectileTarget.transform.position
+      : target.transform.position;
+    const toTarget = TEMP_TURRET_DIR.copy(targetPos).sub(turretOrigin);
     const dist = toTarget.length();
     if (dist > turret.range) continue;
     if (dist > 1e-5) toTarget.divideScalar(dist);
     else toTarget.set(0, 0, 1);
-    recordShotHelper(state, ship, target, dist);
+    recordShotHelper(state, ship, projectileTarget ? null : target, dist);
     fireProjectile(state, ship, toTarget, {
       originPosition: turretOrigin,
       override: {
@@ -44,11 +63,14 @@ export function runEmbeddedTurrets(state: GameState, ship: ShipEntity, target: S
         projectileSpeed: turret.projectileSpeed,
         range: turret.range,
         bulletType: turret.bulletType,
-        targetId: target.id,
+        targetId: projectileTarget ? undefined : target.id,
         projectileCategory: turret.projectileCategory,
       },
-      targetId: target.id,
+      targetId: projectileTarget ? undefined : target.id,
     });
+    if (projectileTarget) {
+      destroyEntity(state, projectileTarget);
+    }
     turret.cooldown = turret.fireRate;
   }
 }
@@ -76,7 +98,17 @@ export function updateTurrets(state: GameState, delta: number): void {
     if (t.turret.cooldown > 0) continue;
 
     let target: ShipEntity | null = null;
-    if (t.turret.priority && t.turret.priority !== 'any') {
+    let projectileTarget: ProjectileEntity | null = null;
+    if (t.turret.priority === 'antiProjectile') {
+      projectileTarget = findPointDefenseTarget(state, {
+        origin,
+        team: ship.ship.team,
+        maxRange: t.turret.range,
+        preferTargetId: ship.id,
+      });
+    }
+
+    if (!projectileTarget && t.turret.priority && t.turret.priority !== 'any') {
       const ships = state.queries.ships.entities as ShipEntity[];
       const preferSmall = t.turret.priority === 'antiFighter';
       let bestScore = Number.POSITIVE_INFINITY;
@@ -108,11 +140,14 @@ export function updateTurrets(state: GameState, delta: number): void {
       target = best;
     }
 
-    if (!target) {
+    if (!projectileTarget && !target) {
       target = findNearestEnemy(state, ship);
     }
-    if (!target) continue;
-    const toTarget = TEMP_TURRET_DIR.copy(target.transform.position).sub(origin);
+    if (!projectileTarget && !target) continue;
+    const targetPos = projectileTarget
+      ? projectileTarget.transform.position
+      : target!.transform.position;
+    const toTarget = TEMP_TURRET_DIR.copy(targetPos).sub(origin);
     const dist = toTarget.length();
     if (dist > t.turret.range) continue;
     if (dist > 1e-5) toTarget.divideScalar(dist);
@@ -126,7 +161,7 @@ export function updateTurrets(state: GameState, delta: number): void {
     const minPitch = t.turret.minPitch ?? -Math.PI / 2;
     const maxPitch = t.turret.maxPitch ?? Math.PI / 2;
     if (yaw < minYaw || yaw > maxYaw || pitch < minPitch || pitch > maxPitch) continue;
-    recordShotHelper(state, ship, target, dist);
+    recordShotHelper(state, ship, projectileTarget ? null : target, dist);
     fireProjectile(state, ship, toTarget, {
       originPosition: origin,
       override: {
@@ -134,11 +169,14 @@ export function updateTurrets(state: GameState, delta: number): void {
         projectileSpeed: t.turret.projectileSpeed,
         range: t.turret.range,
         bulletType: t.turret.bulletType,
-        targetId: target.id,
+        targetId: projectileTarget ? undefined : target!.id,
         projectileCategory: t.turret.projectileCategory,
       },
-      targetId: target.id,
+      targetId: projectileTarget ? undefined : target!.id,
     });
+    if (projectileTarget) {
+      destroyEntity(state, projectileTarget);
+    }
     t.turret.cooldown = t.turret.fireRate;
   }
 }

--- a/src/game/utils/targetSelection.ts
+++ b/src/game/utils/targetSelection.ts
@@ -1,4 +1,11 @@
-import type { GameState, ShipEntity } from '../../types/index.js';
+import type { Vector3 } from 'three';
+import type {
+  GameState,
+  ProjectileEntity,
+  ShipEntity,
+  Team,
+} from '../../types/index.js';
+import type { ProjectileCategory } from '../../types/combat.js';
 
 /**
  * Finds the nearest enemy ship to a given origin ship.
@@ -23,4 +30,60 @@ export function findNearestEnemy(state: GameState, origin: ShipEntity): ShipEnti
   }
 
   return closest;
+}
+
+export interface PointDefenseTargetOptions {
+  origin: Vector3;
+  team: Team;
+  maxRange: number;
+  preferTargetId?: number;
+  categories?: ProjectileCategory[];
+}
+
+const DEFAULT_PD_CATEGORIES: ProjectileCategory[] = ['missile', 'torpedo'];
+
+/**
+ * Finds the nearest hostile projectile for point-defense targeting.
+ *
+ * @param {GameState} state - The game state.
+ * @param {PointDefenseTargetOptions} options - Targeting options.
+ * @returns {ProjectileEntity | null} The selected projectile target.
+ */
+export function findPointDefenseTarget(
+  state: GameState,
+  options: PointDefenseTargetOptions,
+): ProjectileEntity | null {
+  const projectiles = state.queries.projectiles.entities as ProjectileEntity[];
+  const maxRangeSq = Math.max(0, options.maxRange) ** 2;
+  const categories = options.categories ?? DEFAULT_PD_CATEGORIES;
+  let best: ProjectileEntity | null = null;
+  let bestSq = Number.POSITIVE_INFINITY;
+  let bestIncoming: ProjectileEntity | null = null;
+  let bestIncomingSq = Number.POSITIVE_INFINITY;
+
+  for (const projectile of projectiles) {
+    if (projectile.projectile.team === options.team) continue;
+    const category = projectile.projectile.category ?? 'bullet';
+    const isThreat =
+      projectile.projectile.homing || categories.includes(category);
+    if (!isThreat) continue;
+
+    const distanceSq = options.origin.distanceToSquared(projectile.transform.position);
+    if (distanceSq > maxRangeSq) continue;
+
+    if (options.preferTargetId != null && projectile.projectile.targetId === options.preferTargetId) {
+      if (distanceSq < bestIncomingSq) {
+        bestIncomingSq = distanceSq;
+        bestIncoming = projectile;
+      }
+      continue;
+    }
+
+    if (distanceSq < bestSq) {
+      bestSq = distanceSq;
+      best = projectile;
+    }
+  }
+
+  return bestIncoming ?? best;
 }

--- a/src/types/combat.ts
+++ b/src/types/combat.ts
@@ -117,7 +117,7 @@ export interface TurretSpec {
   /** Optional upper pitch limit in radians relative to parent forward. */
   maxPitch?: number;
   /** Optional targeting priority for turret AI. */
-  priority?: 'any' | 'antiFighter' | 'antiCapital';
+  priority?: 'any' | 'antiFighter' | 'antiCapital' | 'antiProjectile';
   /** Optional canonical projectile category override for behaviour hints. */
   projectileCategory?: ProjectileCategory;
 }
@@ -149,7 +149,7 @@ export interface TurretComponent extends TurretSpec {
   /** Upper pitch limit in radians. */
   maxPitch?: number;
   /** Targeting priority for turret AI. */
-  priority?: 'any' | 'antiFighter' | 'antiCapital';
+  priority?: 'any' | 'antiFighter' | 'antiCapital' | 'antiProjectile';
 }
 
 /** Parameters for a short-lived muzzle flash event emitted when a weapon fires. */

--- a/src/utils/steering.ts
+++ b/src/utils/steering.ts
@@ -6,6 +6,9 @@ export const FORWARD = new Vector3(0, 0, 1);
 const DEFAULT_FALLBACK = new Vector3(0, 0, 1);
 const TEMP_DIR = new Vector3();
 const TEMP_LEAD = new Vector3();
+const TEMP_SEEK = new Vector3();
+const TEMP_INTERCEPT = new Vector3();
+const TEMP_INTERCEPT_TARGET = new Vector3();
 
 /**
  * Normalizes a vector safely, handling zero-length vectors by falling back to a default.
@@ -82,6 +85,145 @@ export function computeLeadDirection(
   }
 
   return out;
+}
+
+/**
+ * Computes a direction that seeks a target position.
+ *
+ * @param {Vector3} targetPos - The target position.
+ * @param {Vector3} sourcePos - The current position.
+ * @param {Vector3} [out=new Vector3()] - The vector to store the result.
+ * @param {Vector3} [fallback=FORWARD] - Fallback direction if target is co-located.
+ * @returns {Vector3} The normalized seek direction.
+ */
+export function computeSeekDirection(
+  targetPos: Vector3,
+  sourcePos: Vector3,
+  out: Vector3 = new Vector3(),
+  fallback: Vector3 = FORWARD,
+): Vector3 {
+  TEMP_SEEK.copy(targetPos).sub(sourcePos);
+  return safeNormalize(out, TEMP_SEEK, fallback);
+}
+
+/**
+ * Computes an arrival direction and speed scale based on distance thresholds.
+ *
+ * @param {Vector3} targetPos - The target position.
+ * @param {Vector3} sourcePos - The current position.
+ * @param {number} slowRadius - Distance at which to start slowing.
+ * @param {number} [stopRadius=0] - Distance at which to stop.
+ * @param {Vector3} [out=new Vector3()] - The vector to store the direction.
+ * @param {Vector3} [fallback=FORWARD] - Fallback direction if target is co-located.
+ * @returns {{ direction: Vector3; speedScale: number; distance: number }} Result object.
+ */
+export function computeArriveDirection(
+  targetPos: Vector3,
+  sourcePos: Vector3,
+  slowRadius: number,
+  stopRadius = 0,
+  out: Vector3 = new Vector3(),
+  fallback: Vector3 = FORWARD,
+): { direction: Vector3; speedScale: number; distance: number } {
+  TEMP_SEEK.copy(targetPos).sub(sourcePos);
+  const distance = TEMP_SEEK.length();
+  const slow = Math.max(0, slowRadius);
+  const stop = Math.max(0, stopRadius);
+  let speedScale = 1;
+
+  if (!Number.isFinite(distance) || distance <= stop) {
+    speedScale = 0;
+  } else if (slow > stop && distance < slow) {
+    speedScale = (distance - stop) / (slow - stop);
+  }
+
+  safeNormalize(out, TEMP_SEEK, fallback);
+  return { direction: out, speedScale, distance };
+}
+
+/**
+ * Computes an intercept direction for a moving target given source speed.
+ *
+ * @param {Vector3} targetPos - The target position.
+ * @param {Vector3} sourcePos - The current position.
+ * @param {Vector3} targetVelocity - The target velocity vector.
+ * @param {number} sourceSpeed - The source speed.
+ * @param {Vector3} [out=new Vector3()] - The vector to store the result.
+ * @param {Vector3} [fallback=FORWARD] - Fallback direction if intercept fails.
+ * @returns {Vector3} The normalized intercept direction.
+ */
+export function computeInterceptDirection(
+  targetPos: Vector3,
+  sourcePos: Vector3,
+  targetVelocity: Vector3,
+  sourceSpeed: number,
+  out: Vector3 = new Vector3(),
+  fallback: Vector3 = FORWARD,
+): Vector3 {
+  TEMP_INTERCEPT.copy(targetPos).sub(sourcePos);
+  const speed = Math.max(0, sourceSpeed);
+  if (speed <= 1e-6) {
+    return safeNormalize(out, TEMP_INTERCEPT, fallback);
+  }
+
+  const a = targetVelocity.lengthSq() - speed * speed;
+  const b = 2 * TEMP_INTERCEPT.dot(targetVelocity);
+  const c = TEMP_INTERCEPT.lengthSq();
+  let t = 0;
+
+  if (Math.abs(a) < 1e-6) {
+    if (Math.abs(b) > 1e-6) {
+      t = -c / b;
+    }
+  } else {
+    const discriminant = b * b - 4 * a * c;
+    if (discriminant >= 0) {
+      const sqrt = Math.sqrt(discriminant);
+      const t1 = (-b - sqrt) / (2 * a);
+      const t2 = (-b + sqrt) / (2 * a);
+      t = Math.min(t1, t2);
+      if (t < 0) t = Math.max(t1, t2);
+    }
+  }
+
+  if (!Number.isFinite(t) || t <= 0) {
+    return safeNormalize(out, TEMP_INTERCEPT, fallback);
+  }
+
+  TEMP_INTERCEPT_TARGET.copy(targetPos).addScaledVector(targetVelocity, t);
+  TEMP_INTERCEPT_TARGET.sub(sourcePos);
+  return safeNormalize(out, TEMP_INTERCEPT_TARGET, fallback);
+}
+
+/**
+ * Computes an evasion direction away from an intercept path.
+ *
+ * @param {Vector3} threatPos - The threat position.
+ * @param {Vector3} sourcePos - The current position.
+ * @param {Vector3} threatVelocity - The threat velocity vector.
+ * @param {number} sourceSpeed - The source speed.
+ * @param {Vector3} [out=new Vector3()] - The vector to store the result.
+ * @param {Vector3} [fallback=FORWARD] - Fallback direction if evasion fails.
+ * @returns {Vector3} The normalized evasion direction.
+ */
+export function computeEvadeDirection(
+  threatPos: Vector3,
+  sourcePos: Vector3,
+  threatVelocity: Vector3,
+  sourceSpeed: number,
+  out: Vector3 = new Vector3(),
+  fallback: Vector3 = FORWARD,
+): Vector3 {
+  computeInterceptDirection(
+    threatPos,
+    sourcePos,
+    threatVelocity,
+    sourceSpeed,
+    out,
+    fallback,
+  );
+  out.multiplyScalar(-1);
+  return safeNormalize(out, out, fallback);
 }
 
 /**

--- a/test/vitest/projectile-extended.spec.ts
+++ b/test/vitest/projectile-extended.spec.ts
@@ -349,4 +349,19 @@ describe('extended projectile behaviours', () => {
     expect(target.ship.hp).toBeLessThan(initialHpPrimary);
     expect(secondaryTarget.ship.hp).toBeLessThan(initialHpSecondary);
   });
+
+  it('spawns torpedoes with default homing configuration', () => {
+    attacker.ship.bulletType = 'torpedo:standard';
+    attacker.ship.projectileSpeed = 55;
+
+    fireProjectile(state, attacker, new Vector3(0, 0, 1), {
+      originPosition: attacker.transform.position.clone(),
+      targetId: target.id,
+    });
+
+    flushPostPhysicsMutations(state);
+    const spawned = (state.queries.projectiles.entities as ProjectileEntity[])[0];
+    expect(spawned.projectile.homing).toBeDefined();
+    expect(spawned.projectile.homing?.turnRate).toBeCloseTo(Math.PI / 3, 5);
+  });
 });

--- a/test/vitest/steering-utils.spec.ts
+++ b/test/vitest/steering-utils.spec.ts
@@ -4,6 +4,10 @@ import {
   FORWARD,
   clampAngle,
   computeLeadDirection,
+  computeSeekDirection,
+  computeArriveDirection,
+  computeInterceptDirection,
+  computeEvadeDirection,
   orientQuaternionFromDirection,
   safeNormalize,
   steerDirection,
@@ -47,6 +51,44 @@ describe('steering utilities', () => {
 
     const noLead = computeLeadDirection(targetPos, sourcePos, velocity, 0);
     expect(noLead.y).toBeCloseTo(0, 6);
+  });
+
+  it('computes seek and arrive directions safely', () => {
+    const seekDir = computeSeekDirection(
+      new Vector3(10, 0, 0),
+      new Vector3(0, 0, 0),
+    );
+    expect(seekDir.length()).toBeCloseTo(1, 6);
+    expect(seekDir.x).toBeGreaterThan(0.9);
+
+    const arrive = computeArriveDirection(
+      new Vector3(0, 0, 0),
+      new Vector3(0, 0, 0),
+      5,
+      1,
+    );
+    expect(arrive.speedScale).toBe(0);
+    expect(arrive.direction.length()).toBeCloseTo(1, 6);
+  });
+
+  it('computes intercept and evade directions', () => {
+    const intercept = computeInterceptDirection(
+      new Vector3(10, 0, 0),
+      new Vector3(0, 0, 0),
+      new Vector3(0, 2, 0),
+      6,
+    );
+    expect(intercept.length()).toBeCloseTo(1, 6);
+    expect(intercept.y).toBeGreaterThan(0.1);
+
+    const evade = computeEvadeDirection(
+      new Vector3(10, 0, 0),
+      new Vector3(0, 0, 0),
+      new Vector3(0, 0, 0),
+      4,
+    );
+    expect(evade.length()).toBeCloseTo(1, 6);
+    expect(evade.x).toBeLessThan(0);
   });
 
   it('steers direction respecting turn limits', () => {

--- a/test/vitest/turret-point-defense.spec.ts
+++ b/test/vitest/turret-point-defense.spec.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from 'vitest';
+import { Quaternion, Vector3 } from 'three';
+import { updateTurrets } from '../../src/game/systems/turrets.js';
+import { createDefaultMotionStats } from '../../src/game/ships.js';
+import { createProgressionDefaults } from '../../src/game/progression.js';
+import type { GameState, ProjectileEntity, ShipEntity, TurretEntity } from '../../src/types/index.js';
+
+function makeRigidBodyStub(init?: {
+  pos?: { x: number; y: number; z: number };
+  rot?: { x: number; y: number; z: number; w: number };
+}) {
+  let pos = init?.pos ?? { x: 0, y: 0, z: 0 };
+  let rot = init?.rot ?? { x: 0, y: 0, z: 0, w: 1 };
+  return {
+    translation() {
+      return pos;
+    },
+    rotation() {
+      return rot;
+    },
+    setNextKinematicTranslation(p: { x: number; y: number; z: number }) {
+      pos = { ...p };
+    },
+    setNextKinematicRotation(r: { x: number; y: number; z: number; w: number }) {
+      rot = { ...r };
+    },
+    isValid() {
+      return true;
+    },
+  } as any;
+}
+
+function makeStateStub(): GameState {
+  const entities: any[] = [];
+  const queries = {
+    ships: { entities: [] as any[] },
+    turrets: { entities: [] as any[] },
+    projectiles: { entities: [] as any[] },
+  } as any;
+  const shipById = new Map<number, ShipEntity>();
+
+  const rapierStub = {
+    RigidBodyDesc: {
+      kinematicPositionBased: () => {
+        const d: any = { _pos: { x: 0, y: 0, z: 0 }, _rot: { x: 0, y: 0, z: 0, w: 1 } };
+        d.setTranslation = function (x: number, y: number, z: number) {
+          this._pos = { x, y, z };
+          return this;
+        };
+        d.setRotation = function (r: { x: number; y: number; z: number; w: number }) {
+          this._rot = r;
+          return this;
+        };
+        return d;
+      },
+    },
+    ColliderDesc: {
+      ball: () => ({
+        setActiveEvents() {
+          return this;
+        },
+        setActiveCollisionTypes() {
+          return this;
+        },
+      }),
+      capsule: () => ({
+        setActiveEvents() {
+          return this;
+        },
+        setActiveCollisionTypes() {
+          return this;
+        },
+      }),
+    },
+    ActiveEvents: { COLLISION_EVENTS: 1 },
+    ActiveCollisionTypes: { ALL: 1 },
+  } as any;
+
+  return {
+    rapier: rapierStub,
+    physicsWorld: {
+      createRigidBody: (desc?: any) =>
+        makeRigidBodyStub(desc ? { pos: desc._pos, rot: desc._rot } : undefined),
+      createCollider: () => ({ handle: Math.floor(Math.random() * 10000), isValid: () => true }),
+      removeCollider() {},
+      removeRigidBody() {},
+    },
+    eventQueue: {} as any,
+    world: {
+      add: (e: any) => {
+        entities.push(e);
+        if (e.ship) queries.ships.entities.push(e);
+        if (e.turret) queries.turrets.entities.push(e);
+        if (e.projectile) queries.projectiles.entities.push(e);
+        return e;
+      },
+      remove: (e: any) => {
+        const index = entities.indexOf(e);
+        if (index >= 0) entities.splice(index, 1);
+        const shipIndex = queries.ships.entities.indexOf(e);
+        if (shipIndex >= 0) queries.ships.entities.splice(shipIndex, 1);
+        const turretIndex = queries.turrets.entities.indexOf(e);
+        if (turretIndex >= 0) queries.turrets.entities.splice(turretIndex, 1);
+        const projIndex = queries.projectiles.entities.indexOf(e);
+        if (projIndex >= 0) queries.projectiles.entities.splice(projIndex, 1);
+      },
+    } as any,
+    colliderLookup: new Map(),
+    shipById,
+    nextEntityId: 1,
+    time: 0,
+    queries,
+    rng: { next: () => 0.5 } as any,
+    paused: false,
+    timeScale: 1,
+    explosions: [],
+    explosionPool: [],
+    progressionEvents: new Map(),
+    uiFlags: { hudHealthBars: false },
+    ai: {
+      metrics: undefined,
+    } as any,
+    simulation: {
+      deferredMutations: [] as any[],
+      postStepMutations: [] as any[],
+      rapierDiagnostics: {} as any,
+      subsystemTimings: {
+        durations: {},
+        lastTickIndex: -1,
+        lastTickTime: 0,
+      },
+    } as any,
+  } as unknown as GameState;
+}
+
+function createShip(
+  state: GameState,
+  id: number,
+  team: 'blue' | 'red',
+  hull: 'fighter' | 'frigate',
+  pos: Vector3,
+): ShipEntity {
+  const rb = makeRigidBodyStub({ pos: { x: pos.x, y: pos.y, z: pos.z } });
+  const progression = createProgressionDefaults(hull);
+  const ship: ShipEntity = {
+    id,
+    rigidBody: rb,
+    collider: { handle: id, isValid: () => true } as any,
+    transform: { position: pos.clone(), rotation: new Quaternion(), scale: 1 },
+    ship: {
+      team,
+      hull,
+      hp: 100,
+      maxHp: 100,
+      shield: 0,
+      maxShield: 0,
+      cooldown: 0,
+      fireRate: 1,
+      damage: 10,
+      projectileSpeed: 100,
+      range: 1000,
+      speed: 0,
+      bulletType: 'bullet:heavy',
+      velocity: new Vector3(),
+      angularVelocity: new Vector3(),
+      lateralAcceleration: 0,
+      motion: createDefaultMotionStats(),
+      ...progression,
+    },
+    model: hull,
+    shieldRipples: [],
+    turrets: [],
+  } as unknown as ShipEntity;
+
+  (state.queries.ships as any).entities.push(ship);
+  state.shipById.set(id, ship);
+  return ship;
+}
+
+function createTurretEntity(
+  state: GameState,
+  parent: ShipEntity,
+  priority: 'antiProjectile' | 'antiFighter' | 'antiCapital' | 'any',
+): TurretEntity {
+  const rb = makeRigidBodyStub({
+    pos: {
+      x: parent.transform.position.x,
+      y: parent.transform.position.y,
+      z: parent.transform.position.z,
+    },
+  });
+  const turretEntity: TurretEntity = {
+    id: state.nextEntityId++,
+    rigidBody: rb,
+    collider: { handle: Math.floor(Math.random() * 10000), isValid: () => true } as any,
+    transform: {
+      position: parent.transform.position.clone(),
+      rotation: new Quaternion(),
+      scale: 1,
+    },
+    turret: {
+      parent,
+      offset: new Vector3(0, 0, 0),
+      damage: 10,
+      fireRate: 1,
+      projectileSpeed: 100,
+      range: 1000,
+      bulletType: 'bullet:laser',
+      cooldown: 0,
+      index: 0,
+      yaw: 0,
+      pitch: 0,
+      minYaw: -Math.PI,
+      maxYaw: Math.PI,
+      minPitch: -Math.PI,
+      maxPitch: Math.PI,
+      priority,
+    },
+  } as unknown as TurretEntity;
+
+  (state.queries.turrets as any).entities.push(turretEntity);
+  return turretEntity;
+}
+
+function createProjectile(
+  state: GameState,
+  id: number,
+  team: 'blue' | 'red',
+  pos: Vector3,
+  targetId?: number,
+): ProjectileEntity {
+  const projectile: ProjectileEntity = {
+    id,
+    rigidBody: {
+      setNextKinematicTranslation: () => {},
+      setNextKinematicRotation: () => {},
+      isValid: () => true,
+    } as any,
+    collider: { handle: id + 1000, isValid: () => true } as any,
+    transform: {
+      position: pos.clone(),
+      rotation: new Quaternion(),
+      scale: 1,
+    },
+    projectile: {
+      team,
+      damage: 10,
+      ttl: 5,
+      maxTtl: 5,
+      speed: 20,
+      bulletType: 'missile:light',
+      damageType: 'kinetic',
+      category: 'missile',
+      targetId,
+      homing: { turnRate: Math.PI / 2, lead: true },
+    },
+    direction: new Vector3(0, 0, 1),
+  };
+  (state.queries.projectiles as any).entities.push(projectile);
+  return projectile;
+}
+
+describe('point defense turret targeting', () => {
+  it('prioritizes hostile projectiles when antiProjectile is set', () => {
+    const state = makeStateStub();
+    const blueShip = createShip(state, 1, 'blue', 'frigate', new Vector3(0, 0, 0));
+    createTurretEntity(state, blueShip, 'antiProjectile');
+    createShip(state, 2, 'red', 'fighter', new Vector3(200, 0, 0));
+
+    const projectile = createProjectile(state, 999, 'red', new Vector3(30, 0, 0), blueShip.id);
+
+    updateTurrets(state, 0.016);
+    const projectiles = state.queries.projectiles.entities as ProjectileEntity[];
+    expect(projectiles).not.toContain(projectile);
+  });
+
+  it('falls back to ship targeting when no projectile exists', () => {
+    const state = makeStateStub();
+    const blueShip = createShip(state, 1, 'blue', 'frigate', new Vector3(0, 0, 0));
+    createTurretEntity(state, blueShip, 'antiProjectile');
+    const redShip = createShip(state, 2, 'red', 'fighter', new Vector3(200, 0, 0));
+
+    updateTurrets(state, 0.016);
+
+    for (const mutation of state.simulation.postStepMutations) {
+      mutation();
+    }
+
+    const projectiles = state.queries.projectiles.entities as ProjectileEntity[];
+    expect(projectiles.length).toBe(1);
+    expect(projectiles[0].projectile.targetId).toBe(redShip.id);
+  });
+});


### PR DESCRIPTION
- Added steering helper functions for seek, arrive, intercept, and evade in `src/utils/steering.ts`.
- Enabled default homing configuration for `torpedo:standard` in `src/config/projectiles.ts`.
- Introduced point defense targeting logic in turrets, allowing them to prioritize hostile projectiles and fallback to ship targeting.
- Updated turret targeting logic to support `priority: 'antiProjectile'`.
- Created new design document `DESIGN066` outlining the changes and requirements.
- Created task `TASK161` to track progress on the implementation.
- Added unit tests for new steering functions and turret point defense behavior.