### PR TITLE
Update dependencies: happy-dom and three-mesh-bvh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react-dom": "^19.2.3",
         "rimraf": "^6.1.2",
         "three": "^0.182.0",
-        "three-mesh-bvh": "^0.9.6",
+        "three-mesh-bvh": "^0.9.7",
         "three-stdlib": "^2.36.1",
         "zustand": "^5.0.10"
       },
@@ -57,7 +57,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
         "globals": "^17.0.0",
-        "happy-dom": "^20.3.0",
+        "happy-dom": "^20.3.1",
         "jiti": "^2.6.1",
         "lint-staged": "^16.2.7",
         "pixelmatch": "^7.1.0",
@@ -3400,7 +3400,6 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4800,7 +4799,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -6097,9 +6095,9 @@
       "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/happy-dom": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.3.0.tgz",
-      "integrity": "sha512-5qJbkqcvR8j/a4av5IWqqIWmEGf9dt6OhGMS6qxCgjSOBGzGa5XLoqg40OyD8XNzQ+g1g2zsXi10kjfpzYH55Q==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.3.1.tgz",
+      "integrity": "sha512-tLvsizNno05Hij0PoB0QN/S8xf0YU2AGvO11/JlJDw5McA/gzyn0Ni1RwbTI1/zteUbOekJH0t6q8HFvjbxsGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10013,9 +10011,9 @@
       "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.9.6.tgz",
-      "integrity": "sha512-XdOw/SOQ/SNhY1qIv6CPCrzwBCkfJZoOQKOTNY9iywEzAQBj17aOZWxbBO1VBn4F58OfTl949+8vzQY0Tmu1ew==",
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.9.7.tgz",
+      "integrity": "sha512-EYSJbykeAjhVxwZjuUYq/kelIbqBoV9sbAgvZ+j1xCgZyNYSkr51WDJWS4WIfK2OX6YcjBGoTicX4RoOVQzx0g==",
       "license": "MIT",
       "peerDependencies": {
         "three": ">= 0.159.0"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
     "globals": "^17.0.0",
-    "happy-dom": "^20.3.0",
+    "happy-dom": "^20.3.1",
     "jiti": "^2.6.1",
     "lint-staged": "^16.2.7",
     "pixelmatch": "^7.1.0",
@@ -104,7 +104,7 @@
     "react-dom": "^19.2.3",
     "rimraf": "^6.1.2",
     "three": "^0.182.0",
-    "three-mesh-bvh": "^0.9.6",
+    "three-mesh-bvh": "^0.9.7",
     "three-stdlib": "^2.36.1",
     "zustand": "^5.0.10"
   },


### PR DESCRIPTION
Upgrade happy-dom to version 20.3.1 and three-mesh-bvh to version 0.9.7 to ensure compatibility and access to the latest features and fixes.