### PR TITLE
chore(ci): switch workflows to pnpm and use pnpm install

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,19 +35,23 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: '20'
-        cache: 'npm'
+        cache: 'pnpm'
+        cache-dependency-path: pnpm-lock.yaml
     
-    - name: Install dependencies
-      run: npm ci
+    - name: Install pnpm & deps
+      run: |
+        corepack enable
+        corepack prepare pnpm@10.28.2 --activate
+        pnpm install --frozen-lockfile
     
     - name: Run TypeScript typecheck
-      run: npm run typecheck
+      run: pnpm run typecheck
     
     - name: Run tests
-      run: npm test
+      run: pnpm test
     
     - name: Build for production
-      run: npm run build
+      run: pnpm run build
     
     - name: Copy spaceautobattler.html to index.html for GitHub Pages
       run: cp dist/spaceautobattler.html dist/index.html

--- a/.github/workflows/experiment-metrics.yml
+++ b/.github/workflows/experiment-metrics.yml
@@ -60,25 +60,29 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: '20'
-        cache: 'npm'
+        cache: 'pnpm'
+        cache-dependency-path: pnpm-lock.yaml
     
-    - name: Install dependencies
-      run: npm ci
+    - name: Install pnpm & deps
+      run: |
+        corepack enable
+        corepack prepare pnpm@10.28.2 --activate
+        pnpm install --frozen-lockfile
     
     - name: Run TypeScript typecheck
-      run: npm run typecheck
+      run: pnpm run typecheck
       
     - name: Run unit tests
-      run: npm test
+      run: pnpm test
       env: ${{ matrix.experiment.env }}
     
     - name: Run AI performance budget test
-      run: npm run perf:ai-budget || echo "⚠️  Performance test failed - known issue with test harness"
+      run: pnpm run perf:ai-budget || echo "⚠️  Performance test failed - known issue with test harness"
       env: ${{ matrix.experiment.env }}
       
     - name: Run extended performance test (higher load)
       env: ${{ matrix.experiment.env }}
-      run: AI_BUDGET_SHIPS=450 AI_BUDGET_TICKS=200 AI_BUDGET_MS=3.5 npm run perf:ai-budget || echo "⚠️  Extended performance test failed - known issue with test harness"
+      run: AI_BUDGET_SHIPS=450 AI_BUDGET_TICKS=200 AI_BUDGET_MS=3.5 pnpm run perf:ai-budget || echo "⚠️  Extended performance test failed - known issue with test harness"
 
   experiment-summary:
     name: Experiment Results Summary

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,12 +10,17 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: lts/*
-    - name: Install dependencies
-      run: npm ci
+        cache: 'pnpm'
+        cache-dependency-path: pnpm-lock.yaml
+    - name: Install pnpm & deps
+      run: |
+        corepack enable
+        corepack prepare pnpm@10.28.2 --activate
+        pnpm install --frozen-lockfile
     - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+      run: pnpm exec playwright install --with-deps
     - name: Run Playwright tests
-      run: npx playwright test
+      run: pnpm exec playwright test
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:


### PR DESCRIPTION
Summary:
- Switch CI workflows to use pnpm for dependency installs and caching.

Changes:
- Update .github/workflows/deploy-pages.yml, .github/workflows/playwright.yml, and .github/workflows/experiment-metrics.yml:
  - Use ctions/setup-node@v6 with cache: 'pnpm' and cache-dependency-path: pnpm-lock.yaml.
  - Replace npm install steps with Corepack + pnpm install --frozen-lockfile.
  - Replace 
pm run/test/build and 
px playwright invocations with pnpm equivalents (pnpm run, pnpm test, pnpm run build, pnpm exec playwright).
- Ensure pnpm-lock.yaml is used by CI (already present in repo).

Motivation:
The project declares packageManager: pnpm@10.28.2 in package.json; CI was still using 
pm ci. Using pnpm in CI ensures deterministic installs and cacheability that aligns with local development.

Notes:
- I generated/verified the lockfile locally and updated the workflows to prepare pnpm via Corepack (pnpm@10.28.2).
- Please verify CI runs green; if you'd like I can follow up on any failures in this PR.
