### PR TITLE
fix(ci): make pnpm available for setup-node caching

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -30,6 +30,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v5
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10.28.2
+        run_install: false
       
     - name: Setup Node.js
       uses: actions/setup-node@v6
@@ -38,11 +44,8 @@ jobs:
         cache: 'pnpm'
         cache-dependency-path: pnpm-lock.yaml
     
-    - name: Install pnpm & deps
-      run: |
-        corepack enable
-        corepack prepare pnpm@10.28.2 --activate
-        pnpm install --frozen-lockfile
+    - name: Install deps
+      run: pnpm install --frozen-lockfile
     
     - name: Run TypeScript typecheck
       run: pnpm run typecheck

--- a/.github/workflows/experiment-metrics.yml
+++ b/.github/workflows/experiment-metrics.yml
@@ -55,6 +55,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v5
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10.28.2
+        run_install: false
       
     - name: Setup Node.js
       uses: actions/setup-node@v6
@@ -63,25 +69,43 @@ jobs:
         cache: 'pnpm'
         cache-dependency-path: pnpm-lock.yaml
     
-    - name: Install pnpm & deps
-      run: |
-        corepack enable
-        corepack prepare pnpm@10.28.2 --activate
-        pnpm install --frozen-lockfile
+    - name: Install deps
+      run: pnpm install --frozen-lockfile
     
     - name: Run TypeScript typecheck
       run: pnpm run typecheck
       
     - name: Run unit tests
       run: pnpm test
-      env: ${{ matrix.experiment.env }}
+      env:
+        AI_VERTICAL_EXPERIMENT_OFF: ${{ matrix.experiment.env.AI_VERTICAL_EXPERIMENT_OFF }}
+        AI_VERTICAL_EXPERIMENT_ON: ${{ matrix.experiment.env.AI_VERTICAL_EXPERIMENT_ON }}
+        AI_ENGAGEMENT_BOOST_OFF: ${{ matrix.experiment.env.AI_ENGAGEMENT_BOOST_OFF }}
+        AI_ENGAGEMENT_BOOST_ON: ${{ matrix.experiment.env.AI_ENGAGEMENT_BOOST_ON }}
+        AI_TICKRATE_EXPERIMENT_OFF: ${{ matrix.experiment.env.AI_TICKRATE_EXPERIMENT_OFF }}
+        AI_TICKRATE_EXPERIMENT_ON: ${{ matrix.experiment.env.AI_TICKRATE_EXPERIMENT_ON }}
+        AI_RANGE_POLICY: ${{ matrix.experiment.env.AI_RANGE_POLICY }}
     
     - name: Run AI performance budget test
       run: pnpm run perf:ai-budget || echo "⚠️  Performance test failed - known issue with test harness"
-      env: ${{ matrix.experiment.env }}
+      env:
+        AI_VERTICAL_EXPERIMENT_OFF: ${{ matrix.experiment.env.AI_VERTICAL_EXPERIMENT_OFF }}
+        AI_VERTICAL_EXPERIMENT_ON: ${{ matrix.experiment.env.AI_VERTICAL_EXPERIMENT_ON }}
+        AI_ENGAGEMENT_BOOST_OFF: ${{ matrix.experiment.env.AI_ENGAGEMENT_BOOST_OFF }}
+        AI_ENGAGEMENT_BOOST_ON: ${{ matrix.experiment.env.AI_ENGAGEMENT_BOOST_ON }}
+        AI_TICKRATE_EXPERIMENT_OFF: ${{ matrix.experiment.env.AI_TICKRATE_EXPERIMENT_OFF }}
+        AI_TICKRATE_EXPERIMENT_ON: ${{ matrix.experiment.env.AI_TICKRATE_EXPERIMENT_ON }}
+        AI_RANGE_POLICY: ${{ matrix.experiment.env.AI_RANGE_POLICY }}
       
     - name: Run extended performance test (higher load)
-      env: ${{ matrix.experiment.env }}
+      env:
+        AI_VERTICAL_EXPERIMENT_OFF: ${{ matrix.experiment.env.AI_VERTICAL_EXPERIMENT_OFF }}
+        AI_VERTICAL_EXPERIMENT_ON: ${{ matrix.experiment.env.AI_VERTICAL_EXPERIMENT_ON }}
+        AI_ENGAGEMENT_BOOST_OFF: ${{ matrix.experiment.env.AI_ENGAGEMENT_BOOST_OFF }}
+        AI_ENGAGEMENT_BOOST_ON: ${{ matrix.experiment.env.AI_ENGAGEMENT_BOOST_ON }}
+        AI_TICKRATE_EXPERIMENT_OFF: ${{ matrix.experiment.env.AI_TICKRATE_EXPERIMENT_OFF }}
+        AI_TICKRATE_EXPERIMENT_ON: ${{ matrix.experiment.env.AI_TICKRATE_EXPERIMENT_ON }}
+        AI_RANGE_POLICY: ${{ matrix.experiment.env.AI_RANGE_POLICY }}
       run: AI_BUDGET_SHIPS=450 AI_BUDGET_TICKS=200 AI_BUDGET_MS=3.5 pnpm run perf:ai-budget || echo "⚠️  Extended performance test failed - known issue with test harness"
 
   experiment-summary:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,16 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10.28.2
+        run_install: false
     - uses: actions/setup-node@v6
       with:
         node-version: lts/*
         cache: 'pnpm'
         cache-dependency-path: pnpm-lock.yaml
-    - name: Install pnpm & deps
-      run: |
-        corepack enable
-        corepack prepare pnpm@10.28.2 --activate
-        pnpm install --frozen-lockfile
+    - name: Install deps
+      run: pnpm install --frozen-lockfile
     - name: Install Playwright Browsers
       run: pnpm exec playwright install --with-deps
     - name: Run Playwright tests


### PR DESCRIPTION
### What changed\n- Install pnpm via pnpm/action-setup before actions/setup-node when using cache: 'pnpm'.\n- Simplify dependency install steps to 'pnpm install --frozen-lockfile'.\n- Fix invalid env expression in experiment-metrics matrix steps by expanding env keys explicitly.\n\n### Why\nGitHub Actions runners may not have pnpm on PATH by default; setup-node's pnpm cache mode invokes pnpm early and fails otherwise.\n\n### Workflows touched\n- .github/workflows/playwright.yml\n- .github/workflows/deploy-pages.yml\n- .github/workflows/experiment-metrics.yml\n\n### Validation\n- Not run locally (workflow-only changes).