### PR TITLE
Fix #513: Include all non-Playwright tests in Vitest config and fix broken tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,47 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10.31.0
+        run_install: false
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: '20'
+        cache: 'pnpm'
+        cache-dependency-path: pnpm-lock.yaml
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Run Typecheck
+      run: pnpm run typecheck
+
+    - name: Run Vitest
+      run: pnpm test
+
+    - name: Sanity check test count
+      run: |
+        # Ensure we are catching all intended test files (currently 168 non-Playwright files)
+        ACTUAL_COUNT=$(find test -name "*.spec.ts" -o -name "*.test.ts" -o -name "*.spec.tsx" | grep -v "test/playwright/" | wc -l | xargs)
+        echo "Found $ACTUAL_COUNT non-Playwright test files."
+        
+        if [ "$ACTUAL_COUNT" -lt 168 ]; then
+          echo "Error: Test discovery gap detected! Expected 168 test files, but only found $ACTUAL_COUNT."
+          echo "Check vitest.config.js include/exclude patterns."
+          exit 1
+        fi

--- a/src/renderer/materialRegistry.tsx
+++ b/src/renderer/materialRegistry.tsx
@@ -143,6 +143,11 @@ export function getInstanceFriendlyMaterial(
   } = options;
 
   const entry = registry.get(key);
+  if (!entry) {
+    onFallback?.({ requestedKey: key, resolvedKey: null, reason: 'missing' });
+    return fallbackFactory();
+  }
+
   const info = createInstancedMaterial(key, fallbackFactory);
   if (!requireInstanceColor && !requireInstanceUv) {
     return info;
@@ -176,14 +181,10 @@ export function getInstanceFriendlyMaterial(
     }
   }
 
-  let reason: InstanceFriendlyFallbackDetails['reason'];
-  if (!entry) {
-    reason = 'missing';
-  } else if (!colorOk) {
-    reason = 'no-instance-color';
-  } else {
-    reason = 'no-instance-uv';
-  }
+  let reason: InstanceFriendlyFallbackDetails['reason'] = !colorOk
+    ? 'no-instance-color'
+    : 'no-instance-uv';
+
   onFallback?.({ requestedKey: key, resolvedKey: null, reason });
   info.material.dispose();
   return fallbackFactory();

--- a/test/config/renderer-facade.spec.ts
+++ b/test/config/renderer-facade.spec.ts
@@ -4,21 +4,23 @@ describe('renderer config facade', () => {
   it('re-exports motion, shield, effects, and postprocessing symbols', async () => {
     const facade = await import('../../src/config/renderer.js');
     const keys = Object.keys(facade).sort();
-    expect(keys).toMatchInlineSnapshot(`[
-      "HULL_TINT",
-      "PARTICLE_TRAILS_CONFIG",
-      "POSTPROCESSING_CONFIG",
-      "RENDERER_MOTION_DEFAULTS",
-      "RENDERER_VISUAL_CONFIG",
-      "SHIELD_RIPPLE_TUNING",
-      "SHIELD_TUNING",
-      "SHIELD_VISUALS",
-      "SHIELD_VISUAL_DEFAULTS",
-      "TEAM_COLORS",
-      "THRUSTER_GLOW_CONFIG",
-      "getShieldVisuals",
-      "resolveRendererMotionConfig",
-      "setGlobalShieldMaterial",
-    ]`);
+    expect(keys).toMatchInlineSnapshot(`
+      [
+        "HULL_TINT",
+        "PARTICLE_TRAILS_CONFIG",
+        "POSTPROCESSING_CONFIG",
+        "RENDERER_MOTION_DEFAULTS",
+        "RENDERER_VISUAL_CONFIG",
+        "SHIELD_RIPPLE_TUNING",
+        "SHIELD_TUNING",
+        "SHIELD_VISUALS",
+        "SHIELD_VISUAL_DEFAULTS",
+        "TEAM_COLORS",
+        "THRUSTER_GLOW_CONFIG",
+        "getShieldVisuals",
+        "resolveRendererMotionConfig",
+        "setGlobalShieldMaterial",
+      ]
+    `);
   });
 });

--- a/test/progression/xp.spec.ts
+++ b/test/progression/xp.spec.ts
@@ -23,11 +23,15 @@ describe('progression xp helpers', () => {
 
     awardDamageXp(ship, 50, state, 11, 'laser', 'beam');
 
-    expect(ship.xp).toBeCloseTo(50 * XP_CONFIG.damageXpMultiplier);
-    expect(state.progressionEvents.get(11)).toHaveLength(1);
+    // damageDealt (50) * multiplier (0.5) = 25 XP
+    // ship.xpToNext is 20, so it levels up.
+    // Remaining XP should be 25 - 20 = 5
+    expect(ship.xp).toBeCloseTo(5);
+    expect(ship.level).toBe(2);
+    expect(state.progressionEvents.get(11)).toHaveLength(2); // damage + levelup
     expect(state.progressionEvents.get(11)?.[0]).toMatchObject({
       type: 'damage',
-      deltaXp: 5,
+      deltaXp: 25,
       details: '50.0 damage dealt with laser [beam]',
     });
   });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -31,13 +31,7 @@ export default defineConfig({
   },
   test: {
     include: [
-      'test/vitest/*.spec.ts',
-      'test/vitest/*.test.ts',
-      'test/vitest/**/*.spec.ts',
-      'test/vitest/**/*.spec.tsx',
-      'test/components/**/*.spec.ts',
-      'test/components/**/*.spec.tsx',
-      'test/utils/**/*.spec.ts',
+      'test/**/*.{spec,test}.{ts,tsx}',
     ],
     exclude: ['test/playwright/**'],
     environment: 'happy-dom',


### PR DESCRIPTION
Expand the Vitest configuration to include all non-Playwright test files, ensuring comprehensive test coverage. Implement a sanity check in the CI pipeline to verify the expected number of test files, preventing silent failures. Adjust existing tests for accuracy and consistency.