### PR TITLE
[Code Review] Remove dead embedded turret execution fallback

### DIFF
--- a/src/game/ships.ts
+++ b/src/game/ships.ts
@@ -3,7 +3,6 @@ import type {
   GameState,
   ShipBlueprint,
   ShipEntity,
-  TurretState,
   TurretEntity,
 } from '../types/index.js';
 import { SHIP_STATS } from '../data/shipStats.js';
@@ -73,17 +72,6 @@ export function spawnShip(state: GameState, blueprint: ShipBlueprint): ShipEntit
     },
     model: blueprint.hull,
     shieldRipples: [],
-    turrets: (stats.turrets ?? []).map<TurretState>((t, idx) => ({
-      offset: t.offset.clone(),
-      damage: t.damage,
-      fireRate: t.fireRate,
-      projectileSpeed: t.projectileSpeed,
-      range: applyRangeVariance(t.range, aiState.traitSeed, idx + 1),
-      bulletType: t.bulletType,
-      projectileCategory: t.projectileCategory,
-      priority: t.priority ?? 'any',
-      cooldown: t.fireRate * state.rng.next(),
-    })),
     ai: aiState,
   };
 

--- a/src/game/systems/combat.ts
+++ b/src/game/systems/combat.ts
@@ -8,7 +8,7 @@
 export { fireProjectile, advanceProjectiles, TEMP_POS } from './projectiles.js';
 export { FORWARD } from '../../utils/steering.js';
 
-export { runEmbeddedTurrets, updateTurrets } from './turrets.js';
+export { updateTurrets } from './turrets.js';
 export { findNearestEnemy } from '../utils/targetSelection.js';
 
 export { resolveProjectiles } from './damage.js';

--- a/src/game/systems/shipControl/index.ts
+++ b/src/game/systems/shipControl/index.ts
@@ -3,7 +3,6 @@ import { ensureAiEnabled } from './aiSafety.js';
 import { executeShipAi } from './aiExecutor.js';
 import { handleShipWeapons } from './weapons.js';
 import { updateShipLifecycle } from './lifecycle.js';
-import { runEmbeddedTurrets } from '../turrets.js';
 
 export { getShipById } from './aiExecutor.js';
 
@@ -23,11 +22,7 @@ export function prepareShips(state: GameState, delta: number): void {
 
   for (const ship of ships) {
     updateShipLifecycle(state, ship, delta);
-    const preferredTarget = executeAICommand(state, ship, delta);
-
-    if (state.queries.turrets.entities.length === 0 && ship.turrets && preferredTarget) {
-      runEmbeddedTurrets(state, ship, preferredTarget);
-    }
+    executeAICommand(state, ship, delta);
   }
 }
 

--- a/src/game/systems/shipControl/lifecycle.ts
+++ b/src/game/systems/shipControl/lifecycle.ts
@@ -17,11 +17,6 @@ const MUZZLE_FLASH_LIFETIME = 0.25;
  */
 export function updateShipLifecycle(state: GameState, ship: ShipEntity, delta: number): void {
   ship.ship.cooldown = Math.max(0, ship.ship.cooldown - delta);
-  if (ship.turrets) {
-    for (const turret of ship.turrets) {
-      turret.cooldown = Math.max(0, turret.cooldown - delta);
-    }
-  }
 
   updateCaptainAbilities(ship.ship, state.time, delta);
   repairSubsystems(ship.ship, delta);

--- a/src/game/systems/turrets.ts
+++ b/src/game/systems/turrets.ts
@@ -4,7 +4,7 @@ import type {
   ProjectileEntity,
   ShipEntity,
   TurretEntity,
-  TurretState,
+  TurretSpec,
 } from '../../types/index.js';
 import { recordShotHelper } from '../metrics.js';
 import { fireProjectile, TEMP_POS } from './projectiles.js';
@@ -21,58 +21,10 @@ const TEMP_LOCAL_DIR = new Vector3();
 const SMALL_HULLS = new Set(['fighter', 'corvette']);
 const LARGE_HULLS = new Set(['frigate', 'destroyer', 'carrier']);
 
-function getTurretWorldPosition(ship: ShipEntity, turret: TurretState): Vector3 {
+function getTurretWorldPosition(ship: ShipEntity, turret: TurretSpec): Vector3 {
   const world = TEMP_POS.copy(turret.offset).multiplyScalar(ship.transform.scale);
   world.applyQuaternion(ship.transform.rotation).add(ship.transform.position);
   return world;
-}
-
-/**
- * Runs logic for embedded turrets (not separate entities).
- *
- * @param {GameState} state - The game state.
- * @param {ShipEntity} ship - The ship with embedded turrets.
- * @param {ShipEntity} target - The current target.
- */
-export function runEmbeddedTurrets(state: GameState, ship: ShipEntity, target: ShipEntity): void {
-  for (const turret of ship.turrets ?? []) {
-    if (turret.cooldown > 0) continue;
-    const turretOrigin = getTurretWorldPosition(ship, turret);
-    const projectileTarget =
-      turret.priority === 'antiProjectile'
-        ? findPointDefenseTarget(state, {
-            origin: turretOrigin,
-            team: ship.ship.team,
-            maxRange: turret.range,
-            preferTargetId: ship.id,
-          })
-        : null;
-    const targetPos = projectileTarget
-      ? projectileTarget.transform.position
-      : target.transform.position;
-    const toTarget = TEMP_TURRET_DIR.copy(targetPos).sub(turretOrigin);
-    const dist = toTarget.length();
-    if (dist > turret.range) continue;
-    if (dist > 1e-5) toTarget.divideScalar(dist);
-    else toTarget.set(0, 0, 1);
-    recordShotHelper(state, ship, projectileTarget ? null : target, dist);
-    fireProjectile(state, ship, toTarget, {
-      originPosition: turretOrigin,
-      override: {
-        damage: turret.damage,
-        projectileSpeed: turret.projectileSpeed,
-        range: turret.range,
-        bulletType: turret.bulletType,
-        targetId: projectileTarget ? undefined : target.id,
-        projectileCategory: turret.projectileCategory,
-      },
-      targetId: projectileTarget ? undefined : target.id,
-    });
-    if (projectileTarget) {
-      destroyEntity(state, projectileTarget);
-    }
-    turret.cooldown = turret.fireRate;
-  }
 }
 
 /**

--- a/src/types/combat.ts
+++ b/src/types/combat.ts
@@ -122,12 +122,6 @@ export interface TurretSpec {
   projectileCategory?: ProjectileCategory;
 }
 
-/** Runtime turret state (derived from TurretSpec). Lives on the parent ship entity. */
-export interface TurretState extends TurretSpec {
-  /** Countdown timer until the turret can fire again. */
-  cooldown: number;
-}
-
 /** ECS component for a turret entity, referencing its parent ship. */
 export interface TurretComponent extends TurretSpec {
   /** The parent ship this turret is mounted on. */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,7 +29,6 @@ export type {
   DamageEffectiveness,
   ProjectileComponent,
   TurretSpec,
-  TurretState,
   TurretComponent,
   MuzzleFlash,
 } from './combat.js';

--- a/src/types/ship.ts
+++ b/src/types/ship.ts
@@ -17,7 +17,7 @@ import type {
   Captain,
   ProgressionEvent,
 } from './progression.js';
-import type { TurretState, MuzzleFlash } from './combat.js';
+import type { MuzzleFlash } from './combat.js';
 
 /**
  * Definition of a launch slot for a carrier.
@@ -178,8 +178,6 @@ export interface GameEntity extends TransformComponent {
   /** Recent shield ripple events, renderer-only consumption. Kept on GameState for determinism. */
   shieldRipples?: ShieldRipple[];
   /** Optional array of turrets mounted on this ship (if entity has a ShipComponent). */
-  turrets?: TurretState[];
-  /** Recent muzzle flash events; rendered client-side and naturally fade based on state.time. */
   muzzleFlashes?: MuzzleFlash[];
 }
 

--- a/test/vitest/turret-priority.spec.ts
+++ b/test/vitest/turret-priority.spec.ts
@@ -3,7 +3,7 @@ import { Quaternion, Vector3 } from 'three';
 import { updateTurrets } from '../../src/game/systems/turrets.js';
 import { createDefaultMotionStats } from '../../src/game/ships.js';
 import { createProgressionDefaults } from '../../src/game/progression.js';
-import type { GameState, ShipEntity, TurretEntity, TurretState } from '../../src/types/index.js';
+import type { GameState, ShipEntity, TurretEntity } from '../../src/types/index.js';
 
 // --- Mocks and Stubs (copied/adapted from turrets.spec.ts) ---
 
@@ -160,7 +160,6 @@ function createShip(
     },
     model: hull,
     shieldRipples: [],
-    turrets: [],
   } as unknown as ShipEntity;
 
   (state.queries.ships as any).entities.push(ship);

--- a/test/vitest/turrets.spec.ts
+++ b/test/vitest/turrets.spec.ts
@@ -3,7 +3,7 @@ import { Quaternion, Vector3 } from 'three';
 import { applyProgressionDefaults } from './helpers/progression.js';
 import { createDefaultMotionStats } from '../../src/game/ships.js';
 import { updateGame } from '../../src/game/systems.js';
-import type { GameState, ShipEntity, TurretState } from '../../src/types/index.js';
+import type { GameState, ShipEntity, TurretEntity, TurretSpec } from '../../src/types/index.js';
 
 function makeRigidBodyStub(init?: {
   pos?: { x: number; y: number; z: number };
@@ -188,9 +188,10 @@ function makeStateStub(): GameState {
 }
 
 function makeShipWithTurret(
+  state: GameState,
   team: 'red' | 'blue',
   pos: Vector3,
-  turret: Omit<TurretState, 'cooldown'> & { cooldown?: number },
+  turret: TurretSpec,
 ): ShipEntity {
   const rb = makeRigidBodyStub();
   const ship = {
@@ -223,20 +224,29 @@ function makeShipWithTurret(
     },
     model: 'corvette' as any,
     shieldRipples: [],
-    turrets: [
-      {
-        offset: turret.offset.clone(),
-        damage: turret.damage,
-        fireRate: turret.fireRate,
-        projectileSpeed: turret.projectileSpeed,
-        range: turret.range,
-        bulletType: turret.bulletType,
-        cooldown: turret.cooldown ?? 0,
-      },
-    ],
   } as unknown as ShipEntity;
 
   applyProgressionDefaults(ship.ship, { hull: 'corvette', maxHpOverride: ship.ship.maxHp });
+
+  // Create associated TurretEntity
+  const tRb = makeRigidBodyStub();
+  const turretEntity = {
+    id: state.nextEntityId++,
+    rigidBody: tRb as any,
+    collider: { handle: Math.floor(Math.random() * 10000), isValid: () => true } as any,
+    transform: {
+      position: pos.clone(),
+      rotation: new Quaternion(),
+      scale: 1,
+    },
+    turret: {
+      parent: ship,
+      ...turret,
+      cooldown: 0,
+    },
+  } as unknown as TurretEntity;
+  state.world.add(turretEntity);
+
   return ship;
 }
 
@@ -244,7 +254,7 @@ describe('Turret system', () => {
   it('fires turret with its own stats and origin', () => {
     const state = makeStateStub();
 
-    const friendly = makeShipWithTurret('blue', new Vector3(0, 0, 0), {
+    const friendly = makeShipWithTurret(state, 'blue', new Vector3(0, 0, 0), {
       offset: new Vector3(1, 0, 0),
       damage: 7,
       fireRate: 1.0,


### PR DESCRIPTION
Closes #520. Removed unreachable embedded turret execution path and associated dead code (TurretState, ship.turrets property). Refactored tests to use TurretEntity.