### PR TITLE
perf: optimize sensor visibility check using spatial grid

### DIFF
--- a/src/game/systems/sensors.ts
+++ b/src/game/systems/sensors.ts
@@ -182,7 +182,8 @@ export function updateSensorSystem(state: GameState, ships: ShipEntity[]): void 
 
     getForwardFromQuaternion(source.transform.rotation, TMP_FORWARD).normalize();
 
-    for (const target of ships) {
+    const nearbyTargets = spatialGrid!.query(source.transform.position, trackingRange);
+    for (const target of nearbyTargets) {
       if (target === source) continue;
       if (target.ship.team === team) continue;
       TMP_VECTOR.copy(target.transform.position).sub(source.transform.position);

--- a/src/utils/spatialGrid.ts
+++ b/src/utils/spatialGrid.ts
@@ -55,6 +55,22 @@ export class SpatialGrid {
 
     // Determine which cells to check based on radius
     const cellRadius = Math.ceil(radius / this.cellSize);
+
+    // If the volume of cells to search is extremely large relative to the number of
+    // actually populated cells, it is much faster to scan all populated cells directly.
+    const totalCellsToScan = Math.pow(cellRadius * 2 + 1, 3);
+    if (totalCellsToScan > this.cells.size) {
+      for (const cell of this.cells.values()) {
+        for (const ship of cell) {
+          const distSq = position.distanceToSquared(ship.transform.position);
+          if (distSq <= radiusSq) {
+            results.push(ship);
+          }
+        }
+      }
+      return results;
+    }
+
     const centerX = Math.floor(position.x / this.cellSize);
     const centerY = Math.floor(position.y / this.cellSize);
     const centerZ = Math.floor(position.z / this.cellSize);


### PR DESCRIPTION
Closes #579

Optimizes the sensor visibility check by querying the spatial grid instead of doing $O(N^2)$ checks against all ships. Additionally, adds a cell volume check to the spatial grid query to fall back to a linear scan of active cells when the query volume is huge compared to the number of active ships (e.g. dense formations).