### PR TITLE
fix: skip collision resolution for destroyed ships in same-tick projectile loop

### DIFF
--- a/src/game/systems/damage.ts
+++ b/src/game/systems/damage.ts
@@ -170,7 +170,7 @@ function handleBeamProjectile(
 
   if (!beam.applied && projectile.projectile.targetId != null) {
     const target = shipsById.get(projectile.projectile.targetId);
-    if (target && target.ship.team !== projectile.projectile.team) {
+    if (target && target.ship.hp > 0 && target.ship.team !== projectile.projectile.team) {
       const outcome = applyProjectileDamage(state, projectile, target, ships, shipsById);
       if (outcome.destroyed) {
         toRemove.add(target);
@@ -197,6 +197,7 @@ function applyAoeDamage(
   const origin = projectile.transform.position;
   const nearbyShips = querySpatialHash(shipSpatialHash, origin, radius);
   for (const ship of nearbyShips) {
+    if (ship.ship.hp <= 0) continue;
     if (primaryTarget && ship === primaryTarget) continue;
     if (ship.ship.team === projectile.projectile.team) continue;
     const distance = ship.transform.position.distanceTo(origin);
@@ -274,6 +275,7 @@ export function resolveProjectiles(state: GameState, delta: number): void {
 
       let triggered = false;
       for (const target of fuseTargets) {
+        if (target.ship.hp <= 0) continue;
         if (target.ship.team === projectile.projectile.team) continue;
         const dist = target.transform.position.distanceTo(projectile.transform.position);
         if (dist <= fuseRadius) {
@@ -312,6 +314,7 @@ export function resolveProjectiles(state: GameState, delta: number): void {
     );
 
     for (const ship of nearbyShips) {
+      if (ship.ship.hp <= 0) continue;
       const impactRadius = ship.transform.scale * 0.9 + projRadius;
       if (ship.ship.team === projectile.projectile.team) continue;
       const distance = ship.transform.position.distanceTo(projectile.transform.position);

--- a/test/vitest/projectile-extended.spec.ts
+++ b/test/vitest/projectile-extended.spec.ts
@@ -364,4 +364,146 @@ describe('extended projectile behaviours', () => {
     expect(spawned.projectile.homing).toBeDefined();
     expect(spawned.projectile.homing?.turnRate).toBeCloseTo(Math.PI / 3, 5);
   });
+
+  it('skips standard projectile collisions on destroyed ships (hp <= 0)', () => {
+    target.ship.hp = 0;
+    const projectile = createProjectileEntity({
+      id: 501,
+      transform: {
+        position: target.transform.position.clone(),
+        rotation: new Quaternion(),
+        scale: 0.5,
+      },
+      projectile: {
+        team: attacker.ship.team,
+        damage: 20,
+        ttl: 5,
+        maxTtl: 5,
+        speed: 10,
+        bulletType: 'torpedo:standard',
+        damageType: attacker.ship.damageType,
+        sourceId: attacker.id,
+      },
+    });
+    (state.queries.projectiles.entities as ProjectileEntity[]).push(projectile);
+
+    const initialXp = attacker.ship.xp;
+    resolveProjectiles(state, 0.1);
+
+    // The projectile should NOT be removed (so it shouldn't collide and be destroyed)
+    expect((state.queries.projectiles.entities as ProjectileEntity[]).includes(projectile)).toBe(
+      true,
+    );
+    // Attacker should not have earned any damage XP from a dead ship
+    expect(attacker.ship.xp).toBe(initialXp);
+  });
+
+  it('skips proximity fuse triggers on destroyed ships (hp <= 0)', () => {
+    target.ship.hp = 0;
+    const projectile = createProjectileEntity({
+      id: 502,
+      transform: {
+        position: target.transform.position.clone(),
+        rotation: new Quaternion(),
+        scale: 0.5,
+      },
+      projectile: {
+        team: attacker.ship.team,
+        damage: 20,
+        ttl: 5,
+        maxTtl: 5,
+        speed: 10,
+        bulletType: 'torpedo:standard',
+        damageType: attacker.ship.damageType,
+        sourceId: attacker.id,
+        proximityFuse: { radius: 2 },
+        aoeRadius: 4,
+      },
+    });
+    (state.queries.projectiles.entities as ProjectileEntity[]).push(projectile);
+
+    const initialXp = attacker.ship.xp;
+    resolveProjectiles(state, 0.1);
+
+    // Proximity fuse should NOT trigger, so projectile should not be removed
+    expect((state.queries.projectiles.entities as ProjectileEntity[]).includes(projectile)).toBe(
+      true,
+    );
+    expect(attacker.ship.xp).toBe(initialXp);
+  });
+
+  it('skips AoE damage on destroyed ships (hp <= 0)', () => {
+    const nearby = createTestShip(3, 'red', new Vector3(2, 0, 0));
+    nearby.ship.hp = 0;
+    state.queries.ships.entities.push(nearby);
+    state.shipById.set(nearby.id, nearby);
+
+    const projectile = createProjectileEntity({
+      id: 503,
+      transform: {
+        position: target.transform.position.clone(),
+        rotation: new Quaternion(),
+        scale: 0.5,
+      },
+      projectile: {
+        team: attacker.ship.team,
+        damage: 20,
+        ttl: 5,
+        maxTtl: 5,
+        speed: 10,
+        bulletType: 'torpedo:standard',
+        damageType: attacker.ship.damageType,
+        sourceId: attacker.id,
+        aoeRadius: 5,
+      },
+    });
+    (state.queries.projectiles.entities as ProjectileEntity[]).push(projectile);
+
+    const initialNearbyHp = nearby.ship.hp;
+    const initialXp = attacker.ship.xp;
+
+    resolveProjectiles(state, 0.1);
+
+    // The nearby ship has hp = 0, so it should not receive any AoE damage.
+    expect(nearby.ship.hp).toBe(initialNearbyHp);
+  });
+
+  it('skips beam projectile damage on destroyed ships (hp <= 0)', () => {
+    target.ship.hp = 0;
+    const beam = createProjectileEntity({
+      id: 504,
+      transform: {
+        position: attacker.transform.position.clone(),
+        rotation: new Quaternion(),
+        scale: 0.4,
+      },
+      projectile: {
+        team: attacker.ship.team,
+        damage: 25,
+        ttl: 0.4,
+        maxTtl: 0.4,
+        speed: 0,
+        bulletType: 'beam:laser',
+        damageType: attacker.ship.damageType,
+        sourceId: attacker.id,
+        category: 'beam',
+        beam: {
+          ttl: 0.4,
+          maxLength: 20,
+          width: 0.5,
+          hitPoint: target.transform.position.clone(),
+          applied: false,
+        },
+        targetId: target.id,
+      },
+    });
+    (state.queries.projectiles.entities as ProjectileEntity[]).push(beam);
+
+    const initialXp = attacker.ship.xp;
+    resolveProjectiles(state, 0.05);
+
+    // The beam shouldn't apply damage to the dead target, so no XP is awarded
+    expect(attacker.ship.xp).toBe(initialXp);
+    expect(beam.projectile.beam?.applied).toBe(true);
+  });
 });


### PR DESCRIPTION
Fixes #580.

### Summary
When a ship is destroyed by a projectile, it is added to the `toRemove` list and deleted via `destroyEntity` at the end of the physics/update tick. However, projectile collision checks processed later in the same frame's loop still collide with the dead ship. This causes projectiles to be absorbed by "ghost" dead ships, triggering redundant damage calculations and awarding extra damage XP.

This PR adds health checks (`hp <= 0` exclusions) to ignore already-destroyed ships during same-tick collisions, proximity fuse triggers, AoE damage applications, and beam target damage resolutions.

### Changes
- **`src/game/systems/damage.ts`**: Added health checks in `resolveProjectiles`, `applyAoeDamage`, and `handleBeamProjectile`.
- **`test/vitest/projectile-extended.spec.ts`**: Added unit tests to cover each of these edge cases.