### PR TITLE
fix: resolve React hooks ordering violation in BattleSceneContent

### DIFF
--- a/src/components/Battlefield.tsx
+++ b/src/components/Battlefield.tsx
@@ -35,11 +35,12 @@ type DebugWindow = Window & {
 
 function BattleSceneContent({ ppEnabled }: BattleSceneContentProps): React.ReactElement {
   const state = useOptionalGameState();
+  const axesHelper = useMemo(() => new AxesHelper(200), []);
+  useEffect(() => () => axesHelper.dispose(), [axesHelper]);
+
   if (!state) return <></>;
   const renderWorkerShipsOnly = shouldRenderWorkerShipsOnly();
   const renderWorkerShips = shouldRenderWorkerShips();
-  const axesHelper = useMemo(() => new AxesHelper(200), []);
-  useEffect(() => () => axesHelper.dispose(), [axesHelper]);
   // Expose a local `ships` binding to make particle integration explicit for static checks
   const ships = state.queries.ships;
 


### PR DESCRIPTION
Moves the axesHelper useMemo and useEffect hooks before the early return in BattleSceneContent to avoid violating the Rules of Hooks.